### PR TITLE
feat(databases): complete Databases Stack — PostgreSQL + Redis + MariaDB + pgAdmin + Redis Commander

### DIFF
--- a/stacks/databases/.env.example
+++ b/stacks/databases/.env.example
@@ -1,12 +1,37 @@
-# Database Stack
+# ──────────────────────────────────────────────
+# Databases Stack — Environment Variables
+# ──────────────────────────────────────────────
+# cp .env.example .env && nano .env
+# Generate strong passwords: openssl rand -base64 24
+
+# ── Global ────────────────────────────────────
+DOMAIN=example.com
+TZ=Asia/Shanghai
+
+# ── PostgreSQL ────────────────────────────────
 POSTGRES_ROOT_USER=postgres
 POSTGRES_ROOT_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+
+# ── Redis ─────────────────────────────────────
 REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
+
+# ── MariaDB ───────────────────────────────────
 MARIADB_ROOT_PASSWORD=CHANGE_ME_MARIADB_PASSWORD
 
-# Per-service passwords
+# ── pgAdmin UI ────────────────────────────────
+PGADMIN_EMAIL=admin@example.com
+PGADMIN_PASSWORD=CHANGE_ME_PGADMIN
+
+# ── Redis Commander UI ────────────────────────
+REDIS_COMMANDER_USER=admin
+REDIS_COMMANDER_PASSWORD=CHANGE_ME_REDIS_COMMANDER
+
+# ── Per-service Database Passwords ────────────
 NEXTCLOUD_DB_PASSWORD=CHANGE_ME
 GITEA_DB_PASSWORD=CHANGE_ME
 OUTLINE_DB_PASSWORD=CHANGE_ME
+AUTHENTIK_DB_PASSWORD=CHANGE_ME
+GRAFANA_DB_PASSWORD=CHANGE_ME
 VAULTWARDEN_DB_PASSWORD=CHANGE_ME
 BOOKSTACK_DB_PASSWORD=CHANGE_ME
+

--- a/stacks/databases/README.md
+++ b/stacks/databases/README.md
@@ -1,0 +1,224 @@
+# Databases Stack
+
+Shared database layer for all homelab services. Centralizes PostgreSQL, Redis, and MariaDB to avoid each service running its own database instance.
+
+## Architecture
+
+```
+Other Stacks (Nextcloud, Gitea, Outline, Authentik, ...)
+         │
+         ▼
+    databases network (internal)
+         │
+    ┌────┼────────────┬──────────────┐
+    │    │             │              │
+    ▼    ▼             ▼              ▼
+PostgreSQL  Redis    MariaDB    (no external access)
+ 16.4       7.4.0    11.5.2
+    │         │
+    ▼         ▼
+Traefik (proxy network — admin UIs only)
+    │
+    ├─► pgadmin.${DOMAIN}   → pgAdmin
+    └─► redis.${DOMAIN}     → Redis Commander
+```
+
+## Services
+
+| Service | Version | Network | Description |
+|---------|---------|---------|-------------|
+| PostgreSQL | 16.4-alpine | databases only | Primary relational database |
+| Redis | 7.4.0-alpine | databases only | Cache & message queue |
+| MariaDB | 11.5.2 | databases only | MySQL-compatible database |
+| pgAdmin | 8.11 | databases + proxy | PostgreSQL web UI |
+| Redis Commander | latest | databases + proxy | Redis web UI |
+
+## Quick Start
+
+```bash
+# 1. Configure environment
+cp .env.example .env
+nano .env    # Set strong passwords!
+
+# 2. Generate strong passwords
+for var in POSTGRES_ROOT_PASSWORD REDIS_PASSWORD MARIADB_ROOT_PASSWORD; do
+  echo "$var=$(openssl rand -base64 24)"
+done
+
+# 3. Start databases
+docker compose up -d
+
+# 4. Verify initialization
+docker compose logs postgres | grep "init-postgres"
+
+# 5. Check health
+docker compose ps
+```
+
+## Multi-tenant PostgreSQL
+
+The init script (`initdb/01-init-databases.sh`) automatically creates isolated databases and users for each service:
+
+| Database | User | Used By |
+|----------|------|---------|
+| nextcloud | nextcloud | Nextcloud (Storage Stack) |
+| gitea | gitea | Gitea (Productivity Stack) |
+| outline | outline | Outline (Productivity Stack) |
+| authentik | authentik | Authentik (SSO Stack) |
+| grafana | grafana | Grafana (Observability Stack) |
+| vaultwarden | vaultwarden | Vaultwarden (Productivity Stack) |
+| bookstack | bookstack | BookStack (Productivity Stack) |
+
+The init script is **idempotent** — safe to run multiple times without errors or data loss.
+
+## Redis Database Allocation
+
+Redis databases are isolated by number. Configure in each service's connection string:
+
+| DB | Service | Connection String |
+|----|---------|-------------------|
+| 0 | Authentik | `redis://:PASSWORD@redis:6379/0` |
+| 1 | Outline | `redis://:PASSWORD@redis:6379/1` |
+| 2 | Gitea | `redis://:PASSWORD@redis:6379/2` |
+| 3 | Nextcloud | `redis://:PASSWORD@redis:6379/3` |
+| 4 | Grafana | `redis://:PASSWORD@redis:6379/4` |
+
+## Connection Strings for Other Stacks
+
+### PostgreSQL
+
+```yaml
+# In other stack's docker-compose.yml:
+services:
+  my-app:
+    environment:
+      DATABASE_URL: postgresql://nextcloud:${NEXTCLOUD_DB_PASSWORD}@postgres:5432/nextcloud
+    networks:
+      - databases
+networks:
+  databases:
+    external: true
+```
+
+### Redis
+
+```yaml
+services:
+  my-app:
+    environment:
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
+    networks:
+      - databases
+```
+
+### MariaDB
+
+```yaml
+services:
+  my-app:
+    environment:
+      DATABASE_URL: mysql://bookstack:${BOOKSTACK_DB_PASSWORD}@mariadb:3306/bookstack
+    networks:
+      - databases
+```
+
+## Network Isolation
+
+Database containers are **NOT** exposed to the `proxy` network or host ports:
+
+- `postgres`, `redis`, `mariadb` → `databases` network only
+- `pgadmin`, `redis-commander` → `databases` + `proxy` (for Traefik web UI)
+- No host port bindings = no direct external access
+
+Other stacks connect by joining the `databases` network:
+
+```yaml
+networks:
+  databases:
+    external: true
+```
+
+## Backup & Restore
+
+### Automated Backup
+
+```bash
+# Run backup (creates timestamped .tar.gz)
+sudo bash scripts/backup-databases.sh
+
+# Schedule daily backup via cron
+echo "0 3 * * * cd /path/to/stacks/databases && bash scripts/backup-databases.sh" | sudo crontab -
+```
+
+The backup script:
+- `pg_dumpall` — dumps all PostgreSQL databases
+- `redis-cli BGSAVE` — triggers Redis persistence, copies dump.rdb
+- `mysqldump` — dumps all MariaDB databases
+- Compresses to `homelab-db-backup-YYYYMMDD_HHMMSS.tar.gz`
+- Retains last 7 days (configurable via `RETAIN_DAYS`)
+- Optional MinIO upload (`MINIO_ENABLED=true`)
+
+### Manual Restore
+
+```bash
+# Extract backup
+tar xzf homelab-db-backup-20260317_030000.tar.gz
+
+# Restore PostgreSQL
+cat postgres-all.sql | docker exec -i homelab-postgres psql -U postgres
+
+# Restore Redis
+docker cp redis-dump.rdb homelab-redis:/data/dump.rdb
+docker compose restart redis
+
+# Restore MariaDB
+cat mariadb-all.sql | docker exec -i homelab-mariadb mysql -u root -p
+```
+
+## Troubleshooting
+
+### Init Script Didn't Run
+
+The Docker entrypoint only runs init scripts on **first start** (when the data directory is empty). To re-run:
+
+```bash
+# Option 1: Exec into container and run manually
+docker exec -it homelab-postgres bash /docker-entrypoint-initdb.d/01-init-databases.sh
+
+# Option 2: Reset data (WARNING: deletes all data!)
+docker compose down -v
+docker compose up -d
+```
+
+### Can't Connect from Another Stack
+
+1. Verify the stack's docker-compose.yml declares the `databases` network as external
+2. Check the container is on the `databases` network:
+   ```bash
+   docker network inspect databases | grep -A5 "my-app"
+   ```
+3. Test connectivity:
+   ```bash
+   docker exec my-app-container ping postgres
+   ```
+
+### pgAdmin Can't Connect
+
+In pgAdmin, add a server with:
+- Host: `postgres` (container name)
+- Port: `5432`
+- Username: `postgres`
+- Password: your `POSTGRES_ROOT_PASSWORD`
+
+### Redis Memory Full
+
+Current limit: 512MB with `allkeys-lru` eviction. To increase:
+
+```yaml
+# In docker-compose.yml, modify redis command:
+command: redis-server --requirepass ${REDIS_PASSWORD} --maxmemory 1gb
+```
+
+---
+
+Generated/reviewed with: claude-opus-4-6

--- a/stacks/databases/docker-compose.yml
+++ b/stacks/databases/docker-compose.yml
@@ -1,12 +1,22 @@
 services:
+  # ──────────────────────────────────────────────
+  # PostgreSQL — Primary Database (Multi-tenant)
+  # ──────────────────────────────────────────────
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16.4-alpine
     container_name: homelab-postgres
-    restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_ROOT_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_ROOT_PASSWORD}
       POSTGRES_DB: postgres
+      # Per-service passwords passed to init script
+      NEXTCLOUD_DB_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-changeme_nextcloud}
+      GITEA_DB_PASSWORD: ${GITEA_DB_PASSWORD:-changeme_gitea}
+      OUTLINE_DB_PASSWORD: ${OUTLINE_DB_PASSWORD:-changeme_outline}
+      AUTHENTIK_DB_PASSWORD: ${AUTHENTIK_DB_PASSWORD:-changeme_authentik}
+      GRAFANA_DB_PASSWORD: ${GRAFANA_DB_PASSWORD:-changeme_grafana}
+      VAULTWARDEN_DB_PASSWORD: ${VAULTWARDEN_DB_PASSWORD:-changeme_vaultwarden}
+      BOOKSTACK_DB_PASSWORD: ${BOOKSTACK_DB_PASSWORD:-changeme_bookstack}
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./initdb:/docker-entrypoint-initdb.d:ro
@@ -19,13 +29,22 @@ services:
       retries: 5
       start_period: 30s
     labels:
-      - "traefik.enable=false"
-
-  redis:
-    image: redis:7-alpine
-    container_name: homelab-redis
+      - traefik.enable=false
     restart: unless-stopped
-    command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
+
+  # ──────────────────────────────────────────────
+  # Redis — Cache & Message Queue
+  # ──────────────────────────────────────────────
+  redis:
+    image: redis:7.4.0-alpine
+    container_name: homelab-redis
+    command: >-
+      redis-server
+      --requirepass ${REDIS_PASSWORD}
+      --appendonly yes
+      --maxmemory 512mb
+      --maxmemory-policy allkeys-lru
+      --databases 16
     volumes:
       - redis-data:/data
     networks:
@@ -36,12 +55,15 @@ services:
       timeout: 5s
       retries: 5
     labels:
-      - "traefik.enable=false"
-
-  mariadb:
-    image: mariadb:11.4
-    container_name: homelab-mariadb
+      - traefik.enable=false
     restart: unless-stopped
+
+  # ──────────────────────────────────────────────
+  # MariaDB — MySQL-compatible Database
+  # ──────────────────────────────────────────────
+  mariadb:
+    image: mariadb:11.5.2
+    container_name: homelab-mariadb
     environment:
       MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
       MARIADB_AUTO_UPGRADE: "1"
@@ -57,12 +79,78 @@ services:
       retries: 5
       start_period: 30s
     labels:
-      - "traefik.enable=false"
+      - traefik.enable=false
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────────
+  # pgAdmin — PostgreSQL Management UI
+  # ──────────────────────────────────────────────
+  pgadmin:
+    image: dpage/pgadmin4:8.11
+    container_name: homelab-pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@example.com}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-changeme}
+      PGADMIN_CONFIG_SERVER_MODE: "True"
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.pgadmin.rule=Host(`pgadmin.${DOMAIN}`)
+      - traefik.http.routers.pgadmin.entrypoints=websecure
+      - traefik.http.routers.pgadmin.tls=true
+      - traefik.http.routers.pgadmin.tls.certresolver=letsencrypt
+      - traefik.http.services.pgadmin.loadbalancer.server.port=80
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:80/misc/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - databases
+      - proxy
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────────
+  # Redis Commander — Redis Management UI
+  # ──────────────────────────────────────────────
+  redis-commander:
+    image: rediscommander/redis-commander:latest
+    container_name: homelab-redis-commander
+    environment:
+      REDIS_HOSTS: "local:redis:6379:0:${REDIS_PASSWORD}"
+      HTTP_USER: ${REDIS_COMMANDER_USER:-admin}
+      HTTP_PASSWORD: ${REDIS_COMMANDER_PASSWORD:-changeme}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.redis-commander.rule=Host(`redis.${DOMAIN}`)
+      - traefik.http.routers.redis-commander.entrypoints=websecure
+      - traefik.http.routers.redis-commander.tls=true
+      - traefik.http.routers.redis-commander.tls.certresolver=letsencrypt
+      - traefik.http.services.redis-commander.loadbalancer.server.port=8081
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8081"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - databases
+      - proxy
+    restart: unless-stopped
 
 volumes:
   postgres-data:
   redis-data:
   mariadb-data:
+  pgadmin-data:
 
 networks:
   databases:

--- a/stacks/databases/initdb/01-init-databases.sh
+++ b/stacks/databases/initdb/01-init-databases.sh
@@ -1,39 +1,66 @@
 #!/bin/bash
 # =============================================================================
 # HomeLab PostgreSQL Init Script
-# Runs on first container start. Creates per-service databases and users.
+# Idempotent — safe to run multiple times without errors or data loss.
+# Runs on first container start via /docker-entrypoint-initdb.d/
 # =============================================================================
 set -euo pipefail
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-  -- Nextcloud
-  CREATE USER nextcloud WITH PASSWORD '${NEXTCLOUD_DB_PASSWORD:-changeme_nextcloud}';
-  CREATE DATABASE nextcloud OWNER nextcloud ENCODING 'UTF8';
-  GRANT ALL PRIVILEGES ON DATABASE nextcloud TO nextcloud;
+# Helper: create database + user if they don't exist (idempotent)
+create_db() {
+  local db_name="$1"
+  local db_password="$2"
+  local extensions="${3:-}"
 
-  -- Gitea
-  CREATE USER gitea WITH PASSWORD '${GITEA_DB_PASSWORD:-changeme_gitea}';
-  CREATE DATABASE gitea OWNER gitea ENCODING 'UTF8';
-  GRANT ALL PRIVILEGES ON DATABASE gitea TO gitea;
+  echo "[init-postgres] Setting up database: $db_name"
 
-  -- Outline
-  CREATE USER outline WITH PASSWORD '${OUTLINE_DB_PASSWORD:-changeme_outline}';
-  CREATE DATABASE outline OWNER outline ENCODING 'UTF8';
-  GRANT ALL PRIVILEGES ON DATABASE outline TO outline;
-  -- Outline requires uuid-ossp extension
-  \connect outline
-  CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-  \connect postgres
-
-  -- Vaultwarden (uses SQLite by default, PostgreSQL optional)
-  CREATE USER vaultwarden WITH PASSWORD '${VAULTWARDEN_DB_PASSWORD:-changeme_vaultwarden}';
-  CREATE DATABASE vaultwarden OWNER vaultwarden ENCODING 'UTF8';
-  GRANT ALL PRIVILEGES ON DATABASE vaultwarden TO vaultwarden;
-
-  -- BookStack
-  CREATE USER bookstack WITH PASSWORD '${BOOKSTACK_DB_PASSWORD:-changeme_bookstack}';
-  CREATE DATABASE bookstack OWNER bookstack ENCODING 'UTF8';
-  GRANT ALL PRIVILEGES ON DATABASE bookstack TO bookstack;
+  # Create user (idempotent)
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    DO \$\$
+    BEGIN
+      IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$db_name') THEN
+        CREATE ROLE "$db_name" WITH LOGIN PASSWORD '$db_password';
+        RAISE NOTICE 'User $db_name created';
+      ELSE
+        ALTER ROLE "$db_name" WITH PASSWORD '$db_password';
+        RAISE NOTICE 'User $db_name already exists, password updated';
+      END IF;
+    END
+    \$\$;
 EOSQL
 
-echo "[init-postgres] All databases created successfully"
+  # Create database (idempotent)
+  if ! psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -tc \
+    "SELECT 1 FROM pg_database WHERE datname = '$db_name'" | grep -q 1; then
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+      -c "CREATE DATABASE \"$db_name\" OWNER \"$db_name\" ENCODING 'UTF8';"
+    echo "[init-postgres]   Database $db_name created"
+  else
+    echo "[init-postgres]   Database $db_name already exists"
+  fi
+
+  # Grant privileges
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+    -c "GRANT ALL PRIVILEGES ON DATABASE \"$db_name\" TO \"$db_name\";"
+
+  # Create extensions if specified
+  if [ -n "$extensions" ]; then
+    IFS=',' read -ra EXTS <<< "$extensions"
+    for ext in "${EXTS[@]}"; do
+      psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$db_name" \
+        -c "CREATE EXTENSION IF NOT EXISTS \"$ext\";"
+      echo "[init-postgres]   Extension $ext enabled in $db_name"
+    done
+  fi
+}
+
+# ── Create per-service databases ──────────────
+create_db "nextcloud"   "${NEXTCLOUD_DB_PASSWORD:-changeme_nextcloud}"
+create_db "gitea"       "${GITEA_DB_PASSWORD:-changeme_gitea}"
+create_db "outline"     "${OUTLINE_DB_PASSWORD:-changeme_outline}"    "uuid-ossp"
+create_db "authentik"   "${AUTHENTIK_DB_PASSWORD:-changeme_authentik}"
+create_db "grafana"     "${GRAFANA_DB_PASSWORD:-changeme_grafana}"
+create_db "vaultwarden" "${VAULTWARDEN_DB_PASSWORD:-changeme_vaultwarden}"
+create_db "bookstack"   "${BOOKSTACK_DB_PASSWORD:-changeme_bookstack}"
+
+echo "[init-postgres] All databases initialized successfully"

--- a/stacks/databases/scripts/backup-databases.sh
+++ b/stacks/databases/scripts/backup-databases.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HomeLab Database Backup Script
+# Backs up PostgreSQL (pg_dumpall) + Redis (BGSAVE) + MariaDB (mysqldump)
+# Compresses to .tar.gz, retains last N days, optional MinIO upload
+# =============================================================================
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────
+BACKUP_DIR="${BACKUP_DIR:-/srv/backups/databases}"
+RETAIN_DAYS="${RETAIN_DAYS:-7}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_NAME="homelab-db-backup-${TIMESTAMP}"
+WORK_DIR="${BACKUP_DIR}/${BACKUP_NAME}"
+
+# MinIO upload (optional)
+MINIO_ENABLED="${MINIO_ENABLED:-false}"
+MINIO_ALIAS="${MINIO_ALIAS:-homelab}"
+MINIO_BUCKET="${MINIO_BUCKET:-backups}"
+MINIO_PATH="${MINIO_PATH:-databases}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[backup]${NC} $*"; }
+warn() { echo -e "${YELLOW}[backup]${NC} $*"; }
+err() { echo -e "${RED}[backup]${NC} $*" >&2; }
+
+# ── Setup ─────────────────────────────────────
+mkdir -p "$WORK_DIR"
+log "Starting backup: $BACKUP_NAME"
+
+# ── PostgreSQL Backup ─────────────────────────
+log "Backing up PostgreSQL..."
+if docker exec homelab-postgres pg_dumpall \
+  -U "${POSTGRES_ROOT_USER:-postgres}" \
+  --clean --if-exists \
+  > "${WORK_DIR}/postgres-all.sql" 2>/dev/null; then
+  log "  PostgreSQL: $(wc -c < "${WORK_DIR}/postgres-all.sql" | xargs) bytes"
+else
+  warn "  PostgreSQL backup failed (container may not be running)"
+fi
+
+# ── Redis Backup ──────────────────────────────
+log "Backing up Redis..."
+if docker exec homelab-redis redis-cli \
+  -a "${REDIS_PASSWORD:-}" \
+  BGSAVE >/dev/null 2>&1; then
+  # Wait for BGSAVE to complete
+  sleep 2
+  docker cp homelab-redis:/data/dump.rdb "${WORK_DIR}/redis-dump.rdb" 2>/dev/null || true
+  if [[ -f "${WORK_DIR}/redis-dump.rdb" ]]; then
+    log "  Redis: $(wc -c < "${WORK_DIR}/redis-dump.rdb" | xargs) bytes"
+  else
+    warn "  Redis dump.rdb copy failed"
+  fi
+  # Also copy AOF if available
+  docker cp homelab-redis:/data/appendonly.aof "${WORK_DIR}/redis-appendonly.aof" 2>/dev/null || true
+else
+  warn "  Redis backup failed (container may not be running)"
+fi
+
+# ── MariaDB Backup ────────────────────────────
+log "Backing up MariaDB..."
+if docker exec homelab-mariadb mysqldump \
+  -u root \
+  -p"${MARIADB_ROOT_PASSWORD:-}" \
+  --all-databases \
+  --single-transaction \
+  --routines \
+  --triggers \
+  > "${WORK_DIR}/mariadb-all.sql" 2>/dev/null; then
+  log "  MariaDB: $(wc -c < "${WORK_DIR}/mariadb-all.sql" | xargs) bytes"
+else
+  warn "  MariaDB backup failed (container may not be running)"
+fi
+
+# ── Compress ──────────────────────────────────
+log "Compressing..."
+ARCHIVE="${BACKUP_DIR}/${BACKUP_NAME}.tar.gz"
+tar -czf "$ARCHIVE" -C "$BACKUP_DIR" "$BACKUP_NAME"
+rm -rf "$WORK_DIR"
+log "Archive: $ARCHIVE ($(du -h "$ARCHIVE" | cut -f1))"
+
+# ── Upload to MinIO (optional) ────────────────
+if [[ "$MINIO_ENABLED" == "true" ]]; then
+  log "Uploading to MinIO..."
+  if command -v mc &>/dev/null; then
+    mc cp "$ARCHIVE" "${MINIO_ALIAS}/${MINIO_BUCKET}/${MINIO_PATH}/${BACKUP_NAME}.tar.gz"
+    log "  Uploaded to ${MINIO_ALIAS}/${MINIO_BUCKET}/${MINIO_PATH}/"
+  else
+    warn "  mc (MinIO client) not found, skipping upload"
+  fi
+fi
+
+# ── Cleanup old backups ───────────────────────
+log "Cleaning up backups older than ${RETAIN_DAYS} days..."
+DELETED=$(find "$BACKUP_DIR" -name "homelab-db-backup-*.tar.gz" -mtime +"$RETAIN_DAYS" -delete -print | wc -l | xargs)
+log "  Removed $DELETED old backup(s)"
+
+# ── Summary ───────────────────────────────────
+log "Backup complete: $ARCHIVE"
+log "Retention: ${RETAIN_DAYS} days"
+ls -lh "$BACKUP_DIR"/homelab-db-backup-*.tar.gz 2>/dev/null | tail -5


### PR DESCRIPTION
## Databases Stack Implementation

Implements **Bounty #11: Database Layer ($130 USDT)**

### Services (5 containers)

| Service | Image | Network | Description |
|---------|-------|---------|-------------|
| PostgreSQL | postgres:16.4-alpine | databases | Multi-tenant relational DB |
| Redis | redis:7.4.0-alpine | databases | Cache & message queue |
| MariaDB | mariadb:11.5.2 | databases | MySQL-compatible DB |
| pgAdmin | dpage/pgadmin4:8.11 | databases + proxy | PostgreSQL web UI |
| Redis Commander | rediscommander/redis-commander | databases + proxy | Redis web UI |

### Key Changes

- **Idempotent init script** — `create_db()` helper uses `IF NOT EXISTS` checks, safe to re-run
- **7 pre-configured databases**: nextcloud, gitea, outline, authentik, grafana, vaultwarden, bookstack
- **pgAdmin + Redis Commander** with Traefik routing for web management
- **Network isolation**: DB containers on `databases` network only, admin UIs bridged to `proxy`
- **Backup script** (`scripts/backup-databases.sh`): pg_dumpall + redis BGSAVE + mysqldump, compressed tar.gz, 7-day retention, optional MinIO upload
- **Redis database allocation** documented (DB 0-4 per service)
- **README.md**: connection strings, restore procedures, cron scheduling, troubleshooting

### Acceptance Criteria

- [x] init-databases.sh creates all databases and users
- [x] init-databases.sh is idempotent (re-run without errors)
- [x] pgAdmin accessible via Traefik and connects to PostgreSQL
- [x] Other stacks can connect via `databases` network hostname
- [x] Database containers NOT exposed to host ports
- [x] backup-databases.sh generates valid .tar.gz backups
- [x] README includes connection string examples for all DB types

Generated/reviewed with: claude-opus-4-6
