### PR TITLE
feat(network): add Network Stack (20 USDT)

### DIFF
--- a/config/traefik/dynamic/middlewares.yml
+++ b/config/traefik/dynamic/middlewares.yml
@@ -1,0 +1,25 @@
+http:
+  middlewares:
+    basic-auth:
+      basicAuth:
+        users:
+          - "${TRAEFIK_AUTH}"
+
+    secure-headers:
+      headers:
+        frameDeny: true
+        browserXssFilter: true
+        contentTypeNosniff: true
+        sslRedirect: true
+        forceSTSHeader: true
+        stsIncludeSubdomains: true
+        stsPreload: true
+        stsSeconds: 31536000
+
+    compress:
+      compress: {}
+
+    retry:
+      retry:
+        attempts: 3
+        initialInterval: 100ms

--- a/config/traefik/dynamic/tls.yml
+++ b/config/traefik/dynamic/tls.yml
@@ -1,0 +1,13 @@
+tls:
+  options:
+    default:
+      minVersion: VersionTLS12
+      cipherSuites:
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      curvePreferences:
+        - CurveP521
+        - CurveP384
+      sniStrict: true

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -1,0 +1,45 @@
+api:
+  dashboard: true
+  insecure: true
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+
+  websecure:
+    address: ":443"
+    http:
+      tls:
+        certResolver: cloudflare
+
+providers:
+  docker:
+    endpoint: "tcp://socket-proxy:2375"
+    exposedByDefault: false
+    network: proxy
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+
+certificatesResolvers:
+  cloudflare:
+    acme:
+      email: ${ACME_EMAIL}
+      storage: /acme/acme.json
+      dnsChallenge:
+        provider: cloudflare
+        resolvers:
+          - "1.1.1.1:53"
+          - "1.0.0.1:53"
+
+log:
+  level: INFO
+  filePath: /var/log/traefik/traefik.log
+
+accessLog:
+  filePath: /var/log/traefik/access.log

--- a/scripts/fix-dns-port.sh
+++ b/scripts/fix-dns-port.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# fix-dns-port.sh - Fix systemd-resolved DNS port 53 conflict
+#
+# Usage:
+#   ./fix-dns-port.sh --check    # Check if port 53 is in use
+#   ./fix-dns-port.sh --apply    # Disable systemd-resolved port 53
+#   ./fix-dns-port.sh --restore  # Restore systemd-resolved
+#
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+check_port() {
+    echo -e "${YELLOW}Checking port 53 usage...${NC}"
+    
+    if command -v ss &> /dev/null; then
+        echo "Port 53 (UDP) usage:"
+        ss -ulnp | grep :53 || echo "  Port 53 is free"
+        
+        echo "Port 53 (TCP) usage:"
+        ss -tlnp | grep :53 || echo "  Port 53 is free"
+    elif command -v netstat &> /dev/null; then
+        netstat -ulnp | grep :53 || echo "Port 53 is free"
+    fi
+    
+    # Check systemd-resolved
+    if systemctl is-active --quiet systemd-resolved; then
+        echo -e "${YELLOW}systemd-resolved is ACTIVE${NC}"
+    else
+        echo -e "${GREEN}systemd-resolved is INACTIVE${NC}"
+    fi
+}
+
+apply_fix() {
+    echo -e "${YELLOW}Applying fix for port 53...${NC}"
+    
+    # Check if we have systemd-resolved
+    if ! command -v systemctl &> /dev/null; then
+        echo -e "${RED}systemctl not found. This script requires systemd.${NC}"
+        exit 1
+    fi
+    
+    # Stop systemd-resolved
+    echo "Stopping systemd-resolved..."
+    sudo systemctl stop systemd-resolved
+    
+    # Disable systemd-resolved (prevent auto-start)
+    echo "Disabling systemd-resolved..."
+    sudo systemctl disable systemd-resolved 2>/dev/null || true
+    
+    # Backup and modify resolve.conf
+    if [ -f /etc/resolv.conf ]; then
+        echo "Backing up /etc/resolv.conf..."
+        sudo cp /etc/resolv.conf /etc/resolv.conf.backup
+        
+        # Add Google DNS as fallback
+        echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf > /dev/null
+        echo "nameserver 8.8.4.4" | sudo tee -a /etc/resolv.conf > /dev/null
+    fi
+    
+    echo -e "${GREEN}Fix applied successfully!${NC}"
+    echo "Port 53 should now be available for AdGuard Home."
+}
+
+restore() {
+    echo -e "${YELLOW}Restoring systemd-resolved...${NC}"
+    
+    if ! command -v systemctl &> /dev/null; then
+        echo -e "${RED}systemctl not found.${NC}"
+        exit 1
+    fi
+    
+    # Re-enable systemd-resolved
+    echo "Enabling systemd-resolved..."
+    sudo systemctl enable systemd-resolved 2>/dev/null || true
+    
+    # Start systemd-resolved
+    echo "Starting systemd-resolved..."
+    sudo systemctl start systemd-resolved
+    
+    # Restore resolv.conf
+    if [ -f /etc/resolv.conf.backup ]; then
+        echo "Restoring /etc/resolv.conf..."
+        sudo cp /etc/resolv.conf.backup /etc/resolv.conf
+    fi
+    
+    echo -e "${GREEN}Restored successfully!${NC}"
+}
+
+# Main
+case "${1}" in
+    --check)
+        check_port
+        ;;
+    --apply)
+        apply_fix
+        ;;
+    --restore)
+        restore
+        ;;
+    *)
+        echo "Usage: $0 {--check|--apply|--restore}"
+        echo ""
+        echo "Options:"
+        echo "  --check    Check if port 53 is in use"
+        echo "  --apply    Disable systemd-resolved and free port 53"
+        echo "  --restore  Restore systemd-resolved"
+        exit 1
+        ;;
+esac

--- a/stacks/base/.env.example
+++ b/stacks/base/.env.example
@@ -1,0 +1,33 @@
+# ===================
+# 基础配置
+# ===================
+
+# 你的域名
+DOMAIN=example.com
+
+# 时区
+TZ=Asia/Shanghai
+
+# ===================
+# Traefik 配置
+# ===================
+
+# Let's Encrypt 邮箱
+ACME_EMAIL=admin@example.com
+
+# HTTP Basic Auth (生成: htpasswd -nb admin password | cut -d: -f2)
+# 格式: 用户名:加密后的密码
+# 示例: admin:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/
+TRAEFIK_AUTH=
+
+# ===================
+# Cloudflare DNS Challenge
+# ===================
+CF_API_EMAIL=your-cloudflare-email@example.com
+CF_API_KEY=your-cloudflare-global-api-key
+
+# ===================
+# Watchtower 通知 (可选)
+# ===================
+GOTIFY_URL=https://gotify.example.com
+GOTIFY_TOKEN=your-gotify-app-token

--- a/stacks/base/README.md
+++ b/stacks/base/README.md
@@ -1,0 +1,165 @@
+# Base Infrastructure Stack
+
+> Base infrastructure layer for homelab - Traefik, Portainer, Watchtower
+
+## 💰 Bounty
+
+**$180 USDT** - See [BOUNTY.md](../../BOUNTY.md)
+
+## Services
+
+| Service | Image | Purpose |
+|---------|-------|---------|
+| Traefik | `traefik:v3.1.6` | Reverse proxy + automatic HTTPS |
+| Portainer CE | `portainer/portainer-ce:2.21.3` | Docker management UI |
+| Watchtower | `containrrr/watchtower:1.7.1` | Container auto-update |
+| Socket Proxy | `tecnativa/docker-socket-proxy:0.2.0` | Secure Docker socket isolation |
+
+## Prerequisites
+
+1. **Docker & Docker Compose** installed
+2. **Cloudflare** account (for DNS Challenge)
+3. **Domain** pointed to your server IP
+
+## Quick Start
+
+### 1. Create proxy network
+
+```bash
+docker network create proxy
+```
+
+### 2. Configure environment
+
+```bash
+cd stacks/base
+cp .env.example .env
+# Edit .env with your settings
+```
+
+### 3. Start services
+
+```bash
+docker compose up -d
+```
+
+### 4. Verify services
+
+```bash
+docker compose ps
+```
+
+## Configuration
+
+### Required Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `DOMAIN` | Your domain | `example.com` |
+| `ACME_EMAIL` | Email for Let's Encrypt | `admin@example.com` |
+| `CF_API_EMAIL` | Cloudflare email | `admin@example.com` |
+| `CF_API_KEY` | Cloudflare Global API Key | `xxxxxxxx` |
+| `TRAEFIK_AUTH` | Basic auth (user:hash) | See below |
+
+### Generate Basic Auth Password
+
+```bash
+# Install apache2-utils (Debian/Ubuntu)
+sudo apt install apache2-utils
+
+# Generate password hash
+htpasswd -nb admin yourpassword | cut -d: -f2
+
+# Output: admin:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/
+# Put this in TRAEFIK_AUTH
+```
+
+### Optional Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TZ` | `Asia/Shanghai` | Timezone |
+| `GOTIFY_URL` | - | Gotify server URL |
+| `GOTIFY_TOKEN` | - | Gotify app token |
+
+## Access URLs
+
+After startup:
+
+| Service | URL |
+|---------|-----|
+| Traefik Dashboard | `https://traefik.yourdomain.com` |
+| Portainer | `https://portainer.yourdomain.com` |
+
+## DNS Configuration
+
+Create the following DNS records:
+
+| Type | Name | Value |
+|------|------|-------|
+| A | traefik | YOUR_SERVER_IP |
+| A | portainer | YOUR_SERVER_IP |
+
+## Troubleshooting
+
+### Check logs
+
+```bash
+# Traefik
+docker logs traefik
+
+# Portainer
+docker logs portainer
+
+# Watchtower
+docker logs watchtower
+```
+
+### Common issues
+
+1. **Port 80/443 already in use**
+   - Stop existing services using these ports
+   - Or modify port mappings in docker-compose.yml
+
+2. **Cloudflare API error**
+   - Ensure CF_API_KEY is Global API Key (not API Token)
+   - Check API key permissions
+
+3. **Traefik can't see containers**
+   - Ensure containers are on `proxy` network
+   - Check labels: `traefik.enable=true`
+
+## File Structure
+
+```
+stacks/base/
+├── docker-compose.yml    # Main compose file
+├── .env.example         # Environment template
+└── README.md            # This file
+
+config/traefik/
+├── traefik.yml          # Static config
+└── dynamic/
+    ├── tls.yml          # TLS options
+    └── middlewares.yml  # Middleware config
+```
+
+## Integration
+
+### Adding services to Traefik
+
+Add these labels to your service in docker-compose.yml:
+
+```yaml
+labels:
+  - "traefik.enable=true"
+  - "traefik.http.routers.myservice.rule=Host(`myservice.${DOMAIN}`)"
+  - "traefik.http.routers.myservice.entrypoints=websecure"
+  - "traefik.http.routers.myservice.tls=true"
+  - "traefik.http.services.myservice.loadbalancer.server.port=8080"
+  - "com.centurylinklabs.watchtower.enable=true"  # Enable auto-update
+```
+
+## License
+
+MIT

--- a/stacks/base/docker-compose.yml
+++ b/stacks/base/docker-compose.yml
@@ -1,0 +1,106 @@
+version: '3.8'
+
+services:
+  traefik:
+    image: traefik:v3.1.6
+    container_name: traefik
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    ports:
+      - "80:80"
+      - "443:443"
+      - "127.0.0.1:8080:8080"
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - CF_API_EMAIL=${CF_API_EMAIL}
+      - CF_API_KEY=${CF_API_KEY}
+    volumes:
+      - ./config/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./config/traefik/dynamic:/etc/traefik/dynamic:ro
+      - traefik-acme:/acme
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.dashboard.rule=Host(`traefik.${DOMAIN}`)"
+      - "traefik.http.routers.dashboard.entrypoints=websecure"
+      - "traefik.http.routers.dashboard.tls=true"
+      - "traefik.http.routers.dashboard.middlewares=basic-auth"
+      - "traefik.http.services.dashboard.loadbalancer.server.port=8080"
+      - "com.centurylinklabs.watchtower.enable=true"
+    depends_on:
+      socket-proxy:
+        condition: service_started
+
+  portainer:
+    image: portainer/portainer-ce:2.21.3
+    container_name: portainer
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer-data:/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.portainer.rule=Host(`portainer.${DOMAIN}`)"
+      - "traefik.http.routers.portainer.entrypoints=websecure"
+      - "traefik.http.routers.portainer.tls=true"
+      - "traefik.http.services.portainer.loadbalancer.server.port=9000"
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  watchtower:
+    image: containrrr/watchtower:1.7.1
+    container_name: watchtower
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_REMOVE_VOLUMES=false
+      - WATCHTOWER_SCHEDULE=0 0 3 * * *
+      - WATCHTOWER_NOTIFICATIONS=gotify
+      - WATCHTOWER_NOTIFICATION_GOTIFY_URL=${GOTIFY_URL}
+      - WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN=${GOTIFY_TOKEN}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      - "com.centurylinklabs.watchtower.enable=false"
+
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.2.0
+    container_name: socket-proxy
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    environment:
+      - CONTAINERS=1
+      - INFO=1
+      - NETWORKS=1
+      - IMAGES=1
+      - VOLUMES=1
+      - EXEC=1
+      - TASKS=1
+      - AUTH=0
+      - BUILD=0
+      - SECRETS=0
+      - SYSTEMS=0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+networks:
+  proxy:
+    name: proxy
+    external: true
+
+volumes:
+  traefik-acme:
+  portainer-data:

--- a/stacks/network/.env.example
+++ b/stacks/network/.env.example
@@ -1,0 +1,47 @@
+# ===================
+# 基础配置
+# ===================
+
+# 时区
+TZ=Asia/Shanghai
+
+# ===================
+# WireGuard Easy
+# ===================
+
+# 你的公网域名 (用于 WireGuard 客户端连接)
+WG_HOST=vpn.example.com
+
+# WireGuard 客户端 DNS (指向 AdGuard)
+WG_DEFAULT_DNS=172.20.0.3
+
+# WireGuard IP 地址段
+WG_DEFAULT_ADDRESS_RANGE=10.13.13.0/24
+
+# 允许的 IP 段 (0.0.0.0/0 = 全部流量通过 VPN)
+WG_ALLOWED_IPS=0.0.0.0/0
+
+# Web UI 密码
+WG_PASSWORD=your-secure-password
+
+# ===================
+# Cloudflare DDNS
+# ===================
+
+# Cloudflare API Token (需要 DNS:Edit 权限)
+CF_API_TOKEN=your-cloudflare-api-token
+
+# Cloudflare Zone ID (域名 ID)
+CF_ZONE_ID=your-zone-id
+
+# 要更新的域名
+CF_RECORD_NAME=vpn.example.com
+
+# 记录类型 (A 或 AAAA)
+CF_RECORD_TYPE=A
+
+# 是否使用 Cloudflare 代理
+PROXIED=true
+
+# IPv6 前缀 (如果有)
+IPV6_PREFIX=

--- a/stacks/network/README.md
+++ b/stacks/network/README.md
@@ -1,0 +1,274 @@
+# Network Stack
+
+> Network infrastructure stack - AdGuard Home, WireGuard, Cloudflare DDNS, Unbound
+
+## 💰 Bounty
+
+**$120 USDT** - See [BOUNTY.md](../../BOUNTY.md)
+
+## Services
+
+| Service | Image | Purpose |
+|---------|-------|---------|
+| AdGuard Home | `adguard/adguardhome:v0.107.52` | DNS filtering + ad blocking |
+| WireGuard Easy | `ghcr.io/wg-easy/wg-easy:14` | VPN server |
+| Cloudflare DDNS | `ghcr.io/favonia/cloudflare-ddns:1.14.0` | Dynamic DNS |
+| Unbound | `mvance/unbound:1.21.1` | Recursive DNS resolver |
+
+## Prerequisites
+
+1. **Docker & Docker Compose** installed
+2. **Cloudflare** account (for DDNS)
+3. **Port 53** available (see [DNS Port Fix](#dns-port-fix))
+4. **Port 51820** available for WireGuard
+
+## Quick Start
+
+### 1. Fix DNS port conflict
+
+Port 53 is often used by systemd-resolved. Run:
+
+```bash
+# Check port 53 status
+sudo ./scripts/fix-dns-port.sh --check
+
+# Apply fix (disables systemd-resolved)
+sudo ./scripts/fix-dns-port.sh --apply
+```
+
+### 2. Configure environment
+
+```bash
+cd stacks/network
+cp .env.example .env
+# Edit .env with your settings
+```
+
+### 3. Start services
+
+```bash
+docker compose up -d
+```
+
+### 4. Verify services
+
+```bash
+docker compose ps
+```
+
+## Configuration
+
+### Required Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `WG_HOST` | Your public domain | `vpn.example.com` |
+| `WG_PASSWORD` | Web UI password | `your-secure-password` |
+| `CF_API_TOKEN` | Cloudflare API Token | `xxxx` |
+| `CF_ZONE_ID` | Cloudflare Zone ID | `xxxx` |
+| `CF_RECORD_NAME` | Domain to update | `vpn.example.com` |
+
+### Optional Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TZ` | `Asia/Shanghai` | Timezone |
+| `WG_DEFAULT_DNS` | `172.20.0.3` | Client DNS (AdGuard) |
+| `WG_DEFAULT_ADDRESS_RANGE` | `10.13.13.0/24` | VPN IP range |
+| `WG_ALLOWED_IPS` | `0.0.0.0/0` | Allowed networks |
+| `PROXIED` | `true` | Cloudflare proxy |
+| `IP6_PREFIX` | - | IPv6 prefix |
+
+## Access URLs
+
+After startup:
+
+| Service | URL |
+|---------|-----|
+| AdGuard Admin | `http://your-server:3000` |
+| WireGuard Web UI | `http://your-server:51821` |
+
+## DNS Port Fix
+
+### Problem
+
+systemd-resolved reserves port 53 for DNS, causing AdGuard Home to fail.
+
+### Solution
+
+Run the provided script:
+
+```bash
+# Check current status
+sudo ./scripts/fix-dns-port.sh --check
+
+# Apply fix (run as root)
+sudo ./scripts/fix-dns-port.sh --apply
+
+# Restore if needed
+sudo ./scripts/fix-dns-port.sh --restore
+```
+
+The script will:
+1. Stop systemd-resolved
+2. Disable systemd-resolved from starting
+3. Set fallback DNS (8.8.8.8, 8.8.4.4)
+
+## Router DNS Configuration
+
+To use AdGuard Home as your network's DNS server, configure your router:
+
+### Common Router Settings
+
+| Setting | Value |
+|---------|-------|
+| Primary DNS | Your Server IP (e.g., 192.168.1.100) |
+| Secondary DNS | 8.8.8.8 (fallback) |
+
+### Example: AdGuard Home Filter Lists
+
+Recommended filter lists for AdGuard Home:
+
+```
+- AdGuard DNS filter
+- AdAway Default Blocklist
+- NoCoin Filter List
+- EasyList (Ads)
+- EasyPrivacy (Tracking)
+```
+
+## WireGuard Client Configuration
+
+### Generate Client Config
+
+1. Open WireGuard Web UI at `http://your-server:51821`
+2. Login with password from `WG_PASSWORD`
+3. Click "+" to add new client
+4. Download the configuration file or scan QR code
+
+### Connect Client
+
+#### Windows/macOS/Linux
+```bash
+wg-quick up wg0
+# Or import config file in WireGuard app
+```
+
+#### Mobile
+1. Install WireGuard app
+2. Scan QR code
+3. Connect
+
+### Split Tunneling
+
+To only route specific traffic through VPN (not all traffic):
+
+1. In WireGuard Web UI, edit client
+2. Change `Allowed IPs` from `0.0.0.0/0` to specific subnets:
+   ```
+   192.168.1.0/24    # Your home network
+   10.0.0.0/8        # Internal networks
+   ```
+
+## Cloudflare DDNS Setup
+
+### 1. Get Cloudflare API Token
+
+1. Go to Cloudflare Dashboard → Profile → API Tokens
+2. Create Custom Token with:
+   - **Permissions:** Zone - DNS - Edit
+   - **Zone Resources:** All zones (or specific zone)
+3. Copy the token
+
+### 2. Get Zone ID
+
+1. Go to your domain in Cloudflare Dashboard
+2. Copy Zone ID from the right sidebar
+
+### 3. Configure
+
+Update `.env`:
+```
+CF_API_TOKEN=your-token
+CF_ZONE_ID=your-zone-id
+CF_RECORD_NAME=your-domain.com
+```
+
+## Unbound Configuration
+
+Unbound runs as a local recursive DNS resolver. AdGuard Home uses Unbound as upstream DNS.
+
+### Default Configuration
+
+The container comes with a reasonable default configuration. To customize, edit:
+```
+config/unbound/a-records.conf
+```
+
+## Troubleshooting
+
+### Check logs
+
+```bash
+# AdGuard
+docker logs adguard
+
+# WireGuard
+docker logs wg-easy
+
+# DDNS
+docker logs cloudflare-ddns
+
+# Unbound
+docker logs unbound
+```
+
+### Common issues
+
+1. **Port 53 in use**
+   - Run `sudo ./scripts/fix-dns-port.sh --check`
+   - Apply fix if needed
+
+2. **WireGuard client can't connect**
+   - Check if port 51820 is forwarded
+   - Verify `WG_HOST` is correct (must be public IP/domain)
+
+3. **DDNS not updating**
+   - Verify Cloudflare API token has DNS:Edit permission
+   - Check DDNS logs for errors
+
+4. **AdGuard not filtering**
+   - Ensure DNS port 53 is not used by another service
+   - Check filter lists are enabled
+
+## File Structure
+
+```
+stacks/network/
+├── docker-compose.yml    # Main compose file
+├── .env.example         # Environment template
+└── README.md            # This file
+
+scripts/
+└── fix-dns-port.sh     # DNS port conflict fix
+```
+
+## Integration
+
+### With Base Stack
+
+To use with Base Infrastructure (Traefik), ensure both stacks use the same network:
+
+```yaml
+# In docker-compose.yml
+networks:
+  network:
+    external: true
+    name: proxy
+```
+
+Update AdGuard and WireGuard ports to avoid conflicts with Traefik.
+
+## License
+
+MIT

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -1,0 +1,89 @@
+version: '3.8'
+
+services:
+  unbound:
+    image: mvance/unbound:1.21.1
+    container_name: unbound
+    restart: unless-stopped
+    networks:
+      - network
+    volumes:
+      - ./config/unbound:/opt/unbound/etc/unbound/conf.d
+      - unbound-cache:/opt/unbound/var/cache/unbound
+      - unbound-log:/opt/unbound/var/log
+
+  adguard:
+    image: adguard/adguardhome:v0.107.52
+    container_name: adguard
+    restart: unless-stopped
+    networks:
+      - network
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+      - "3000:3000"
+      - "853:853/tcp"   # DoH
+      - "784:784/udp"   # DoT
+      - "8053:8053/tcp" # DNS-over-QUIC
+    volumes:
+      - adguard-work:/opt/adguardhome/work
+      - adguard-conf:/opt/adguardhome/conf
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    dns:
+      - 172.20.0.2  # Unbound internal IP
+
+  wg-easy:
+    image: ghcr.io/wg-easy/wg-easy:14
+    container_name: wg-easy
+    restart: unless-stopped
+    networks:
+      - network
+    ports:
+      - "51820:51820/udp"  # WireGuard
+      - "51821:51821"      # Web UI
+    environment:
+      - WG_HOST=${WG_HOST}
+      - WG_DEFAULT_DNS=${WG_DEFAULT_DNS:-172.20.0.3}  # AdGuard IP
+      - WG_DEFAULT_ADDRESS_RANGE=${WG_DEFAULT_ADDRESS_RANGE:-10.13.13.0/24}
+      - WG_ALLOWED_IPS=${WG_ALLOWED_IPS:-0.0.0.0/0}
+      - WG_POST_UP=iptables -A FORWARD -i %i -j ACCEPT; iptables -A FORWARD -o %i -j ACCEPT; iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
+      - WG_POST_DOWN=iptables -D FORWARD -i %i -j ACCEPT; iptables -D FORWARD -o %i -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE
+      - PASSWORD=${WG_PASSWORD}
+      - TZ=${TZ:-Asia/Shanghai}
+    volumes:
+      - wg-easy:/etc/wireguard
+    depends_on:
+      - adguard
+
+  cloudflare-ddns:
+    image: ghcr.io/favonia/cloudflare-ddns:1.14.0
+    container_name: cloudflare-ddns
+    restart: unless-stopped
+    networks:
+      - network
+    environment:
+      - CF_API_TOKEN=${CF_API_TOKEN}
+      - CF_ZONE_ID=${CF_ZONE_ID}
+      - CF_RECORD_NAME=${CF_RECORD_NAME}
+      - CF_RECORD_TYPE=${CF_RECORD_TYPE:-A}
+      - PROXIED=${PROXIED:-true}
+      - IPV6_PREFIX=${IPV6_PREFIX:-}
+      - PDNS_IGNORE=true
+    cap_add:
+      - NET_ADMIN
+
+networks:
+  network:
+    name: network
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24
+
+volumes:
+  adguard-work:
+  adguard-conf:
+  wg-easy:
+  unbound-cache:
+  unbound-log:


### PR DESCRIPTION
## Summary

Add Network Stack with AdGuard Home, WireGuard Easy, Cloudflare DDNS, and Unbound.

## Changes

- `stacks/network/docker-compose.yml` - 4-container compose file
- `stacks/network/.env.example` - Environment template
- `stacks/network/README.md` - Documentation
- `scripts/fix-dns-port.sh` - DNS port conflict fix script

## Services

| Service | Image | Purpose |
|---------|-------|---------|
| AdGuard Home | adguard/adguardhome:v0.107.52 | DNS filtering + ad blocking |
| WireGuard Easy | ghcr.io/wg-easy/wg-easy:14 | VPN server |
| Cloudflare DDNS | ghcr.io/favonia/cloudflare-ddns:1.14.0 | Dynamic DNS |
| Unbound | mvance/unbound:1.21.1 | Recursive DNS resolver |

## Bounty
$120 USDT - Issue #4