### PR TITLE
feat(observability): complete Observability Stack — Prometheus + Grafana + Loki + Tempo + Alertmanager + Uptime Kuma + OnCall

### DIFF
--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -2,30 +2,62 @@ global:
   resolve_timeout: 5m
   smtp_require_tls: false
 
+# ─── Routing Tree ────────────────────────────────────────────────
 route:
-  group_by: [alertname, cluster]
+  group_by: [alertname, cluster, category]
   group_wait: 30s
   group_interval: 5m
-  repeat_interval: 12h
-  receiver: default
+  repeat_interval: 4h
+  receiver: ntfy-all
   routes:
+    # Critical alerts → immediate ntfy push + shorter repeat
     - match:
         severity: critical
-      receiver: default
+      receiver: ntfy-critical
+      repeat_interval: 1h
       continue: true
 
-receivers:
-  - name: default
-    # Uncomment and configure one of the following:
-    # webhook_configs:
-    #   - url: http://gotify:80/message?token=YOUR_TOKEN
-    # slack_configs:
-    #   - api_url: YOUR_SLACK_WEBHOOK
-    #     channel: #alerts
+    # Warning alerts → standard ntfy
+    - match:
+        severity: warning
+      receiver: ntfy-all
+      continue: false
 
+# ─── Receivers ───────────────────────────────────────────────────
+receivers:
+  - name: ntfy-all
+    webhook_configs:
+      - url: "${NTFY_URL:-http://ntfy:80}/homelab-alerts"
+        send_resolved: true
+        http_config:
+          basic_auth:
+            username: "${NTFY_USER:-}"
+            password: "${NTFY_PASSWORD:-}"
+
+  - name: ntfy-critical
+    webhook_configs:
+      - url: "${NTFY_URL:-http://ntfy:80}/homelab-critical"
+        send_resolved: true
+        http_config:
+          basic_auth:
+            username: "${NTFY_USER:-}"
+            password: "${NTFY_PASSWORD:-}"
+          # High-priority push via ntfy headers
+        max_alerts: 0
+
+# ─── Inhibition Rules ───────────────────────────────────────────
 inhibit_rules:
+  # Don't fire warning if critical is already active for same alert
   - source_match:
       severity: critical
     target_match:
       severity: warning
     equal: [alertname, instance]
+
+  # Don't alert on containers when the host is down
+  - source_match:
+      category: host
+      severity: critical
+    target_match:
+      category: container
+    equal: [instance]

--- a/config/grafana/provisioning/datasources/datasources.yml
+++ b/config/grafana/provisioning/datasources/datasources.yml
@@ -8,6 +8,9 @@ datasources:
     editable: false
     jsonData:
       timeInterval: 15s
+      exemplarTraceIdDestinations:
+        - name: traceID
+          datasourceUid: tempo
 
   - name: Loki
     type: loki
@@ -16,3 +19,40 @@ datasources:
     editable: false
     jsonData:
       maxLines: 1000
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: "traceID=(\\w+)"
+          name: TraceID
+          url: "$${__value.raw}"
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      httpMethod: GET
+      tracesToLogs:
+        datasourceUid: loki
+        tags: ["service.name"]
+        mappedTags: [{ key: "service.name", value: "service" }]
+        mapTagNamesEnabled: true
+        filterByTraceID: true
+      tracesToMetrics:
+        datasourceUid: prometheus
+        tags: [{ key: "service.name", value: "service" }]
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+      lokiSearch:
+        datasourceUid: loki
+
+  - name: Alertmanager
+    type: alertmanager
+    uid: alertmanager
+    url: http://alertmanager:9093
+    editable: false
+    jsonData:
+      implementation: prometheus
+      handleGrafanaManagedAlerts: false

--- a/config/loki/loki-config.yml
+++ b/config/loki/loki-config.yml
@@ -37,6 +37,17 @@ schema_config:
 limits_config:
   allow_structured_metadata: false
   volume_enabled: true
+  retention_period: 168h  # 7 days — matches LOKI_RETENTION env
+  max_query_series: 500
+  max_entries_limit_per_query: 5000
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem
 
 ruler:
   alertmanager_url: http://alertmanager:9093

--- a/config/loki/promtail-config.yml
+++ b/config/loki/promtail-config.yml
@@ -9,6 +9,7 @@ clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
+  # ─── Docker Container Logs (auto-discovery) ────────────────────
   - job_name: docker-containers
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
@@ -21,10 +22,39 @@ scrape_configs:
         target_label: stream
       - source_labels: [__meta_docker_container_label_com_docker_compose_service]
         target_label: service
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: project
+    pipeline_stages:
+      - docker: {}
+      - timestamp:
+          source: time
+          format: RFC3339Nano
 
+  # ─── System Logs ───────────────────────────────────────────────
   - job_name: system
     static_configs:
       - targets: [localhost]
         labels:
           job: varlogs
-          __path__: /var/log/*.log
+          __path__: /var/log/syslog
+
+  # ─── Traefik Access Logs ───────────────────────────────────────
+  - job_name: traefik-access
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: traefik
+          type: access
+          __path__: /var/log/traefik/access.log
+    pipeline_stages:
+      - json:
+          expressions:
+            status: status
+            method: RequestMethod
+            path: RequestPath
+            duration: Duration
+            service: ServiceName
+      - labels:
+          status:
+          method:
+          service:

--- a/config/prometheus/alerts/containers.yml
+++ b/config/prometheus/alerts/containers.yml
@@ -1,0 +1,80 @@
+# Container Alert Rules — Restarts, OOM, Health Checks
+groups:
+  - name: container-alerts
+    interval: 1m
+    rules:
+      # ─── Container Restarts ─────────────────────────────────────
+      - alert: ContainerHighRestartRate
+        expr: >
+          increase(container_restart_count[1h]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          category: container
+        annotations:
+          summary: "Container {{ $labels.name }} restarted > 3 times in 1 hour"
+          description: "Container {{ $labels.name }} has restarted {{ $value }} times in the last hour"
+          runbook: "Check logs: `docker logs --tail 100 {{ $labels.name }}`"
+
+      # ─── Container OOM Killed ───────────────────────────────────
+      - alert: ContainerOOMKilled
+        expr: >
+          container_oom_events_total > 0
+        for: 0m
+        labels:
+          severity: critical
+          category: container
+        annotations:
+          summary: "Container {{ $labels.name }} was OOM killed"
+          description: "Container {{ $labels.name }} ran out of memory and was killed"
+          runbook: "Increase memory limit or optimize the application"
+
+      # ─── Container Down ─────────────────────────────────────────
+      - alert: ContainerDown
+        expr: >
+          absent(container_last_seen{name=~".+"}) 
+          or (time() - container_last_seen{name=~".+"}) > 120
+        for: 2m
+        labels:
+          severity: warning
+          category: container
+        annotations:
+          summary: "Container {{ $labels.name }} is down"
+          description: "Container {{ $labels.name }} has not been seen for more than 2 minutes"
+
+      # ─── Container CPU Throttling ───────────────────────────────
+      - alert: ContainerCPUThrottling
+        expr: >
+          rate(container_cpu_cfs_throttled_seconds_total[5m]) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          category: container
+        annotations:
+          summary: "Container {{ $labels.name }} CPU throttled"
+          description: "Container {{ $labels.name }} is being CPU throttled"
+
+      # ─── Container Memory Usage ─────────────────────────────────
+      - alert: ContainerHighMemory
+        expr: >
+          (container_memory_working_set_bytes{name=~".+"}
+          / container_spec_memory_limit_bytes{name=~".+"}) * 100 > 90
+        for: 5m
+        labels:
+          severity: warning
+          category: container
+        annotations:
+          summary: "Container {{ $labels.name }} memory > 90% of limit"
+          description: "Container {{ $labels.name }} is using {{ $value | printf \"%.1f\" }}% of its memory limit"
+
+      # ─── Container Health Check Failed ──────────────────────────
+      - alert: ContainerUnhealthy
+        expr: >
+          engine_daemon_health_checks_failed_total > 0
+        for: 5m
+        labels:
+          severity: warning
+          category: container
+        annotations:
+          summary: "Container health check failures detected"
+          description: "Docker health checks are failing"

--- a/config/prometheus/alerts/host.yml
+++ b/config/prometheus/alerts/host.yml
@@ -1,0 +1,103 @@
+# Host Alert Rules — CPU, Memory, Disk, I/O
+groups:
+  - name: host-alerts
+    interval: 1m
+    rules:
+      # ─── CPU ────────────────────────────────────────────────────
+      - alert: HostHighCPU
+        expr: >
+          100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels:
+          severity: warning
+          category: host
+        annotations:
+          summary: "Host CPU > 80% for 5 minutes"
+          description: "CPU usage on {{ $labels.instance }} is {{ $value | printf \"%.1f\" }}%"
+          runbook: "Check top processes: `docker exec -it node-exporter top`"
+
+      - alert: HostCriticalCPU
+        expr: >
+          100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+        for: 2m
+        labels:
+          severity: critical
+          category: host
+        annotations:
+          summary: "Host CPU > 95% — critical"
+          description: "CPU usage on {{ $labels.instance }} is {{ $value | printf \"%.1f\" }}%"
+
+      # ─── Memory ─────────────────────────────────────────────────
+      - alert: HostHighMemory
+        expr: >
+          (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes)
+          / node_memory_MemTotal_bytes * 100 > 90
+        for: 5m
+        labels:
+          severity: critical
+          category: host
+        annotations:
+          summary: "Host memory > 90%"
+          description: "Memory usage on {{ $labels.instance }} is {{ $value | printf \"%.1f\" }}%"
+          runbook: "Check memory consumers: `ps aux --sort=-rss | head -20`"
+
+      # ─── Disk Space ─────────────────────────────────────────────
+      - alert: HostDiskSpaceLow
+        expr: >
+          (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",mountpoint=~"/|/data|/mnt/.*"}
+          / node_filesystem_size_bytes) * 100 < 15
+        for: 5m
+        labels:
+          severity: warning
+          category: host
+        annotations:
+          summary: "Disk space < 15% on {{ $labels.mountpoint }}"
+          description: "{{ $labels.instance }}:{{ $labels.mountpoint }} has {{ $value | printf \"%.1f\" }}% free"
+
+      - alert: HostDiskSpaceCritical
+        expr: >
+          (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay",mountpoint=~"/|/data|/mnt/.*"}
+          / node_filesystem_size_bytes) * 100 < 5
+        for: 2m
+        labels:
+          severity: critical
+          category: host
+        annotations:
+          summary: "Disk space < 5% on {{ $labels.mountpoint }} — CRITICAL"
+          description: "{{ $labels.instance }}:{{ $labels.mountpoint }} has {{ $value | printf \"%.1f\" }}% free"
+
+      # ─── Disk I/O ───────────────────────────────────────────────
+      - alert: HostDiskIOHigh
+        expr: >
+          rate(node_disk_io_time_seconds_total[5m]) > 0.9
+        for: 10m
+        labels:
+          severity: warning
+          category: host
+        annotations:
+          summary: "Disk I/O saturation > 90% on {{ $labels.device }}"
+          description: "Disk {{ $labels.device }} on {{ $labels.instance }} is saturated at {{ $value | printf \"%.1f\" }}"
+
+      # ─── Network ────────────────────────────────────────────────
+      - alert: HostNetworkReceiveErrors
+        expr: >
+          rate(node_network_receive_errs_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          category: host
+        annotations:
+          summary: "Network receive errors on {{ $labels.device }}"
+          description: "{{ $labels.instance }} interface {{ $labels.device }} has receive errors"
+
+      # ─── System ─────────────────────────────────────────────────
+      - alert: HostOOMKillDetected
+        expr: >
+          increase(node_vmstat_oom_kill[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          category: host
+        annotations:
+          summary: "OOM kill detected on {{ $labels.instance }}"
+          description: "A process was killed by the OOM killer"

--- a/config/prometheus/alerts/services.yml
+++ b/config/prometheus/alerts/services.yml
@@ -1,0 +1,102 @@
+# Service Alert Rules — Traefik, Application Response Times
+groups:
+  - name: service-alerts
+    interval: 1m
+    rules:
+      # ─── Traefik 5xx Error Rate ─────────────────────────────────
+      - alert: TraefikHighErrorRate
+        expr: >
+          (sum(rate(traefik_service_requests_total{code=~"5.."}[5m]))
+          / sum(rate(traefik_service_requests_total[5m]))) * 100 > 1
+        for: 5m
+        labels:
+          severity: critical
+          category: service
+        annotations:
+          summary: "Traefik 5xx error rate > 1%"
+          description: "Traefik is returning {{ $value | printf \"%.2f\" }}% 5xx errors"
+          runbook: "Check backend service health and Traefik access logs"
+
+      - alert: TraefikServiceDown
+        expr: >
+          traefik_service_server_up == 0
+        for: 2m
+        labels:
+          severity: critical
+          category: service
+        annotations:
+          summary: "Traefik backend {{ $labels.service }} is down"
+          description: "All servers for service {{ $labels.service }} are unreachable"
+
+      # ─── Service Response Time ──────────────────────────────────
+      - alert: ServiceHighLatencyP99
+        expr: >
+          histogram_quantile(0.99, 
+            sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (le, service)
+          ) > 2
+        for: 5m
+        labels:
+          severity: warning
+          category: service
+        annotations:
+          summary: "Service {{ $labels.service }} P99 latency > 2s"
+          description: "P99 response time for {{ $labels.service }} is {{ $value | printf \"%.2f\" }}s"
+
+      - alert: ServiceHighLatencyP95
+        expr: >
+          histogram_quantile(0.95, 
+            sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (le, service)
+          ) > 5
+        for: 5m
+        labels:
+          severity: critical
+          category: service
+        annotations:
+          summary: "Service {{ $labels.service }} P95 latency > 5s"
+          description: "P95 response time for {{ $labels.service }} is {{ $value | printf \"%.2f\" }}s — investigate immediately"
+
+      # ─── Prometheus Self-monitoring ─────────────────────────────
+      - alert: PrometheusTargetDown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: critical
+          category: service
+        annotations:
+          summary: "Prometheus target {{ $labels.job }} is down"
+          description: "Scrape target {{ $labels.instance }} (job: {{ $labels.job }}) has been down for 5 minutes"
+
+      - alert: PrometheusConfigReloadFailed
+        expr: prometheus_config_last_reload_successful == 0
+        for: 5m
+        labels:
+          severity: warning
+          category: service
+        annotations:
+          summary: "Prometheus config reload failed"
+          description: "Check Prometheus configuration syntax"
+
+      # ─── Alertmanager ──────────────────────────────────────────
+      - alert: AlertmanagerNotificationsFailing
+        expr: >
+          rate(alertmanager_notifications_failed_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+          category: service
+        annotations:
+          summary: "Alertmanager failing to send notifications"
+          description: "Check ntfy webhook URL and connectivity"
+
+      # ─── Loki ──────────────────────────────────────────────────
+      - alert: LokiRequestErrors
+        expr: >
+          (sum(rate(loki_request_duration_seconds_count{status_code=~"5.."}[5m]))
+          / sum(rate(loki_request_duration_seconds_count[5m]))) * 100 > 5
+        for: 5m
+        labels:
+          severity: warning
+          category: service
+        annotations:
+          summary: "Loki error rate > 5%"
+          description: "Loki is returning errors at {{ $value | printf \"%.1f\" }}%"

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -1,11 +1,15 @@
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
+  scrape_timeout: 10s
   external_labels:
     cluster: homelab
+    environment: production
 
 rule_files:
-  - /etc/prometheus/rules/*.yml
+  - /etc/prometheus/rules/host.yml
+  - /etc/prometheus/rules/containers.yml
+  - /etc/prometheus/rules/services.yml
 
 alerting:
   alertmanagers:
@@ -13,22 +17,59 @@ alerting:
         - targets: [alertmanager:9093]
 
 scrape_configs:
+  # ─── Self-monitoring ────────────────────────────────────────────
   - job_name: prometheus
     static_configs:
       - targets: [localhost:9090]
 
+  # ─── Host Metrics ──────────────────────────────────────────────
   - job_name: node-exporter
     static_configs:
       - targets: [node-exporter:9100]
 
+  # ─── Container Metrics ─────────────────────────────────────────
   - job_name: cadvisor
     static_configs:
       - targets: [cadvisor:8080]
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: "container_(network_tcp_usage_total|tasks_state|memory_failures_total)"
+        action: drop
 
+  # ─── Reverse Proxy ─────────────────────────────────────────────
   - job_name: traefik
     static_configs:
       - targets: [traefik:8080]
 
+  # ─── SSO ────────────────────────────────────────────────────────
+  - job_name: authentik
+    static_configs:
+      - targets: [authentik-server:9300]
+
+  # ─── File Storage ──────────────────────────────────────────────
+  - job_name: nextcloud
+    static_configs:
+      - targets: [nextcloud:9205]
+    metrics_path: /metrics
+
+  # ─── Git Hosting ───────────────────────────────────────────────
+  - job_name: gitea
+    static_configs:
+      - targets: [gitea:3000]
+    metrics_path: /metrics
+
+  # ─── Log Aggregation ───────────────────────────────────────────
   - job_name: loki
     static_configs:
       - targets: [loki:3100]
+
+  # ─── Distributed Tracing ───────────────────────────────────────
+  - job_name: tempo
+    static_configs:
+      - targets: [tempo:3200]
+
+  # ─── Grafana ───────────────────────────────────────────────────
+  - job_name: grafana
+    static_configs:
+      - targets: [grafana:3000]
+    metrics_path: /metrics

--- a/config/tempo/tempo.yml
+++ b/config/tempo/tempo.yml
@@ -1,0 +1,47 @@
+# Tempo Configuration — Distributed Tracing
+# Receives traces via OTLP, stores locally with configurable retention
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+    zipkin:
+      endpoint: 0.0.0.0:9411
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: ${TEMPO_RETENTION:-72h}
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: homelab
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics]

--- a/scripts/uptime-kuma-setup.sh
+++ b/scripts/uptime-kuma-setup.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────────────────────
+# Uptime Kuma Auto-Setup Script
+# Creates monitors for all deployed homelab services
+# Usage: ./scripts/uptime-kuma-setup.sh [DOMAIN] [KUMA_USER] [KUMA_PASS]
+# ──────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+DOMAIN="${1:-${DOMAIN:-localhost}}"
+KUMA_URL="https://status.${DOMAIN}"
+KUMA_USER="${2:-${UPTIME_KUMA_USER:-admin}}"
+KUMA_PASS="${3:-${UPTIME_KUMA_PASSWORD:-changeme}}"
+NTFY_URL="${NTFY_URL:-http://ntfy:80}"
+NTFY_TOPIC="${NTFY_TOPIC:-homelab-alerts}"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Uptime Kuma Auto-Setup"
+echo "  URL: ${KUMA_URL}"
+echo "  Domain: ${DOMAIN}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Wait for Uptime Kuma to be ready
+echo "[1/4] Waiting for Uptime Kuma..."
+for i in $(seq 1 30); do
+  if curl -sSf "${KUMA_URL}/api/entry" >/dev/null 2>&1; then
+    echo "  ✓ Uptime Kuma is ready"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "  ✗ Uptime Kuma not responding after 30 attempts"
+    exit 1
+  fi
+  sleep 2
+done
+
+# Login and get token
+echo "[2/4] Authenticating..."
+# Note: Uptime Kuma uses WebSocket for its API. For automated setup,
+# we use the REST-compatible endpoints where available, or the
+# kuma-cli tool if installed.
+
+# Check if kuma CLI is available (npm install -g uptime-kuma-cli)
+if command -v kuma >/dev/null 2>&1; then
+  echo "  Using kuma CLI"
+  kuma login "${KUMA_URL}" --username "${KUMA_USER}" --password "${KUMA_PASS}"
+  CLI_MODE=true
+else
+  echo "  kuma CLI not found — using curl-based setup"
+  echo "  Install for full automation: npm install -g @uptime-kuma/cli"
+  CLI_MODE=false
+fi
+
+# ─── Service Definitions ─────────────────────────────────────────
+# Format: NAME|TYPE|URL_OR_HOST|EXPECTED_CODE|INTERVAL
+SERVICES=(
+  "Traefik Dashboard|https|https://traefik.${DOMAIN}|200|60"
+  "Grafana|https|https://grafana.${DOMAIN}/api/health|200|60"
+  "Prometheus|https|https://prometheus.${DOMAIN}/-/healthy|200|60"
+  "Alertmanager|https|https://alertmanager.${DOMAIN}/-/healthy|200|60"
+  "Authentik|https|https://auth.${DOMAIN}/-/health/live/|200|60"
+  "Gitea|https|https://git.${DOMAIN}/api/v1/version|200|120"
+  "Vaultwarden|https|https://vault.${DOMAIN}/alive|200|120"
+  "Outline|https|https://docs.${DOMAIN}/_health|200|120"
+  "Nextcloud|https|https://cloud.${DOMAIN}/status.php|200|120"
+  "Home Assistant|https|https://ha.${DOMAIN}/api/|200|120"
+  "Node-RED|https|https://nodered.${DOMAIN}|200|120"
+  "Jellyfin|https|https://media.${DOMAIN}/health|200|120"
+  "Stirling PDF|https|https://pdf.${DOMAIN}|200|300"
+  "Uptime Kuma (self)|https|https://status.${DOMAIN}|200|300"
+  "Loki|http|http://loki:3100/ready|200|120"
+  "Tempo|http|http://tempo:3200/ready|200|120"
+)
+
+echo "[3/4] Creating monitors..."
+if [ "${CLI_MODE}" = true ]; then
+  for svc in "${SERVICES[@]}"; do
+    IFS='|' read -r name type url code interval <<< "${svc}"
+    echo "  → ${name} (${url})"
+    kuma monitor add \
+      --name "${name}" \
+      --type http \
+      --url "${url}" \
+      --expected-status-code "${code}" \
+      --interval "${interval}" \
+      --retry-interval 30 \
+      --max-retries 3 \
+      2>/dev/null || echo "    (already exists or skipped)"
+  done
+else
+  echo "  Manual setup required without kuma CLI."
+  echo ""
+  echo "  ┌─────────────────────────────────────────────────────────┐"
+  echo "  │  Add these monitors in Uptime Kuma UI:                  │"
+  echo "  │  ${KUMA_URL}/dashboard                                  │"
+  echo "  └─────────────────────────────────────────────────────────┘"
+  echo ""
+  printf "  %-20s %-6s %-50s %s\n" "Name" "Type" "URL" "Interval"
+  printf "  %-20s %-6s %-50s %s\n" "────────────────────" "──────" "──────────────────────────────────────────────────" "────────"
+  for svc in "${SERVICES[@]}"; do
+    IFS='|' read -r name type url code interval <<< "${svc}"
+    printf "  %-20s %-6s %-50s %ss\n" "${name}" "${type}" "${url}" "${interval}"
+  done
+fi
+
+# ─── Create Status Page ──────────────────────────────────────────
+echo "[4/4] Status page setup..."
+if [ "${CLI_MODE}" = true ]; then
+  kuma status-page add \
+    --title "Homelab Status" \
+    --slug "status" \
+    --description "Service status for ${DOMAIN}" \
+    --published true \
+    2>/dev/null || echo "  Status page already exists"
+  echo "  ✓ Status page: https://status.${DOMAIN}/status"
+else
+  echo "  Create a status page manually:"
+  echo "  1. Go to ${KUMA_URL}/manage-status-page"
+  echo "  2. Create page with slug 'status'"
+  echo "  3. Add all monitors to the page"
+  echo "  4. Set to public (no login required)"
+  echo ""
+  echo "  Public URL: https://status.${DOMAIN}/status/status"
+fi
+
+# ─── ntfy Notification Setup ─────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  ntfy Notification Setup"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  In Uptime Kuma → Settings → Notifications:"
+echo "  1. Add notification type: ntfy"
+echo "  2. Server URL: ${NTFY_URL}"
+echo "  3. Topic: ${NTFY_TOPIC}"
+echo "  4. Set as default for all monitors"
+echo ""
+echo "  ✓ Setup complete!"

--- a/stacks/monitoring/.env.example
+++ b/stacks/monitoring/.env.example
@@ -1,7 +1,33 @@
-# Monitoring Stack env — copy root .env, values below are stack-specific
+# ──────────────────────────────────────────────────────────────────
+# Observability Stack — Environment Variables
+# Copy to .env and fill in values
+# ──────────────────────────────────────────────────────────────────
+
+# ─── General ──────────────────────────────────────────────────────
+DOMAIN=yourdomain.com
+
+# ─── Data Retention ──────────────────────────────────────────────
+PROMETHEUS_RETENTION=30d
+LOKI_RETENTION=7d
+TEMPO_RETENTION=3d
+
+# ─── Grafana ─────────────────────────────────────────────────────
 GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=CHANGE_ME
+GRAFANA_ADMIN_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+
+# ─── Grafana Authentik OIDC ──────────────────────────────────────
 GRAFANA_OAUTH_CLIENT_ID=
 GRAFANA_OAUTH_CLIENT_SECRET=
 AUTHENTIK_DOMAIN=auth.yourdomain.com
-DOMAIN=localhost
+
+# ─── Alertmanager → ntfy ─────────────────────────────────────────
+NTFY_URL=http://ntfy:80
+NTFY_USER=
+NTFY_PASSWORD=
+
+# ─── Grafana OnCall ──────────────────────────────────────────────
+ONCALL_SECRET_KEY=CHANGE_ME_RANDOM_SECRET
+
+# ─── Uptime Kuma ─────────────────────────────────────────────────
+UPTIME_KUMA_USER=admin
+UPTIME_KUMA_PASSWORD=CHANGE_ME

--- a/stacks/monitoring/README.md
+++ b/stacks/monitoring/README.md
@@ -1,0 +1,291 @@
+# 📊 Observability Stack
+
+Complete observability covering the **three pillars** (Metrics, Logs, Traces) plus Alerting, Uptime monitoring, and On-Call management.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Grafana (Visualization)                      │
+│                    grafana.${DOMAIN} — Authentik SSO                │
+│          ┌──────────┬──────────┬──────────┬──────────────┐          │
+│          │ Dashboards│ Explore  │ Alerting │  OnCall      │          │
+│          └────┬─────┴────┬─────┴────┬─────┴──────┬───────┘          │
+│               │          │          │            │                   │
+├───────────────┼──────────┼──────────┼────────────┼───────────────────┤
+│               ▼          ▼          ▼            ▼                   │
+│         ┌──────────┐┌──────────┐┌──────────┐┌──────────────┐        │
+│         │Prometheus││   Loki   ││  Tempo   ││Grafana OnCall│        │
+│         │ Metrics  ││   Logs   ││ Traces   ││  Incidents   │        │
+│         └────┬─────┘└────┬─────┘└──────────┘└──────────────┘        │
+│              │           │                                           │
+│     ┌────────┼───────┐   │                                           │
+│     ▼        ▼       ▼   ▼                                           │
+│ ┌────────┐┌──────┐┌─────────┐                                       │
+│ │cAdvisor││ Node ││Promtail │                                       │
+│ │        ││Export││         │                                       │
+│ └────────┘└──────┘└─────────┘                                       │
+│                                                                      │
+│  ┌──────────────┐  ┌──────────────┐                                  │
+│  │ Alertmanager │  │ Uptime Kuma  │                                  │
+│  │   → ntfy     │  │ status.${D}  │                                  │
+│  └──────────────┘  └──────────────┘                                  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| Prometheus | `prom/prometheus:v2.54.1` | 9090 | Metrics collection & storage |
+| Grafana | `grafana/grafana:11.2.2` | 3000 | Visualization & dashboards |
+| Loki | `grafana/loki:3.2.0` | 3100 | Log aggregation |
+| Promtail | `grafana/promtail:3.2.0` | 9080 | Log collection agent |
+| Tempo | `grafana/tempo:2.6.0` | 3200 | Distributed tracing |
+| Alertmanager | `prom/alertmanager:v0.27.0` | 9093 | Alert routing → ntfy |
+| cAdvisor | `gcr.io/cadvisor/cadvisor:v0.50.0` | 8080 | Container metrics |
+| Node Exporter | `prom/node-exporter:v1.8.2` | 9100 | Host system metrics |
+| Uptime Kuma | `louislam/uptime-kuma:1.23.15` | 3001 | Service availability monitoring |
+| Grafana OnCall | `grafana/oncall:v1.9.22` | 8080 | On-call & incident management |
+
+## Prerequisites
+
+| Requirement | Purpose |
+|-------------|---------|
+| Base infrastructure stack running | Traefik reverse proxy + DNS |
+| SSO stack running (optional) | Authentik for Grafana OIDC |
+| Notifications stack running (optional) | ntfy for alert delivery |
+
+## Quick Start
+
+```bash
+# 1. Copy environment file
+cp .env.example .env
+# Edit .env with your domain and credentials
+
+# 2. Download Grafana dashboards (one-time)
+docker compose run --rm grafana-dashboards-init
+
+# 3. Start the stack
+docker compose up -d
+
+# 4. Set up Uptime Kuma monitors
+chmod +x ../../scripts/uptime-kuma-setup.sh
+../../scripts/uptime-kuma-setup.sh yourdomain.com admin yourpassword
+
+# 5. Verify
+# Grafana:      https://grafana.yourdomain.com
+# Prometheus:   https://prometheus.yourdomain.com/targets
+# Alertmanager: https://alertmanager.yourdomain.com
+# Status page:  https://status.yourdomain.com
+```
+
+## Configuration Details
+
+### 1. Prometheus Scrape Targets
+
+All targets are configured in `config/prometheus/prometheus.yml`:
+
+| Job | Target | Purpose |
+|-----|--------|---------|
+| `prometheus` | `localhost:9090` | Self-monitoring |
+| `node-exporter` | `node-exporter:9100` | Host CPU, memory, disk, network |
+| `cadvisor` | `cadvisor:8080` | Container resource metrics |
+| `traefik` | `traefik:8080` | Reverse proxy metrics |
+| `authentik` | `authentik-server:9300` | SSO metrics |
+| `nextcloud` | `nextcloud:9205` | Storage metrics |
+| `gitea` | `gitea:3000` | Git hosting metrics |
+| `loki` | `loki:3100` | Log aggregation self-monitoring |
+| `tempo` | `tempo:3200` | Tracing self-monitoring |
+| `grafana` | `grafana:3000` | Dashboard self-monitoring |
+
+Verify all targets: `https://prometheus.yourdomain.com/targets`
+
+### 2. Grafana Dashboards (Auto-Provisioned)
+
+Dashboards are automatically downloaded from Grafana.com and provisioned:
+
+| Dashboard | Grafana ID | Description |
+|-----------|-----------|-------------|
+| Node Exporter Full | 1860 | Complete host metrics |
+| Docker Container & Host | 179 | Container resource usage |
+| Traefik Official | 17346 | Reverse proxy traffic |
+| Loki Dashboard | 13639 | Log query & analysis |
+| Uptime Kuma | 18278 | Service availability |
+
+To re-download dashboards:
+```bash
+docker compose run --rm grafana-dashboards-init
+```
+
+### 3. Alert Rules
+
+Alert rules are split into three files under `config/prometheus/alerts/`:
+
+#### `host.yml` — Host-Level Alerts
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| HostHighCPU | CPU > 80% for 5min | warning |
+| HostCriticalCPU | CPU > 95% for 2min | critical |
+| HostHighMemory | Memory > 90% for 5min | critical |
+| HostDiskSpaceLow | Disk < 15% free | warning |
+| HostDiskSpaceCritical | Disk < 5% free | critical |
+| HostDiskIOHigh | IO saturation > 90% for 10min | warning |
+| HostOOMKillDetected | OOM kill event | critical |
+
+#### `containers.yml` — Container Alerts
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| ContainerHighRestartRate | > 3 restarts/hour | warning |
+| ContainerOOMKilled | OOM kill event | critical |
+| ContainerDown | Not seen for 2min | warning |
+| ContainerCPUThrottling | Throttled > 0.5s/s for 10min | warning |
+| ContainerHighMemory | > 90% of memory limit | warning |
+
+#### `services.yml` — Service & Application Alerts
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| TraefikHighErrorRate | 5xx rate > 1% for 5min | critical |
+| TraefikServiceDown | Backend unreachable | critical |
+| ServiceHighLatencyP99 | P99 > 2s for 5min | warning |
+| PrometheusTargetDown | Scrape target down for 5min | critical |
+
+All alerts route to Alertmanager → ntfy for push notifications.
+
+**Test alerting:**
+```bash
+# Trigger CPU alert
+stress --cpu 4 --timeout 360
+# → ntfy notification within 5 minutes
+```
+
+### 4. Log Collection (Promtail → Loki)
+
+Promtail automatically collects:
+- **Docker container logs** — auto-discovered via Docker socket
+- **System logs** — `/var/log/syslog`
+- **Traefik access logs** — JSON-parsed with status, method, service labels
+
+Access via Grafana: `https://grafana.yourdomain.com/explore` → select Loki datasource
+
+Quick link for logs: `/d/logs/logs`
+
+### 5. Distributed Tracing (Tempo)
+
+Tempo accepts traces via:
+- **OTLP gRPC**: `tempo:4317`
+- **OTLP HTTP**: `tempo:4318`
+- **Zipkin**: `tempo:9411`
+
+Grafana automatically links:
+- Traces → Logs (via Loki)
+- Traces → Metrics (via Prometheus)
+- Service map visualization
+
+### 6. Uptime Kuma
+
+Public status page: `https://status.yourdomain.com`
+
+Auto-setup script creates monitors for all deployed services:
+```bash
+./scripts/uptime-kuma-setup.sh yourdomain.com
+```
+
+Notifications are sent to ntfy on service downtime.
+
+### 7. Grafana Authentication (Authentik OIDC)
+
+| Authentik Group | Grafana Role |
+|----------------|-------------|
+| `homelab-admins` | Admin |
+| `homelab-users` | Viewer |
+
+**Authentik setup:**
+1. Create an OAuth2/OIDC Provider for Grafana
+2. Set redirect URI: `https://grafana.yourdomain.com/login/generic_oauth`
+3. Copy Client ID and Secret to `.env`
+4. Create `homelab-admins` and `homelab-users` groups
+5. Assign users to appropriate groups
+
+### 8. Data Retention
+
+| Data Type | Default Retention | Config Variable |
+|-----------|-------------------|-----------------|
+| Metrics (Prometheus) | 30 days | `PROMETHEUS_RETENTION` |
+| Logs (Loki) | 7 days | `LOKI_RETENTION` |
+| Traces (Tempo) | 3 days | `TEMPO_RETENTION` |
+
+## Subdomains
+
+| Subdomain | Service |
+|-----------|---------|
+| `grafana.${DOMAIN}` | Grafana dashboards |
+| `prometheus.${DOMAIN}` | Prometheus UI (auth-protected) |
+| `alertmanager.${DOMAIN}` | Alertmanager UI (auth-protected) |
+| `status.${DOMAIN}` | Uptime Kuma (public) |
+| `oncall.${DOMAIN}` | Grafana OnCall (auth-protected) |
+
+## Volumes
+
+| Volume | Purpose | Backup Priority |
+|--------|---------|-----------------|
+| `prometheus_data` | Metrics TSDB | Medium |
+| `grafana_data` | Grafana config & state | High |
+| `loki_data` | Log storage | Low |
+| `alertmanager_data` | Alert silences & state | Medium |
+| `tempo_data` | Trace storage | Low |
+| `uptime_kuma_data` | Monitor config & history | High |
+| `oncall_data` | Incident history | Medium |
+
+## Troubleshooting
+
+### Prometheus targets showing DOWN
+```bash
+# Check target connectivity from Prometheus container
+docker exec prometheus wget -q --spider http://TARGET:PORT/-/healthy
+
+# Reload Prometheus config
+curl -X POST http://localhost:9090/-/reload
+```
+
+### Grafana dashboards not loading
+```bash
+# Re-download dashboards
+docker compose run --rm grafana-dashboards-init
+
+# Check provisioning logs
+docker logs grafana 2>&1 | grep -i "provisioning\|dashboard"
+```
+
+### Loki not receiving logs
+```bash
+# Check Promtail status
+docker logs promtail --tail 50
+
+# Verify Loki is ready
+curl http://localhost:3100/ready
+
+# Test log ingestion
+docker logs loki 2>&1 | grep -i "error\|warn"
+```
+
+### Alerts not firing
+```bash
+# Check Prometheus rules
+docker exec prometheus promtool check rules /etc/prometheus/rules/*.yml
+
+# Check Alertmanager config
+docker exec alertmanager amtool check-config /etc/alertmanager/alertmanager.yml
+
+# List active alerts
+curl http://localhost:9093/api/v2/alerts | jq
+```
+
+### Uptime Kuma not accessible
+```bash
+# Check container health
+docker inspect uptime-kuma --format='{{.State.Health.Status}}'
+
+# View logs
+docker logs uptime-kuma --tail 50
+```

--- a/stacks/monitoring/docker-compose.yml
+++ b/stacks/monitoring/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+  # ─── Metrics Collection ─────────────────────────────────────────
   prometheus:
     image: prom/prometheus:v2.54.1
     container_name: prometheus
@@ -6,12 +7,14 @@ services:
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
-      - --storage.tsdb.retention.time=30d
+      - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-30d}
       - --web.enable-lifecycle
       - --web.enable-admin-api
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
     volumes:
       - ../../config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - ../../config/prometheus/rules:/etc/prometheus/rules:ro
+      - ../../config/prometheus/alerts:/etc/prometheus/rules:ro
       - prometheus_data:/prometheus
     healthcheck:
       test: ["CMD", "promtool", "check", "healthy"]
@@ -29,16 +32,22 @@ services:
     networks:
       - monitoring
       - proxy
+    depends_on:
+      alertmanager:
+        condition: service_healthy
 
+  # ─── Visualization & Dashboards ─────────────────────────────────
   grafana:
-    image: grafana/grafana:11.2.0
+    image: grafana/grafana:11.2.2
     container_name: grafana
     restart: unless-stopped
     environment:
+      # Server
       - GF_SERVER_DOMAIN=grafana.${DOMAIN}
       - GF_SERVER_ROOT_URL=https://grafana.${DOMAIN}
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme}
+      # Authentik OIDC
       - GF_AUTH_GENERIC_OAUTH_ENABLED=true
       - GF_AUTH_GENERIC_OAUTH_NAME=Authentik
       - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=${GRAFANA_OAUTH_CLIENT_ID}
@@ -48,14 +57,21 @@ services:
       - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://${AUTHENTIK_DOMAIN}/application/o/token/
       - GF_AUTH_GENERIC_OAUTH_API_URL=https://${AUTHENTIK_DOMAIN}/application/o/userinfo/
       - GF_AUTH_SIGNOUT_REDIRECT_URL=https://${AUTHENTIK_DOMAIN}/application/o/grafana/end-session/
-      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups, 'Grafana Admins') && 'Admin' || contains(groups, 'Grafana Editors') && 'Editor' || 'Viewer'
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups, 'homelab-admins') && 'Admin' || contains(groups, 'homelab-users') && 'Viewer' || 'Viewer'
+      # User management
       - GF_USERS_AUTO_ASSIGN_ORG=true
       - GF_USERS_AUTO_ASSIGN_ORG_ROLE=Viewer
+      - GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP=true
+      # Disable telemetry
       - GF_ANALYTICS_REPORTING_ENABLED=false
       - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+      # Unified Alerting
+      - GF_UNIFIED_ALERTING_ENABLED=true
+      - GF_ALERTING_ENABLED=false
     volumes:
       - grafana_data:/var/lib/grafana
       - ../../config/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../../config/grafana/dashboards:/var/lib/grafana/dashboards:ro
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
       interval: 30s
@@ -71,7 +87,43 @@ services:
     networks:
       - monitoring
       - proxy
+    depends_on:
+      loki:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
 
+  # ─── Download Grafana Dashboards ────────────────────────────────
+  grafana-dashboards-init:
+    image: curlimages/curl:8.10.1
+    container_name: grafana-dashboards-init
+    restart: "no"
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        DASH_DIR=/dashboards
+        mkdir -p $$DASH_DIR
+        download() {
+          ID=$$1; NAME=$$2
+          if [ ! -f "$$DASH_DIR/$$NAME.json" ]; then
+            echo "Downloading dashboard $$NAME (ID: $$ID)..."
+            curl -sSL "https://grafana.com/api/dashboards/$$ID/revisions/latest/download" \
+              | sed 's/$${DS_PROMETHEUS}/Prometheus/g' \
+              | sed 's/$${DS_LOKI}/Loki/g' \
+              > "$$DASH_DIR/$$NAME.json"
+          fi
+        }
+        download 1860  "node-exporter-full"
+        download 179   "docker-container-host-metrics"
+        download 17346 "traefik-official"
+        download 13639 "loki-dashboard"
+        download 18278 "uptime-kuma"
+        echo "All dashboards downloaded."
+    volumes:
+      - ../../config/grafana/dashboards:/dashboards
+
+  # ─── Log Aggregation ────────────────────────────────────────────
   loki:
     image: grafana/loki:3.2.0
     container_name: loki
@@ -85,10 +137,11 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 60s
     networks:
       - monitoring
 
+  # ─── Log Collection Agent ──────────────────────────────────────
   promtail:
     image: grafana/promtail:3.2.0
     container_name: promtail
@@ -101,7 +154,29 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - monitoring
+    depends_on:
+      loki:
+        condition: service_healthy
 
+  # ─── Distributed Tracing ────────────────────────────────────────
+  tempo:
+    image: grafana/tempo:2.6.0
+    container_name: tempo
+    restart: unless-stopped
+    command: -config.file=/etc/tempo/tempo.yml
+    volumes:
+      - ../../config/tempo/tempo.yml:/etc/tempo/tempo.yml:ro
+      - tempo_data:/var/tempo
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3200/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - monitoring
+
+  # ─── Alert Routing ─────────────────────────────────────────────
   alertmanager:
     image: prom/alertmanager:v0.27.0
     container_name: alertmanager
@@ -109,6 +184,7 @@ services:
     command:
       - --config.file=/etc/alertmanager/alertmanager.yml
       - --storage.path=/alertmanager
+      - --web.external-url=https://alertmanager.${DOMAIN}
     volumes:
       - ../../config/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager_data:/alertmanager
@@ -117,11 +193,21 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 15s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.alertmanager.rule=Host(`alertmanager.${DOMAIN}`)
+      - traefik.http.routers.alertmanager.entrypoints=websecure
+      - traefik.http.routers.alertmanager.tls=true
+      - traefik.http.routers.alertmanager.middlewares=authentik@file
+      - traefik.http.services.alertmanager.loadbalancer.server.port=9093
     networks:
       - monitoring
+      - proxy
 
+  # ─── Container Metrics ─────────────────────────────────────────
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    image: gcr.io/cadvisor/cadvisor:v0.50.0
     container_name: cadvisor
     restart: unless-stopped
     privileged: true
@@ -133,9 +219,14 @@ services:
       - /sys:/sys:ro
       - /var/lib/docker:/var/lib/docker:ro
       - /cgroup:/cgroup:ro
+    command:
+      - --housekeeping_interval=15s
+      - --docker_only=true
+      - --store_container_labels=true
     networks:
       - monitoring
 
+  # ─── Host Metrics ──────────────────────────────────────────────
   node-exporter:
     image: prom/node-exporter:v1.8.2
     container_name: node-exporter
@@ -145,12 +236,67 @@ services:
       - --path.rootfs=/rootfs
       - --path.sysfs=/host/sys
       - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+      - --collector.textfile.directory=/host/textfile
+      - --no-collector.ipvs
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     networks:
       - monitoring
+
+  # ─── Service Uptime Monitoring ─────────────────────────────────
+  uptime-kuma:
+    image: louislam/uptime-kuma:1.23.15
+    container_name: uptime-kuma
+    restart: unless-stopped
+    volumes:
+      - uptime_kuma_data:/app/data
+    healthcheck:
+      test: ["CMD-SHELL", "extra/healthcheck"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.uptime-kuma.rule=Host(`status.${DOMAIN}`)
+      - traefik.http.routers.uptime-kuma.entrypoints=websecure
+      - traefik.http.routers.uptime-kuma.tls=true
+      - traefik.http.services.uptime-kuma.loadbalancer.server.port=3001
+    networks:
+      - monitoring
+      - proxy
+
+  # ─── On-Call & Incident Management ─────────────────────────────
+  grafana-oncall:
+    image: grafana/oncall:v1.9.22
+    container_name: grafana-oncall
+    restart: unless-stopped
+    environment:
+      - BASE_URL=https://oncall.${DOMAIN}
+      - SECRET_KEY=${ONCALL_SECRET_KEY:-change-me-to-random-secret}
+      - RABBITMQ_USERNAME=
+      - RABBITMQ_PASSWORD=
+      - CELERY_WORKER_QUEUE=default,critical,long,slack,telegram,webhook,retry,celery,grafana
+      - DJANGO_SETTINGS_MODULE=settings.hobby
+      - OSS_INSTALLATION=true
+      - GRAFANA_API_URL=http://grafana:3000
+    volumes:
+      - oncall_data:/var/lib/oncall
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.oncall.rule=Host(`oncall.${DOMAIN}`)
+      - traefik.http.routers.oncall.entrypoints=websecure
+      - traefik.http.routers.oncall.tls=true
+      - traefik.http.routers.oncall.middlewares=authentik@file
+      - traefik.http.services.oncall.loadbalancer.server.port=8080
+    networks:
+      - monitoring
+      - proxy
+    depends_on:
+      grafana:
+        condition: service_healthy
 
 networks:
   monitoring:
@@ -163,3 +309,6 @@ volumes:
   grafana_data:
   loki_data:
   alertmanager_data:
+  tempo_data:
+  uptime_kuma_data:
+  oncall_data:


### PR DESCRIPTION
## 📊 Complete Observability Stack — Three Pillars + Alerting + Uptime

Closes #10

### What's Included

**10 services** covering the full observability spectrum:

| Service | Image | Purpose |
|---------|-------|---------|
| Prometheus | `prom/prometheus:v2.54.1` | Metrics collection & storage |
| Grafana | `grafana/grafana:11.2.2` | Visualization & dashboards |
| Loki | `grafana/loki:3.2.0` | Log aggregation |
| Promtail | `grafana/promtail:3.2.0` | Log collection agent |
| Tempo | `grafana/tempo:2.6.0` | Distributed tracing |
| Alertmanager | `prom/alertmanager:v0.27.0` | Alert routing → ntfy |
| cAdvisor | `gcr.io/cadvisor/cadvisor:v0.50.0` | Container metrics |
| Node Exporter | `prom/node-exporter:v1.8.2` | Host system metrics |
| Uptime Kuma | `louislam/uptime-kuma:1.23.15` | Service uptime & status page |
| Grafana OnCall | `grafana/oncall:v1.9.22` | On-call & incident management |

### Prometheus Scrape Targets (10 jobs)

`cadvisor`, `node-exporter`, `traefik`, `authentik`, `nextcloud`, `gitea`, `prometheus` (self), `loki`, `tempo`, `grafana`

### Grafana Dashboards (Auto-Provisioned)

Init container downloads from Grafana.com on first start:
- **Node Exporter Full** (ID: 1860)
- **Docker Container & Host Metrics** (ID: 179)
- **Traefik Official** (ID: 17346)
- **Loki Dashboard** (ID: 13639)
- **Uptime Kuma** (ID: 18278)

### Alert Rules (3 files)

**`host.yml`** — Host CPU >80% (5min), Memory >90%, Disk <15%/<5%, Disk I/O saturation, OOM kill detection

**`containers.yml`** — Restart rate >3/hr, OOM killed, Container down, CPU throttling, Memory >90% of limit

**`services.yml`** — Traefik 5xx >1%, Service P99 >2s, Target down, Alertmanager notification failures, Loki errors

All alerts route: `Alertmanager → ntfy push notifications`

### Grafana Authentication

Authentik OIDC integration:
- `homelab-admins` group → Grafana **Admin** role
- `homelab-users` group → Grafana **Viewer** role

### Data Retention

| Data | Retention | Configurable |
|------|-----------|-------------|
| Metrics (Prometheus) | 30 days | `PROMETHEUS_RETENTION` |
| Logs (Loki) | 7 days | `LOKI_RETENTION` |
| Traces (Tempo) | 3 days | `TEMPO_RETENTION` |

### Uptime Kuma

- Public status page at `status.${DOMAIN}`
- Auto-setup script: `scripts/uptime-kuma-setup.sh` creates monitors for all services
- Downtime notifications via ntfy

### Distributed Tracing (Tempo)

- Receives OTLP (gRPC/HTTP) and Zipkin traces
- Grafana links: Traces ↔ Logs (Loki) ↔ Metrics (Prometheus)
- Service map visualization
- Metrics generation from traces (span-metrics, service-graphs)

### Files Changed

```
config/prometheus/prometheus.yml         — 10 scrape targets
config/prometheus/alerts/host.yml        — Host alert rules
config/prometheus/alerts/containers.yml  — Container alert rules
config/prometheus/alerts/services.yml    — Service alert rules
config/alertmanager/alertmanager.yml     — ntfy routing
config/grafana/provisioning/datasources/ — Prometheus + Loki + Tempo + Alertmanager
config/loki/loki-config.yml             — Retention + compactor
config/loki/promtail-config.yml         — Docker + syslog + Traefik access logs
config/tempo/tempo.yml                  — OTLP + metrics generation
scripts/uptime-kuma-setup.sh            — Auto-create monitors
stacks/monitoring/docker-compose.yml    — 10 services + init container
stacks/monitoring/.env.example          — All configuration variables
stacks/monitoring/README.md             — Complete documentation
```

### Verification Checklist

- [x] Grafana accessible, all dashboards auto-provisioned
- [x] Prometheus targets page — all jobs configured
- [x] Loki log queries via Promtail auto-discovery
- [x] Alert rules: CPU, memory, disk, container restarts, 5xx errors
- [x] Alertmanager routes to ntfy
- [x] Uptime Kuma status page publicly accessible
- [x] `uptime-kuma-setup.sh` auto-creates service monitors
- [x] Grafana Authentik OIDC with role mapping
- [x] cAdvisor container metrics dashboard
- [x] Tempo distributed tracing with service map
