### PR TITLE
Implement the notifications stack with ntfy, Gotify, and a unified notify.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,18 @@ OLLAMA_GPU_ENABLED=false       # Set to true if you have NVIDIA GPU
 # NOTIFICATIONS
 # -----------------------------------------------------------------------------
 GOTIFY_PASSWORD=               # REQUIRED
+GOTIFY_DOMAIN=gotify.${DOMAIN}
+GOTIFY_DEFAULTUSER_NAME=admin
+GOTIFY_APP_TOKEN=
+NTFY_DOMAIN=ntfy.${DOMAIN}
+NTFY_BASE_URL=https://ntfy.${DOMAIN}
+NTFY_USERNAME=admin
+NTFY_PASSWORD=
+NTFY_ACCESS_TOKEN=
+NTFY_TOPIC_PREFIX=homelab
+ALERTMANAGER_NTFY_TOPIC=homelab-alerts
+WATCHTOWER_NTFY_TOPIC=homelab-watchtower
+NOTIFY_BACKEND=auto            # auto, ntfy, or gotify
 NTFY_AUTH_ENABLED=true
 
 # -----------------------------------------------------------------------------

--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -1,0 +1,17 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: ntfy
+  group_by:
+    - alertname
+    - job
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 2h
+
+receivers:
+  - name: ntfy
+    webhook_configs:
+      - url: "https://ntfy.${DOMAIN}/homelab-alerts?template=alertmanager"
+        send_resolved: true

--- a/config/ntfy/server.yml
+++ b/config/ntfy/server.yml
@@ -1,0 +1,9 @@
+base-url: "https://ntfy.${DOMAIN}"
+auth-default-access: "deny-all"
+behind-proxy: true
+cache-file: "/var/cache/ntfy/cache.db"
+auth-file: "/var/lib/ntfy/user.db"
+
+# Create your first admin user after the container starts:
+#   docker compose -f stacks/notifications/docker-compose.yml exec ntfy \
+#     ntfy user add --role=admin "$NTFY_USERNAME"

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/notify.sh <topic> <title> <message> [priority]
+
+Examples:
+  scripts/notify.sh homelab-test "Test" "Hello World"
+  scripts/notify.sh backups "Backup finished" "Nightly backup succeeded" high
+EOF
+}
+
+json_escape() {
+  local value="${1//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  value="${value//$'\t'/\\t}"
+  printf '%s' "$value"
+}
+
+normalize_gotify_priority() {
+  case "${1,,}" in
+    min|1)
+      printf '1'
+      ;;
+    low|2)
+      printf '3'
+      ;;
+    default|normal|3)
+      printf '5'
+      ;;
+    high|4)
+      printf '8'
+      ;;
+    max|urgent|5)
+      printf '10'
+      ;;
+    *)
+      printf '5'
+      ;;
+  esac
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
+
+if [[ $# -lt 3 ]]; then
+  usage
+  exit 1
+fi
+
+TOPIC="$1"
+TITLE="$2"
+MESSAGE="$3"
+PRIORITY="${4:-default}"
+BACKEND="${NOTIFY_BACKEND:-auto}"
+
+send_ntfy() {
+  local base_url="${NTFY_BASE_URL:-}"
+  if [[ -z "$base_url" && -n "${NTFY_DOMAIN:-}" ]]; then
+    base_url="https://${NTFY_DOMAIN}"
+  fi
+
+  if [[ -z "$base_url" ]]; then
+    echo "NTFY_BASE_URL or NTFY_DOMAIN is required for ntfy delivery." >&2
+    return 1
+  fi
+
+  local url="${base_url%/}/${TOPIC}"
+  local auth_args=()
+
+  if [[ -n "${NTFY_ACCESS_TOKEN:-}" ]]; then
+    auth_args=(-H "Authorization: Bearer ${NTFY_ACCESS_TOKEN}")
+  elif [[ -n "${NTFY_USERNAME:-}" && -n "${NTFY_PASSWORD:-}" ]]; then
+    auth_args=(-u "${NTFY_USERNAME}:${NTFY_PASSWORD}")
+  fi
+
+  curl --fail --silent --show-error \
+    "${auth_args[@]}" \
+    -H "Title: ${TITLE}" \
+    -H "Priority: ${PRIORITY}" \
+    -d "${MESSAGE}" \
+    "${url}"
+}
+
+send_gotify() {
+  local base_url="${GOTIFY_BASE_URL:-}"
+  if [[ -z "$base_url" && -n "${GOTIFY_DOMAIN:-}" ]]; then
+    base_url="https://${GOTIFY_DOMAIN}"
+  fi
+
+  if [[ -z "$base_url" ]]; then
+    echo "GOTIFY_BASE_URL or GOTIFY_DOMAIN is required for Gotify delivery." >&2
+    return 1
+  fi
+
+  if [[ -z "${GOTIFY_APP_TOKEN:-}" ]]; then
+    echo "GOTIFY_APP_TOKEN is required for Gotify delivery." >&2
+    return 1
+  fi
+
+  local gotify_priority
+  local payload
+  gotify_priority="$(normalize_gotify_priority "$PRIORITY")"
+  payload=$(
+    printf '{"title":"%s","message":"%s","priority":%s}' \
+      "$(json_escape "$TITLE")" \
+      "$(json_escape "$MESSAGE")" \
+      "$gotify_priority"
+  )
+
+  curl --fail --silent --show-error \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "${base_url%/}/message?token=${GOTIFY_APP_TOKEN}"
+}
+
+case "$BACKEND" in
+  ntfy)
+    send_ntfy
+    ;;
+  gotify)
+    send_gotify
+    ;;
+  auto)
+    if ! send_ntfy; then
+      echo "ntfy delivery failed, trying Gotify fallback..." >&2
+      send_gotify
+    fi
+    ;;
+  *)
+    echo "Unsupported NOTIFY_BACKEND: $BACKEND" >&2
+    exit 1
+    ;;
+esac

--- a/stacks/notifications/README.md
+++ b/stacks/notifications/README.md
@@ -1,0 +1,129 @@
+# Notifications Stack
+
+This stack provides a central notification hub for the rest of HomeLab Stack.
+It ships with:
+
+- `ntfy` for mobile push delivery and a lightweight web UI
+- `Gotify` as a backup notification endpoint
+- `scripts/notify.sh` as the single shell interface other scripts should call
+
+## Prerequisites
+
+1. Copy `.env.example` to `.env`.
+2. Set at least these variables:
+   - `DOMAIN`
+   - `NTFY_DOMAIN`
+   - `NTFY_USERNAME`
+   - `NTFY_PASSWORD`
+   - `GOTIFY_DOMAIN`
+   - `GOTIFY_PASSWORD`
+3. Make sure the external Docker network `proxy` already exists and is used by Traefik.
+
+## Start the stack
+
+```bash
+docker compose -f stacks/notifications/docker-compose.yml up -d
+```
+
+## Bootstrap ntfy auth
+
+The checked-in `config/ntfy/server.yml` enables auth with `deny-all`, so create the first admin user after startup:
+
+```bash
+docker compose -f stacks/notifications/docker-compose.yml exec ntfy \
+  ntfy user add --role=admin "$NTFY_USERNAME"
+```
+
+After that, test a push:
+
+```bash
+scripts/notify.sh homelab-test "Test" "Hello World"
+```
+
+If you prefer token-based publishing, generate one from inside the container and store it in `.env`:
+
+```bash
+docker compose -f stacks/notifications/docker-compose.yml exec ntfy \
+  ntfy token add "$NTFY_USERNAME"
+```
+
+## Service URLs
+
+- `https://$NTFY_DOMAIN`
+- `https://$GOTIFY_DOMAIN`
+
+## Integration guide
+
+### Alertmanager
+
+Use the checked-in sample at [config/alertmanager/alertmanager.yml](../../config/alertmanager/alertmanager.yml). The webhook URL uses ntfy's built-in `alertmanager` template:
+
+```yaml
+receivers:
+  - name: ntfy
+    webhook_configs:
+      - url: "https://ntfy.${DOMAIN}/${ALERTMANAGER_NTFY_TOPIC}?template=alertmanager"
+        send_resolved: true
+```
+
+### Watchtower
+
+ntfy supports Watchtower through Shoutrrr URLs. The official ntfy examples recommend:
+
+```env
+WATCHTOWER_NOTIFICATIONS=shoutrrr
+WATCHTOWER_NOTIFICATION_SKIP_TITLE=true
+WATCHTOWER_NOTIFICATION_URL=ntfy://:TOKEN@${NTFY_DOMAIN}/${WATCHTOWER_NTFY_TOPIC}?title=WatchtowerUpdates
+```
+
+Reference: [ntfy Watchtower examples](https://docs.ntfy.sh/examples/).
+
+### Gitea
+
+Create a custom webhook in Gitea and point it to a dedicated ntfy topic:
+
+```text
+https://ntfy.${DOMAIN}/gitea-events?title=GiteaEvent
+```
+
+For private instances, add Basic Auth credentials or use an ntfy access token in the `Authorization: Bearer ...` header.
+
+### Home Assistant
+
+Home Assistant has a native ntfy integration. Example `configuration.yaml`:
+
+```yaml
+notify:
+  - platform: ntfy
+    name: homelab_ntfy
+    url: "https://ntfy.${DOMAIN}"
+    username: !secret ntfy_username
+    password: !secret ntfy_password
+```
+
+### Uptime Kuma
+
+Add a new notification channel of type `ntfy` in Uptime Kuma:
+
+- URL: `https://ntfy.${DOMAIN}`
+- Topic: `uptime-kuma`
+- Username/password or token: use the same ntfy credentials you created above
+
+## Unified shell interface
+
+Always call [scripts/notify.sh](../../scripts/notify.sh) from other shell scripts instead of hitting ntfy or Gotify directly:
+
+```bash
+scripts/notify.sh backups "Backup finished" "Nightly job completed" high
+```
+
+Supported backends:
+
+- `NOTIFY_BACKEND=ntfy`
+- `NOTIFY_BACKEND=gotify`
+- `NOTIFY_BACKEND=auto` (try ntfy first, then Gotify)
+
+## Notes
+
+- ntfy is the primary delivery path because it has better mobile support and templated webhook rendering.
+- Gotify is kept as a secondary endpoint in case you prefer its app or want a separate backup channel.

--- a/stacks/notifications/docker-compose.yml
+++ b/stacks/notifications/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  ntfy:
+    image: binwiederhier/ntfy:v2.11.0
+    container_name: homelab-ntfy
+    restart: unless-stopped
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        sed "s|\\$${DOMAIN}|${DOMAIN}|g" /etc/ntfy/server.yml > /tmp/server.yml
+        exec ntfy serve --config /tmp/server.yml
+    environment:
+      TZ: ${TZ}
+    volumes:
+      - ../../config/ntfy/server.yml:/etc/ntfy/server.yml:ro
+      - ../../data/ntfy/cache:/var/cache/ntfy
+      - ../../data/ntfy/auth:/var/lib/ntfy
+    networks:
+      - proxy
+      - notifications
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      - traefik.http.routers.ntfy.rule=Host(`${NTFY_DOMAIN}`)
+      - traefik.http.routers.ntfy.entrypoints=websecure
+      - traefik.http.routers.ntfy.tls=true
+      - traefik.http.routers.ntfy.tls.certresolver=letsencrypt
+      - traefik.http.services.ntfy.loadbalancer.server.port=80
+
+  gotify:
+    image: gotify/server:2.5.0
+    container_name: homelab-gotify
+    restart: unless-stopped
+    environment:
+      TZ: ${TZ}
+      GOTIFY_DEFAULTUSER_NAME: ${GOTIFY_DEFAULTUSER_NAME:-admin}
+      GOTIFY_DEFAULTUSER_PASS: ${GOTIFY_PASSWORD}
+      GOTIFY_SERVER_LISTENADDR: 0.0.0.0:80
+    volumes:
+      - ../../data/gotify:/app/data
+    networks:
+      - proxy
+      - notifications
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      - traefik.http.routers.gotify.rule=Host(`${GOTIFY_DOMAIN}`)
+      - traefik.http.routers.gotify.entrypoints=websecure
+      - traefik.http.routers.gotify.tls=true
+      - traefik.http.routers.gotify.tls.certresolver=letsencrypt
+      - traefik.http.services.gotify.loadbalancer.server.port=80
+
+networks:
+  proxy:
+    external: true
+  notifications:
+    name: homelab-notifications


### PR DESCRIPTION
Implements the real deliverables for #13.

What is included:
- stacks/notifications/docker-compose.yml with pinned ntfy and Gotify images plus Traefik labels
- config/ntfy/server.yml with auth + cache settings required by the issue
- config/alertmanager/alertmanager.yml sample receiver wired to ntfy's Alertmanager template
- scripts/notify.sh <topic> <title> <message> [priority] as the single shell entrypoint for notifications
- stacks/notifications/README.md covering Alertmanager, Watchtower, Gitea, Home Assistant, and Uptime Kuma integration
- notification-related env vars added to .env.example

Validation performed locally:
- bash -n scripts/notify.sh
- docker compose -f stacks/notifications/docker-compose.yml config

This PR is meant to replace placeholder or auto-generated implementations with a runnable notifications stack.