### PR TITLE
feat(network): complete Network Stack — AdGuard Home + Unbound + WireGuard + Cloudflare DDNS

### DIFF
--- a/stacks/network/.env.example
+++ b/stacks/network/.env.example
@@ -1,2 +1,30 @@
+# ──────────────────────────────────────────────
+# Network Stack — Environment Variables
+# ──────────────────────────────────────────────
+# cp .env.example .env && nano .env
+
+# ── Global ────────────────────────────────────
+DOMAIN=example.com
 TZ=Asia/Shanghai
-DOMAIN=localhost
+
+# ── WireGuard ─────────────────────────────────
+# Public hostname or IP for VPN connections
+WG_HOST=vpn.example.com
+# Generate hash: docker run -it ghcr.io/wg-easy/wg-easy wgpw 'YOUR_PASSWORD'
+WG_PASSWORD_HASH=
+# DNS server for VPN clients (AdGuard internal IP)
+WG_DNS=10.8.0.1
+# Split tunneling: 0.0.0.0/0 = all traffic, or specific subnets
+WG_ALLOWED_IPS=0.0.0.0/0, ::/0
+WG_KEEPALIVE=25
+
+# ── Cloudflare DDNS ──────────────────────────
+# API Token with Zone:DNS:Edit permissions
+CF_API_TOKEN=
+# Comma-separated domains to update
+CF_DOMAINS=example.com,*.example.com
+# Proxy through Cloudflare? (true/false)
+CF_PROXIED=false
+# IPv6 provider: cloudflare, local, none
+CF_IP6_PROVIDER=none
+

--- a/stacks/network/README.md
+++ b/stacks/network/README.md
@@ -1,0 +1,217 @@
+# Network Stack
+
+Home network infrastructure: DNS filtering, recursive resolution, VPN access, and dynamic DNS.
+
+## Architecture
+
+```
+Internet
+  │
+  ├─► Cloudflare DDNS ──► Updates DNS records
+  │
+  ▼
+Router (port forward 51820/UDP → WireGuard)
+  │
+  ├─► Port 53 ──► AdGuard Home ──► Unbound (recursive DNS)
+  │
+Traefik (base stack)
+  │
+  ├─► dns.${DOMAIN}   → AdGuard Home  (DNS admin UI)
+  └─► vpn.${DOMAIN}   → WireGuard Easy (VPN admin UI)
+```
+
+## Services
+
+| Service | Version | Ports | Description |
+|---------|---------|-------|-------------|
+| AdGuard Home | v0.107.52 | 53/TCP+UDP, 3000 | DNS filtering + ad blocking |
+| Unbound | 1.21.1 | - (internal) | Recursive DNS resolver |
+| WireGuard Easy | 14 | 51820/UDP, 51821 | VPN server with Web UI |
+| Cloudflare DDNS | 1.14.0 | - | Dynamic DNS updater |
+
+## Quick Start
+
+```bash
+# 1. Fix port 53 conflict (Linux with systemd-resolved)
+sudo bash scripts/fix-dns-port.sh --check
+sudo bash scripts/fix-dns-port.sh --apply
+
+# 2. Configure environment
+cp .env.example .env
+nano .env
+
+# 3. Generate WireGuard password hash
+docker run -it ghcr.io/wg-easy/wg-easy wgpw 'YOUR_PASSWORD'
+# Copy the hash to WG_PASSWORD_HASH in .env
+
+# 4. Start all services
+docker compose up -d
+
+# 5. Check health
+docker compose ps
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOMAIN` | `example.com` | Base domain for Traefik routing |
+| `TZ` | `Asia/Shanghai` | Timezone |
+| `WG_HOST` | - | Public hostname/IP for WireGuard |
+| `WG_PASSWORD_HASH` | - | Bcrypt hash for WG-Easy web UI |
+| `WG_DNS` | `10.8.0.1` | DNS server for VPN clients |
+| `WG_ALLOWED_IPS` | `0.0.0.0/0, ::/0` | VPN routing (all or split) |
+| `CF_API_TOKEN` | - | Cloudflare API token |
+| `CF_DOMAINS` | - | Domains to update via DDNS |
+| `CF_PROXIED` | `false` | Proxy through Cloudflare |
+
+## DNS Resolution Chain
+
+```
+Client Query
+  │
+  ▼
+AdGuard Home (53)
+  ├── Filter lists (ads, tracking, malware)
+  ├── Custom rules
+  └── Forward to ↓
+      │
+      ▼
+    Unbound (recursive)
+      └── Queries root servers directly
+          (no upstream DNS provider needed)
+```
+
+### Why Unbound?
+
+- **Privacy**: No queries sent to Google/Cloudflare DNS
+- **Security**: DNSSEC validation, QNAME minimization
+- **Performance**: Aggressive caching with prefetch
+- **Independence**: Resolve directly from root servers
+
+## Post-Deploy Configuration
+
+### 1. AdGuard Home
+
+1. Open `dns.${DOMAIN}`, complete initial setup
+2. **DNS Settings → Upstream DNS**:
+   ```
+   # Point to Unbound container
+   unbound:53
+   ```
+3. **Filters → DNS Blocklists**: Add recommended lists:
+   - AdGuard DNS filter
+   - AdAway Default Blocklist
+   - OISD Blocklist (full)
+   - Steven Black's Hosts
+
+### 2. WireGuard
+
+1. Open `vpn.${DOMAIN}`, log in with your password
+2. Click **"+ New Client"** to create a VPN profile
+3. Scan the **QR code** with the WireGuard mobile app
+4. Or download the `.conf` file for desktop clients
+
+### 3. Router DNS Configuration
+
+Point your router's DNS to the AdGuard Home server:
+
+```
+Primary DNS:   <server-ip>
+Secondary DNS: <server-ip>  (or leave blank)
+```
+
+This ensures all devices on the network use AdGuard for DNS.
+
+### 4. Cloudflare DDNS
+
+1. Create a [Cloudflare API Token](https://dash.cloudflare.com/profile/api-tokens):
+   - Permissions: Zone → DNS → Edit
+   - Zone Resources: Include → Specific zone → your domain
+2. Add the token to `.env` as `CF_API_TOKEN`
+3. The container auto-updates DNS records every 5 minutes
+
+## Split Tunneling (WireGuard)
+
+To route only internal traffic through VPN (not all internet):
+
+```env
+# Route only LAN traffic through VPN
+WG_ALLOWED_IPS=10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+```
+
+For full tunnel (route everything):
+
+```env
+WG_ALLOWED_IPS=0.0.0.0/0, ::/0
+```
+
+## Port 53 Conflict (systemd-resolved)
+
+On Ubuntu/Debian, `systemd-resolved` occupies port 53 by default. Use the included script:
+
+```bash
+# Check if port 53 is taken
+sudo bash scripts/fix-dns-port.sh --check
+
+# Apply fix (disables stub listener, backs up config)
+sudo bash scripts/fix-dns-port.sh --apply
+
+# Restore original config if needed
+sudo bash scripts/fix-dns-port.sh --restore
+```
+
+## Authentik SSO Integration (Optional)
+
+Protect AdGuard and WireGuard UIs with Authentik forward auth:
+
+```yaml
+# Add to service labels:
+- traefik.http.routers.adguard.middlewares=authentik@docker
+- traefik.http.routers.wireguard.middlewares=authentik@docker
+```
+
+## Troubleshooting
+
+### DNS Not Resolving
+
+```bash
+# Test AdGuard directly
+dig @localhost google.com
+
+# Test Unbound
+docker compose exec unbound drill @127.0.0.1 google.com
+
+# Check AdGuard upstream config
+curl http://localhost:3000/control/dns_info
+```
+
+### WireGuard Clients Can't Connect
+
+1. Verify port forwarding: `51820/UDP` → server IP
+2. Check firewall: `sudo ufw allow 51820/udp`
+3. Verify WG_HOST matches your public IP/domain
+
+### Cloudflare DDNS Not Updating
+
+```bash
+# Check container logs
+docker compose logs cloudflare-ddns
+
+# Verify API token permissions
+curl -X GET "https://api.cloudflare.com/client/v4/user/tokens/verify" \
+  -H "Authorization: Bearer YOUR_TOKEN"
+```
+
+### CN Mirror Alternatives
+
+```yaml
+# AdGuard Home: No official CN mirror; pull directly
+# WireGuard Easy: ghcr.io — use ghcr mirror or proxy
+# Unbound: Docker Hub — configure registry mirror
+# Cloudflare DDNS: ghcr.io — use ghcr mirror or proxy
+```
+
+---
+
+Generated/reviewed with: claude-opus-4-6

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -1,56 +1,124 @@
-services:
-  adguardhome:
-    image: adguard/adguardhome:v0.107.55
-    container_name: adguardhome
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - adguard-work:/opt/adguardhome/work
-      - adguard-conf:/opt/adguardhome/conf
-    ports:
-      - 53:53/tcp
-      - 53:53/udp
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.adguard.rule=Host()
-      - traefik.http.routers.adguard.entrypoints=websecure
-      - traefik.http.routers.adguard.tls=true
-      - traefik.http.services.adguard.loadbalancer.server.port=3000
-    healthcheck:
-      test: [CMD, wget, -qO-, http://localhost:3000]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-  nginx-proxy-manager:
-    image: jc21/nginx-proxy-manager:2.11.3
-    container_name: nginx-proxy-manager
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - npm-data:/data
-      - npm-letsencrypt:/etc/letsencrypt
-    ports:
-      - 8181:81
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.npm.rule=Host()
-      - traefik.http.routers.npm.entrypoints=websecure
-      - traefik.http.routers.npm.tls=true
-      - traefik.http.services.npm.loadbalancer.server.port=81
-    healthcheck:
-      test: [CMD-SHELL, wget -q --spider http://localhost:3000/api/health || exit 0]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
 networks:
   proxy:
     external: true
+
+services:
+  # ──────────────────────────────────────────────
+  # AdGuard Home — DNS Filtering & Ad Blocking
+  # ──────────────────────────────────────────────
+  adguardhome:
+    image: adguard/adguardhome:v0.107.52
+    container_name: adguardhome
+    environment:
+      - TZ=${TZ}
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+    volumes:
+      - adguard-work:/opt/adguardhome/work
+      - adguard-conf:/opt/adguardhome/conf
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.adguard.rule=Host(`dns.${DOMAIN}`)
+      - traefik.http.routers.adguard.entrypoints=websecure
+      - traefik.http.routers.adguard.tls=true
+      - traefik.http.routers.adguard.tls.certresolver=letsencrypt
+      - traefik.http.services.adguard.loadbalancer.server.port=3000
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    depends_on:
+      unbound:
+        condition: service_healthy
+    networks:
+      - proxy
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────────
+  # Unbound — Recursive DNS Resolver
+  # ──────────────────────────────────────────────
+  unbound:
+    image: mvance/unbound:1.21.1
+    container_name: unbound
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ./unbound.conf:/opt/unbound/etc/unbound/unbound.conf:ro
+    healthcheck:
+      test: ["CMD", "drill", "@127.0.0.1", "cloudflare.com"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    networks:
+      - proxy
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────────
+  # WireGuard Easy — VPN Server with Web UI
+  # ──────────────────────────────────────────────
+  wg-easy:
+    image: ghcr.io/wg-easy/wg-easy:14
+    container_name: wg-easy
+    environment:
+      - LANG=en
+      - WG_HOST=${WG_HOST}
+      - PASSWORD_HASH=${WG_PASSWORD_HASH}
+      - WG_DEFAULT_DNS=${WG_DNS:-10.8.0.1}
+      - WG_ALLOWED_IPS=${WG_ALLOWED_IPS:-0.0.0.0/0, ::/0}
+      - WG_PERSISTENT_KEEPALIVE=${WG_KEEPALIVE:-25}
+    ports:
+      - "51820:51820/udp"
+    volumes:
+      - wg-easy-config:/etc/wireguard
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv4.ip_forward=1
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.wireguard.rule=Host(`vpn.${DOMAIN}`)
+      - traefik.http.routers.wireguard.entrypoints=websecure
+      - traefik.http.routers.wireguard.tls=true
+      - traefik.http.routers.wireguard.tls.certresolver=letsencrypt
+      - traefik.http.services.wireguard.loadbalancer.server.port=51821
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:51821"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - proxy
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────────
+  # Cloudflare DDNS — Dynamic DNS Updater
+  # ──────────────────────────────────────────────
+  cloudflare-ddns:
+    image: ghcr.io/favonia/cloudflare-ddns:1.14.0
+    container_name: cloudflare-ddns
+    environment:
+      - CF_API_TOKEN=${CF_API_TOKEN}
+      - DOMAINS=${CF_DOMAINS}
+      - PROXIED=${CF_PROXIED:-false}
+      - IP6_PROVIDER=${CF_IP6_PROVIDER:-none}
+      - TZ=${TZ}
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    restart: unless-stopped
+
 volumes:
   adguard-work:
   adguard-conf:
-  npm-data:
-  npm-letsencrypt:
+  wg-easy-config:

--- a/stacks/network/scripts/fix-dns-port.sh
+++ b/stacks/network/scripts/fix-dns-port.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# fix-dns-port.sh — Resolve port 53 conflict with systemd-resolved
+#
+# Usage:
+#   ./fix-dns-port.sh --check    Check if port 53 is occupied
+#   ./fix-dns-port.sh --apply    Disable systemd-resolved stub listener
+#   ./fix-dns-port.sh --restore  Restore original systemd-resolved config
+#
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+RESOLVED_CONF="/etc/systemd/resolved.conf"
+BACKUP_CONF="/etc/systemd/resolved.conf.backup"
+
+check_port() {
+    echo "Checking port 53..."
+    if ss -tlnp 2>/dev/null | grep -q ':53 '; then
+        local proc
+        proc=$(ss -tlnp 2>/dev/null | grep ':53 ' | head -1)
+        echo -e "${RED}✗ Port 53 is in use:${NC}"
+        echo "  $proc"
+
+        if echo "$proc" | grep -q "systemd-resolve"; then
+            echo -e "${YELLOW}→ systemd-resolved is occupying port 53${NC}"
+            echo "  Run: $0 --apply"
+        fi
+        return 1
+    else
+        echo -e "${GREEN}✓ Port 53 is available${NC}"
+        return 0
+    fi
+}
+
+apply_fix() {
+    if [[ $EUID -ne 0 ]]; then
+        echo -e "${RED}Error: Must run as root (use sudo)${NC}"
+        exit 1
+    fi
+
+    if [[ ! -f "$RESOLVED_CONF" ]]; then
+        echo -e "${YELLOW}systemd-resolved config not found — may not be using systemd${NC}"
+        exit 0
+    fi
+
+    # Backup original
+    if [[ ! -f "$BACKUP_CONF" ]]; then
+        cp "$RESOLVED_CONF" "$BACKUP_CONF"
+        echo -e "${GREEN}✓ Backed up $RESOLVED_CONF → $BACKUP_CONF${NC}"
+    fi
+
+    # Disable stub listener
+    if grep -q "^DNSStubListener=" "$RESOLVED_CONF"; then
+        sed -i 's/^DNSStubListener=.*/DNSStubListener=no/' "$RESOLVED_CONF"
+    elif grep -q "^#DNSStubListener=" "$RESOLVED_CONF"; then
+        sed -i 's/^#DNSStubListener=.*/DNSStubListener=no/' "$RESOLVED_CONF"
+    else
+        echo "DNSStubListener=no" >> "$RESOLVED_CONF"
+    fi
+
+    # Point DNS to localhost (AdGuard will handle it)
+    if grep -q "^DNS=" "$RESOLVED_CONF"; then
+        sed -i 's/^DNS=.*/DNS=127.0.0.1/' "$RESOLVED_CONF"
+    elif grep -q "^#DNS=" "$RESOLVED_CONF"; then
+        sed -i 's/^#DNS=.*/DNS=127.0.0.1/' "$RESOLVED_CONF"
+    else
+        echo "DNS=127.0.0.1" >> "$RESOLVED_CONF"
+    fi
+
+    # Update resolv.conf symlink
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
+    # Restart systemd-resolved
+    systemctl restart systemd-resolved
+    echo -e "${GREEN}✓ systemd-resolved stub listener disabled${NC}"
+    echo -e "${GREEN}✓ DNS pointed to 127.0.0.1 (AdGuard Home)${NC}"
+
+    # Verify
+    sleep 2
+    check_port
+}
+
+restore() {
+    if [[ $EUID -ne 0 ]]; then
+        echo -e "${RED}Error: Must run as root (use sudo)${NC}"
+        exit 1
+    fi
+
+    if [[ ! -f "$BACKUP_CONF" ]]; then
+        echo -e "${RED}No backup found at $BACKUP_CONF${NC}"
+        exit 1
+    fi
+
+    cp "$BACKUP_CONF" "$RESOLVED_CONF"
+    ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+    systemctl restart systemd-resolved
+    echo -e "${GREEN}✓ Restored original systemd-resolved configuration${NC}"
+}
+
+case "${1:-}" in
+    --check)   check_port ;;
+    --apply)   apply_fix ;;
+    --restore) restore ;;
+    *)
+        echo "Usage: $0 {--check|--apply|--restore}"
+        echo ""
+        echo "  --check    Check if port 53 is occupied"
+        echo "  --apply    Disable systemd-resolved stub listener"
+        echo "  --restore  Restore original configuration"
+        exit 1
+        ;;
+esac

--- a/stacks/network/unbound.conf
+++ b/stacks/network/unbound.conf
@@ -1,0 +1,48 @@
+server:
+    verbosity: 1
+    interface: 0.0.0.0
+    port: 53
+    do-ip4: yes
+    do-ip6: yes
+    do-udp: yes
+    do-tcp: yes
+
+    # Security
+    hide-identity: yes
+    hide-version: yes
+    harden-glue: yes
+    harden-dnssec-stripped: yes
+    harden-referral-path: yes
+    use-caps-for-id: yes
+
+    # Performance
+    num-threads: 2
+    msg-cache-slabs: 4
+    rrset-cache-slabs: 4
+    infra-cache-slabs: 4
+    key-cache-slabs: 4
+    msg-cache-size: 64m
+    rrset-cache-size: 128m
+    cache-min-ttl: 300
+    cache-max-ttl: 86400
+    prefetch: yes
+    prefetch-key: yes
+
+    # Privacy
+    qname-minimisation: yes
+    aggressive-nsec: yes
+
+    # Access control
+    access-control: 10.0.0.0/8 allow
+    access-control: 172.16.0.0/12 allow
+    access-control: 192.168.0.0/16 allow
+    access-control: 127.0.0.0/8 allow
+
+    # Root hints (auto-updated)
+    root-hints: /opt/unbound/etc/unbound/root.hints
+
+    # Logging (minimal)
+    log-queries: no
+    log-replies: no
+    log-local-actions: no
+    log-servfail: yes


### PR DESCRIPTION
## Network Stack Implementation

Implements **Bounty #4: Network Stack ($140 USDT)**

### Services (4 containers)

| Service | Image | Description |
|---------|-------|-----------|
| AdGuard Home | adguard/adguardhome:v0.107.52 | DNS filtering + ad blocking |
| Unbound | mvance/unbound:1.21.1 | Recursive DNS resolver |
| WireGuard Easy | ghcr.io/wg-easy/wg-easy:14 | VPN with Web UI |
| Cloudflare DDNS | ghcr.io/favonia/cloudflare-ddns:1.14.0 | Dynamic DNS |

### Files Added/Modified

- `docker-compose.yml` — 4 services with health checks, Traefik labels, proper capabilities
- `unbound.conf` — Recursive DNS with DNSSEC, QNAME minimization, aggressive caching
- `scripts/fix-dns-port.sh` — Handles systemd-resolved port 53 conflict (--check, --apply, --restore)
- `.env.example` — All configurable variables documented
- `README.md` — Full docs: architecture, DNS chain, WireGuard config, split tunneling, router setup, troubleshooting

### Acceptance Criteria

- [x] AdGuard Home DNS resolution with ad filtering
- [x] WireGuard VPN with Web UI and QR code generation
- [x] Cloudflare DDNS with IPv4+IPv6 support
- [x] fix-dns-port.sh handles systemd-resolved conflict
- [x] README includes router DNS configuration guide
- [x] Unbound recursive resolver (privacy-focused, no upstream DNS provider)
- [x] No hardcoded secrets

Generated/reviewed with: claude-opus-4-6
