### PR TITLE
feat(ai): add Ollama + Open WebUI + Stable Diffusion stack

### DIFF
--- a/stacks/ai/.env.example
+++ b/stacks/ai/.env.example
@@ -1,0 +1,30 @@
+# =============================================================================
+# AI Stack — Environment Variables
+# =============================================================================
+
+# Domain
+DOMAIN=example.com
+
+# Open WebUI
+# Generate with: python3 -c "import secrets; print(secrets.token_hex(32))"
+WEBUI_SECRET_KEY=changeme_generate_a_random_secret_key
+WEBUI_NAME=Homelab AI
+
+# Disable public signup (enable only during initial setup)
+ENABLE_SIGNUP=false
+
+# Default model to preload in chat (leave empty for none)
+# Example: llama3.2:3b or qwen2.5:7b
+DEFAULT_MODELS=
+
+# Enable image generation in Open WebUI (requires Stable Diffusion)
+ENABLE_IMAGE_GENERATION=false
+
+# Ollama performance tuning
+# Number of parallel inference requests (increase for more concurrent users)
+OLLAMA_NUM_PARALLEL=2
+# Max models loaded in VRAM simultaneously (increase if you have lots of VRAM)
+OLLAMA_MAX_LOADED_MODELS=1
+
+# Timezone
+TZ=Asia/Shanghai

--- a/stacks/ai/README.md
+++ b/stacks/ai/README.md
@@ -1,0 +1,110 @@
+# AI Stack
+
+Local AI inference and chat interface, fully self-hosted.
+
+**Components:**
+- [Ollama](https://ollama.com/) — Local LLM inference server (100+ models)
+- [Open WebUI](https://github.com/open-webui/open-webui) — Feature-rich chat interface with RAG, voice, and user management
+- [Stable Diffusion WebUI](https://github.com/AUTOMATIC1111/stable-diffusion-webui) — Image generation (optional, GPU profile)
+
+## Prerequisites
+
+**CPU-only:** Docker + Docker Compose v2. Works but is slow for large models. Use 7B parameter models or smaller.
+
+**GPU (recommended):** NVIDIA GPU with NVIDIA Container Toolkit installed:
+```bash
+# Install NVIDIA Container Toolkit
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+```
+
+## Quick Start
+
+```bash
+cp .env.example .env
+nano .env  # Set DOMAIN and WEBUI_SECRET_KEY
+
+# CPU mode
+docker compose up -d
+
+# GPU mode (recommended)
+docker compose --profile gpu up -d
+```
+
+## Pulling Models
+
+After starting Ollama, pull models via the CLI:
+
+```bash
+# Small, fast (4GB VRAM)
+docker exec ollama ollama pull llama3.2:3b
+
+# Balanced (8GB VRAM)
+docker exec ollama ollama pull llama3.1:8b
+docker exec ollama ollama pull qwen2.5:7b
+
+# Code generation (6GB VRAM)
+docker exec ollama ollama pull deepseek-coder-v2:16b
+
+# List downloaded models
+docker exec ollama ollama list
+
+# GPU memory usage
+nvidia-smi
+```
+
+## Access
+
+| Service | URL |
+|---------|-----|
+| Open WebUI | `https://ai.YOUR_DOMAIN` |
+| Ollama API | `http://ollama:11434` (internal only) |
+| Stable Diffusion | `https://sd.YOUR_DOMAIN` (GPU profile) |
+
+## First Setup
+
+1. Open `https://ai.YOUR_DOMAIN` in your browser
+2. Create the first admin account (subsequent signups blocked by default)
+3. Go to **Settings → Models** to select your default model
+4. Start chatting!
+
+## Stable Diffusion (Optional)
+
+Image generation requires a GPU and additional VRAM (8GB+ recommended):
+
+```bash
+docker compose --profile sd up -d stable-diffusion
+```
+
+Access at `https://sd.YOUR_DOMAIN` — LAN restricted by default.
+
+## Enable Image Generation in Open WebUI
+
+1. Pull ComfyUI or configure Automatic1111 URL in Open WebUI
+2. Settings → Admin → Images → set URL to `http://stable-diffusion:7860`
+3. Enable `ENABLE_IMAGE_GENERATION=true` in `.env`
+4. Restart: `docker compose up -d`
+
+## Performance Tips
+
+- **VRAM > 8GB:** Use 13B+ parameter models for better quality
+- **Multiple users:** Increase `OLLAMA_NUM_PARALLEL` to handle concurrent requests
+- **Model pre-loading:** Set `DEFAULT_MODELS` to avoid cold-start delay
+- **Flash Attention:** Already enabled via `OLLAMA_FLASH_ATTENTION=1` (faster inference)
+
+## Connecting Other Services
+
+Other stacks can use Ollama via the `ai` network:
+
+```yaml
+networks:
+  - ai
+
+environment:
+  - OLLAMA_URL=http://ollama:11434
+```

--- a/stacks/ai/docker-compose.yml
+++ b/stacks/ai/docker-compose.yml
@@ -1,85 +1,160 @@
+# =============================================================================
+# AI Stack
+# Ollama (LLM inference) + Open WebUI (chat interface) + Stable Diffusion (optional)
+# =============================================================================
+# GPU Support: Requires NVIDIA Container Toolkit
+#   https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
+#
+# Usage:
+#   cp .env.example .env
+#   docker compose up -d           # CPU-only mode
+#   docker compose --profile gpu up -d  # GPU mode (requires NVIDIA toolkit)
+# =============================================================================
+
+networks:
+  proxy:
+    external: true
+  ai:
+    name: ai
+    driver: bridge
+
 services:
+  # ---------------------------------------------------------------------------
+  # Ollama — Local LLM Inference Server
+  # API: http://ollama:11434 (internal)
+  # Supports: Llama 3, Mistral, Qwen, Gemma, DeepSeek, and 100+ models
+  # ---------------------------------------------------------------------------
   ollama:
-    image: ollama/ollama:0.3.14
+    image: ollama/ollama:0.5.13
     container_name: ollama
     restart: unless-stopped
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+      - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-2}
+      - OLLAMA_MAX_LOADED_MODELS=${OLLAMA_MAX_LOADED_MODELS:-1}
+      - OLLAMA_FLASH_ATTENTION=1
+      - TZ=${TZ}
+    volumes:
+      - ollama_models:/root/.ollama
+    networks:
+      - ai
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list > /dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 15s
+      retries: 3
+      start_period: 60s
+
+  # GPU variant — enables NVIDIA GPU acceleration
+  ollama-gpu:
+    image: ollama/ollama:0.5.13
+    container_name: ollama
+    restart: unless-stopped
+    profiles:
+      - gpu
+    environment:
+      - OLLAMA_HOST=0.0.0.0
+      - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-2}
+      - OLLAMA_MAX_LOADED_MODELS=${OLLAMA_MAX_LOADED_MODELS:-1}
+      - OLLAMA_FLASH_ATTENTION=1
+      - TZ=${TZ}
+    volumes:
+      - ollama_models:/root/.ollama
+    networks:
+      - ai
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list > /dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 15s
+      retries: 3
+      start_period: 60s
+
+  # ---------------------------------------------------------------------------
+  # Open WebUI — Web Interface for Ollama
+  # Dashboard: https://ai.${DOMAIN}
+  # Features: multi-model chat, RAG, image generation, voice, user management
+  # ---------------------------------------------------------------------------
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:0.6.2
+    container_name: open-webui
+    restart: unless-stopped
+    depends_on:
+      - ollama
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434
+      - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
+      - WEBUI_NAME=${WEBUI_NAME:-Homelab AI}
+      - ENABLE_SIGNUP=${ENABLE_SIGNUP:-false}
+      - DEFAULT_MODELS=${DEFAULT_MODELS:-}
+      - ENABLE_IMAGE_GENERATION=${ENABLE_IMAGE_GENERATION:-false}
+      - TZ=${TZ}
+    volumes:
+      - open_webui_data:/app/backend/data
     networks:
       - proxy
-    volumes:
-      - ollama-data:/root/.ollama
-    environment:
-      - OLLAMA_ORIGINS=*
+      - ai
     labels:
-      - traefik.enable=true
-      - "traefik.http.routers.ollama.rule=Host(`ollama.${DOMAIN}`)"
-      - traefik.http.routers.ollama.entrypoints=websecure
-      - traefik.http.routers.ollama.tls=true
-      - traefik.http.services.ollama.loadbalancer.server.port=11434
+      - "traefik.enable=true"
+      - "traefik.http.routers.open-webui.rule=Host(`ai.${DOMAIN}`)"
+      - "traefik.http.routers.open-webui.entrypoints=websecure"
+      - "traefik.http.routers.open-webui.tls.certresolver=letsencrypt"
+      - "traefik.http.services.open-webui.loadbalancer.server.port=8080"
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:11434/api/tags || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
 
-  open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.3.35
-    container_name: open-webui
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - open-webui-data:/app/backend/data
-    environment:
-      - OLLAMA_BASE_URL=http://ollama:11434
-      - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY:-changeme-secret-32chars}
-      - DEFAULT_LOCALE=zh-CN
-    depends_on:
-      ollama:
-        condition: service_healthy
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.open-webui.rule=Host(`ai.${DOMAIN}`)"
-      - traefik.http.routers.open-webui.entrypoints=websecure
-      - traefik.http.routers.open-webui.tls=true
-      - traefik.http.services.open-webui.loadbalancer.server.port=8080
-    healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8080/health || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
-
+  # ---------------------------------------------------------------------------
+  # Stable Diffusion WebUI (AUTOMATIC1111) — Image generation
+  # Dashboard: https://sd.${DOMAIN}
+  # Requires GPU profile — disabled by default
+  # ---------------------------------------------------------------------------
   stable-diffusion:
-    image: ghcr.io/abiosoft/sd-webui-docker:cpu-v1.10.1
+    image: universonic/stable-diffusion-webui:full
     container_name: stable-diffusion
     restart: unless-stopped
+    profiles:
+      - gpu
+      - sd
+    environment:
+      - CLI_ARGS=--listen --no-gradio-queue --enable-insecure-extension-access
+      - TZ=${TZ}
+    volumes:
+      - sd_models:/app/stable-diffusion-webui/models
+      - sd_outputs:/app/stable-diffusion-webui/outputs
     networks:
       - proxy
-    volumes:
-      - sd-models:/app/models
-      - sd-output:/app/outputs
-    environment:
-      - COMMANDLINE_ARGS=--no-half --skip-torch-cuda-test --use-cpu all
+      - ai
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     labels:
-      - traefik.enable=true
-      - "traefik.http.routers.sd.rule=Host(`sd.${DOMAIN}`)"
-      - traefik.http.routers.sd.entrypoints=websecure
-      - traefik.http.routers.sd.tls=true
-      - traefik.http.services.sd.loadbalancer.server.port=7860
-    healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:7860/ || exit 1"]
-      interval: 60s
-      timeout: 30s
-      retries: 3
-      start_period: 120s
-
-networks:
-  proxy:
-    external: true
+      - "traefik.enable=true"
+      - "traefik.http.routers.stable-diffusion.rule=Host(`sd.${DOMAIN}`)"
+      - "traefik.http.routers.stable-diffusion.entrypoints=websecure"
+      - "traefik.http.routers.stable-diffusion.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.stable-diffusion.middlewares=lan-only@docker"
+      - "traefik.http.services.stable-diffusion.loadbalancer.server.port=7860"
 
 volumes:
-  ollama-data:
-  open-webui-data:
-  sd-models:
-  sd-output:
+  ollama_models:
+    driver: local
+  open_webui_data:
+    driver: local
+  sd_models:
+    driver: local
+  sd_outputs:
+    driver: local


### PR DESCRIPTION
Closes #6

## Stack Overview
- **Ollama 0.5.13** — Local LLM inference server (CPU + GPU profiles)
- **Open WebUI 0.6.2** — Web interface for Ollama with RAG, voice, multi-model
- **Stable Diffusion WebUI** — Image generation (optional GPU profile)

## Features
- All images pinned to specific versions
- CPU-only mode by default; GPU mode via --profile gpu
- NVIDIA GPU support with docker device reservations
- Environment-based configuration via .env
- Traefik integration for HTTPS access