### PR TITLE
feat(home-automation): complete Home Automation Stack — HA + Node-RED + Mosquitto + Zigbee2MQTT + ESPHome

### DIFF
--- a/stacks/home-automation/.env.example
+++ b/stacks/home-automation/.env.example
@@ -1,0 +1,19 @@
+# ============================================================
+# Home Automation Stack — Environment Variables
+# ============================================================
+
+# ─── Global ──────────────────────────────────────────────────
+DOMAIN=yourdomain.com
+TZ=Asia/Shanghai
+
+# ─── MQTT (Mosquitto) ───────────────────────────────────────
+MQTT_PORT=1883                  # Host port for MQTT
+MQTT_USER=homeassistant         # MQTT username
+MQTT_PASS=changeme              # MQTT password
+
+# ─── Node-RED ───────────────────────────────────────────────
+NODE_RED_SECRET=                # openssl rand -hex 16 — encrypts flow credentials
+
+# ─── Zigbee2MQTT ────────────────────────────────────────────
+# Uncomment and set your Zigbee adapter device path
+# ZIGBEE_DEVICE=/dev/ttyUSB0   # Common: /dev/ttyUSB0, /dev/ttyACM0

--- a/stacks/home-automation/README.md
+++ b/stacks/home-automation/README.md
@@ -1,0 +1,213 @@
+# Home Automation Stack
+
+Complete smart home automation: **Home Assistant** hub, **Node-RED** visual flows, **Mosquitto** MQTT broker, **Zigbee2MQTT** device gateway, and **ESPHome** firmware manager.
+
+## Services
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| [Home Assistant](https://www.home-assistant.io/) | `ha.yourdomain.com` | Smart home hub |
+| [Node-RED](https://nodered.org/) | `nodered.yourdomain.com` | Visual automation flows |
+| [Mosquitto](https://mosquitto.org/) | Port 1883 (MQTT) | MQTT message broker |
+| [Zigbee2MQTT](https://www.zigbee2mqtt.io/) | `zigbee.yourdomain.com` | Zigbee device gateway |
+| [ESPHome](https://esphome.io/) | `esphome.yourdomain.com` | ESP device firmware |
+
+## Architecture
+
+```
+  Zigbee Devices          ESP Devices          WiFi Devices
+       │                       │                     │
+       ▼                       ▼                     │
+  ┌──────────┐          ┌──────────┐                 │
+  │Zigbee2MQTT│          │ ESPHome  │                 │
+  │  :8080   │          │  :6052   │                 │
+  └─────┬────┘          └─────┬────┘                 │
+        │                     │                      │
+        ▼                     ▼                      ▼
+  ┌──────────────────────────────────────────────────────┐
+  │              Mosquitto MQTT Broker (:1883)           │
+  └──────────────────────┬───────────────────────────────┘
+                         │
+              ┌──────────┼──────────┐
+              ▼                     ▼
+        ┌──────────┐          ┌──────────┐
+        │   Home   │          │ Node-RED │
+        │Assistant │◄────────►│  :1880   │
+        │  :8123   │          └──────────┘
+        │ (host)   │
+        └──────────┘
+```
+
+## Network Mode: Why Host?
+
+Home Assistant uses `network_mode: host` by default because:
+
+1. **mDNS/Bonjour**: Required to discover devices like Chromecast, Apple TV, Sonos
+2. **UPnP/SSDP**: Used by many IoT devices for auto-discovery
+3. **Multicast**: Essential for device protocols that use multicast packets
+
+### Bridge Mode Alternative
+
+If you don't need LAN device discovery, you can switch to bridge mode by modifying the docker-compose.yml:
+
+```yaml
+# Replace network_mode: host with:
+homeassistant:
+  # Remove: network_mode: host
+  networks:
+    - proxy
+    - iot
+  ports:
+    - "8123:8123"
+```
+
+**Bridge mode limitations:**
+- No mDNS device discovery (Chromecast, Sonos, etc.)
+- No UPnP/SSDP auto-discovery
+- Must manually configure device IPs
+- Zigbee/Z-Wave via MQTT still works normally
+
+## Quick Start
+
+```bash
+# 1. Copy environment template
+cp .env.example .env
+
+# 2. Fill in your values
+nano .env
+
+# 3. Set up MQTT authentication
+docker compose up -d mosquitto
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/password_file homeassistant your-mqtt-password
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/password_file zigbee2mqtt your-mqtt-password
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/password_file nodered your-mqtt-password
+docker compose restart mosquitto
+
+# 4. Start all services
+docker compose up -d
+```
+
+## Service Configuration
+
+### MQTT Users
+
+Create separate MQTT users for each service:
+
+```bash
+# Add user (interactive password prompt)
+docker exec -it mosquitto mosquitto_passwd /mosquitto/config/password_file username
+
+# Add user (non-interactive)
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/password_file username password
+
+# Delete user
+docker exec mosquitto mosquitto_passwd -D /mosquitto/config/password_file username
+
+# Restart to apply
+docker compose restart mosquitto
+```
+
+### Home Assistant → MQTT
+
+In Home Assistant, add MQTT integration:
+1. Settings → Devices & Services → Add Integration → MQTT
+2. Broker: `localhost` (host mode) or `mosquitto` (bridge mode)
+3. Port: `1883`
+4. Username: `homeassistant`
+5. Password: your MQTT password
+
+### Node-RED → MQTT
+
+1. Open Node-RED → Settings (☰) → Manage Palette → Install `node-red-contrib-home-assistant-websocket`
+2. Add MQTT broker node:
+   - Server: `mosquitto`
+   - Port: `1883`
+   - Username: `nodered`
+   - Password: your MQTT password
+
+### Node-RED → Home Assistant
+
+1. Install `node-red-contrib-home-assistant-websocket` in Node-RED
+2. Configure HA server node:
+   - Base URL: `http://homeassistant:8123` (bridge) or `http://localhost:8123` (host)
+   - Access Token: Generate long-lived token in HA → Profile → Security
+
+### Zigbee2MQTT
+
+**USB Adapter Setup:**
+
+1. Identify your Zigbee adapter:
+   ```bash
+   ls -l /dev/serial/by-id/
+   ```
+
+2. Uncomment device mapping in docker-compose.yml:
+   ```yaml
+   devices:
+     - /dev/ttyUSB0:/dev/ttyACM0
+   ```
+
+3. Configure Zigbee2MQTT (first start creates config):
+   ```yaml
+   # Edit zigbee2mqtt-data volume → configuration.yaml
+   mqtt:
+     base_topic: zigbee2mqtt
+     server: mqtt://mosquitto:1883
+     user: zigbee2mqtt
+     password: your-mqtt-password
+   serial:
+     port: /dev/ttyACM0
+   frontend:
+     port: 8080
+   ```
+
+**Supported adapters:** SONOFF Zigbee 3.0 USB, ConBee II, CC2531, CC2652
+
+### ESPHome
+
+Access the dashboard at `esphome.yourdomain.com`:
+
+1. Click "New Device" → Enter device name
+2. Choose board type (ESP32, ESP8266)
+3. Edit YAML configuration
+4. Compile and flash via USB or OTA
+
+**USB flashing:** Uncomment `privileged: true` in docker-compose.yml.
+
+## Subdomains
+
+| Subdomain | Service |
+|-----------|---------|
+| `ha.yourdomain.com` | Home Assistant |
+| `nodered.yourdomain.com` | Node-RED |
+| `zigbee.yourdomain.com` | Zigbee2MQTT |
+| `esphome.yourdomain.com` | ESPHome |
+
+## Volumes
+
+| Volume | Content |
+|--------|---------|
+| `ha-config` | Home Assistant configuration, automations, database |
+| `node-red-data` | Node-RED flows, credentials, packages |
+| `mosquitto-data` | MQTT persistent messages |
+| `mosquitto-logs` | MQTT broker logs |
+| `zigbee2mqtt-data` | Zigbee device database, configuration |
+| `esphome-data` | ESPHome device configs, firmware builds |
+
+## Troubleshooting
+
+### Home Assistant can't discover devices
+
+Ensure `network_mode: host` is set. Bridge mode disables mDNS/UPnP discovery.
+
+### MQTT connection refused
+
+1. Check Mosquitto is running: `docker logs mosquitto`
+2. Verify password file exists: `docker exec mosquitto cat /mosquitto/config/password_file`
+3. Test connection: `docker exec mosquitto mosquitto_sub -t '#' -u homeassistant -P your-password -C 1 -W 5`
+
+### Zigbee2MQTT won't start
+
+1. Check USB adapter is detected: `ls /dev/ttyUSB*` or `ls /dev/ttyACM*`
+2. Check permissions: `sudo chmod 666 /dev/ttyUSB0`
+3. View logs: `docker logs zigbee2mqtt`

--- a/stacks/home-automation/config/mosquitto/mosquitto.conf
+++ b/stacks/home-automation/config/mosquitto/mosquitto.conf
@@ -1,0 +1,35 @@
+# ============================================================
+# Mosquitto MQTT Broker — Security Configuration
+# ============================================================
+# Authentication: password file (no anonymous access)
+# Generate password file:
+#   docker exec mosquitto mosquitto_passwd -c /mosquitto/config/password_file homeassistant
+# ============================================================
+
+# ─── Listener ────────────────────────────────────────────────
+listener 1883
+protocol mqtt
+
+# ─── Authentication ──────────────────────────────────────────
+# SECURITY: Disable anonymous access
+allow_anonymous false
+password_file /mosquitto/config/password_file
+
+# ─── Persistence ─────────────────────────────────────────────
+persistence true
+persistence_location /mosquitto/data/
+autosave_interval 60
+
+# ─── Logging ─────────────────────────────────────────────────
+log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
+log_type error
+log_type warning
+log_type notice
+log_timestamp true
+log_timestamp_format %Y-%m-%dT%H:%M:%S
+
+# ─── Connections ─────────────────────────────────────────────
+max_connections -1
+max_inflight_messages 20
+max_queued_messages 1000

--- a/stacks/home-automation/config/mosquitto/password_file
+++ b/stacks/home-automation/config/mosquitto/password_file
@@ -1,0 +1,7 @@
+# Mosquitto password file
+# Generated with: mosquitto_passwd -b /mosquitto/config/password_file <username> <password>
+# DO NOT commit real passwords — this is a placeholder.
+# Create users:
+#   docker exec mosquitto mosquitto_passwd -b /mosquitto/config/password_file homeassistant <password>
+#   docker exec mosquitto mosquitto_passwd -b /mosquitto/config/password_file zigbee2mqtt <password>
+#   docker exec mosquitto mosquitto_passwd -b /mosquitto/config/password_file nodered <password>

--- a/stacks/home-automation/docker-compose.yml
+++ b/stacks/home-automation/docker-compose.yml
@@ -1,12 +1,43 @@
+# ============================================================
+# Home Automation Stack — Home Assistant + Node-RED + Mosquitto + Zigbee2MQTT + ESPHome
+# ============================================================
+# Home Assistant uses network_mode: host for mDNS/UPnP device discovery.
+# See README for bridge mode alternative (with limitations).
+#
+# Prerequisites:
+#   - Base Infrastructure stack (Traefik)
+# ============================================================
+
+networks:
+  proxy:
+    external: true
+  iot:
+    driver: bridge
+
+volumes:
+  ha-config:
+  node-red-data:
+  mosquitto-data:
+  mosquitto-logs:
+  zigbee2mqtt-data:
+  esphome-data:
+
 services:
+  # ─── Home Assistant — Smart Home Hub ───────────────────────────
+  # Uses host networking for mDNS/SSDP device discovery.
+  # Traefik routing handled via labels + docker provider.
   homeassistant:
-    image: homeassistant/home-assistant:2024.11.3
+    image: ghcr.io/home-assistant/home-assistant:2024.9.3
     container_name: homeassistant
     restart: unless-stopped
-    networks:
-      - proxy
+    # Host network for mDNS/UPnP/SSDP device discovery
+    # This is REQUIRED for auto-discovering smart home devices on the LAN.
+    # See README for bridge mode alternative (limited discovery).
+    network_mode: host
     volumes:
       - ha-config:/config
+      - /etc/localtime:/etc/localtime:ro
+      - /run/dbus:/run/dbus:ro
     environment:
       - TZ=${TZ:-Asia/Shanghai}
     privileged: true
@@ -15,89 +46,126 @@ services:
       - "traefik.http.routers.ha.rule=Host(`ha.${DOMAIN}`)"
       - traefik.http.routers.ha.entrypoints=websecure
       - traefik.http.routers.ha.tls=true
+      - traefik.http.routers.ha.tls.certresolver=letsencrypt
       - traefik.http.services.ha.loadbalancer.server.port=8123
+      - com.centurylinklabs.watchtower.enable=true
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8123/ || exit 1"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8123/api/"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 60s
 
+  # ─── Node-RED — Visual Flow Automation ─────────────────────────
   node-red:
-    image: nodered/node-red:3.1.14
+    image: nodered/node-red:4.0.3
     container_name: node-red
     restart: unless-stopped
     networks:
       - proxy
+      - iot
     volumes:
       - node-red-data:/data
     environment:
       - TZ=${TZ:-Asia/Shanghai}
+      - NODE_RED_CREDENTIAL_SECRET=${NODE_RED_SECRET:-}
+    user: "1000:1000"
     labels:
       - traefik.enable=true
       - "traefik.http.routers.nodered.rule=Host(`nodered.${DOMAIN}`)"
       - traefik.http.routers.nodered.entrypoints=websecure
       - traefik.http.routers.nodered.tls=true
+      - traefik.http.routers.nodered.tls.certresolver=letsencrypt
       - traefik.http.services.nodered.loadbalancer.server.port=1880
+      - com.centurylinklabs.watchtower.enable=true
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:1880/ || exit 1"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:1880"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
 
+  # ─── Mosquitto — MQTT Broker ───────────────────────────────────
   mosquitto:
-    image: eclipse-mosquitto:2.0.20
+    image: eclipse-mosquitto:2.0.19
     container_name: mosquitto
     restart: unless-stopped
     networks:
-      - proxy
+      - iot
     volumes:
       - mosquitto-data:/mosquitto/data
       - mosquitto-logs:/mosquitto/log
-      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./config/mosquitto/password_file:/mosquitto/config/password_file:ro
     ports:
-      - "1883:1883"
+      - "${MQTT_PORT:-1883}:1883"
     healthcheck:
-      test: [CMD-SHELL, "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 || exit 1"]
+      test: ["CMD-SHELL", "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 -u ${MQTT_USER:-homeassistant} -P ${MQTT_PASS:-changeme} || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 15s
 
+  # ─── Zigbee2MQTT — Zigbee Device Gateway ───────────────────────
   zigbee2mqtt:
-    image: koenkk/zigbee2mqtt:1.41.0
+    image: koenkk/zigbee2mqtt:1.40.2
     container_name: zigbee2mqtt
     restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - zigbee2mqtt-data:/app/data
-    environment:
-      - TZ=${TZ:-Asia/Shanghai}
     depends_on:
       mosquitto:
         condition: service_healthy
+    networks:
+      - proxy
+      - iot
+    volumes:
+      - zigbee2mqtt-data:/app/data
+      - /run/udev:/run/udev:ro
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    # Uncomment for USB Zigbee adapter
+    # devices:
+    #   - ${ZIGBEE_DEVICE:-/dev/ttyUSB0}:/dev/ttyACM0
     labels:
       - traefik.enable=true
       - "traefik.http.routers.zigbee2mqtt.rule=Host(`zigbee.${DOMAIN}`)"
       - traefik.http.routers.zigbee2mqtt.entrypoints=websecure
       - traefik.http.routers.zigbee2mqtt.tls=true
+      - traefik.http.routers.zigbee2mqtt.tls.certresolver=letsencrypt
       - traefik.http.services.zigbee2mqtt.loadbalancer.server.port=8080
+      - com.centurylinklabs.watchtower.enable=true
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8080/ || exit 1"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
 
-networks:
-  proxy:
-    external: true
-
-volumes:
-  ha-config:
-  node-red-data:
-  mosquitto-data:
-  mosquitto-logs:
-  zigbee2mqtt-data:
+  # ─── ESPHome — ESP Device Firmware Manager ─────────────────────
+  esphome:
+    image: ghcr.io/esphome/esphome:2024.9.3
+    container_name: esphome
+    restart: unless-stopped
+    networks:
+      - proxy
+      - iot
+    volumes:
+      - esphome-data:/config
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - ESPHOME_DASHBOARD_USE_PING=true
+    # Uncomment for USB flashing
+    # privileged: true
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.esphome.rule=Host(`esphome.${DOMAIN}`)"
+      - traefik.http.routers.esphome.entrypoints=websecure
+      - traefik.http.routers.esphome.tls=true
+      - traefik.http.routers.esphome.tls.certresolver=letsencrypt
+      - traefik.http.services.esphome.loadbalancer.server.port=6052
+      - com.centurylinklabs.watchtower.enable=true
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:6052"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/stacks/home-automation/mosquitto.conf
+++ b/stacks/home-automation/mosquitto.conf
@@ -1,6 +1,0 @@
-listener 1883
-allow_anonymous true
-persistence true
-persistence_location /mosquitto/data/
-log_dest file /mosquitto/log/mosquitto.log
-log_dest stdout


### PR DESCRIPTION
## Home Automation Stack — HA + Node-RED + Mosquitto + Zigbee2MQTT + ESPHome

Closes #7

### Changes

**docker-compose.yml** — Complete rewrite with 5 services:

| Service | Image | Purpose |
|---------|-------|---------|
| Home Assistant | `home-assistant:2024.9.3` | Smart home hub (host network) |
| Node-RED | `node-red:4.0.3` | Visual flow automation |
| Mosquitto | `eclipse-mosquitto:2.0.19` | MQTT broker (secured) |
| Zigbee2MQTT | `zigbee2mqtt:1.40.2` | Zigbee device gateway |
| ESPHome | `esphome:2024.9.3` | ESP firmware manager |

### Key Improvements

- **Home Assistant**: `network_mode: host` for mDNS/UPnP device discovery (bridge mode alternative documented in README)
- **Mosquitto secured**: `allow_anonymous false`, password file auth, structured config directory
- **ESPHome added**: ESP32/ESP8266 device firmware OTA management
- **Zigbee2MQTT**: USB adapter mapping, udev access, MQTT auth
- **Node-RED**: credential encryption, HA + MQTT integration guide
- **Comprehensive README**: network mode explanation, MQTT user setup, Zigbee adapter config, troubleshooting
