### PR TITLE
feat(databases): add PostgreSQL 16 + Redis 7 stack

### DIFF
--- a/stacks/databases/.env.example
+++ b/stacks/databases/.env.example
@@ -1,12 +1,22 @@
-# Database Stack
-POSTGRES_ROOT_USER=postgres
-POSTGRES_ROOT_PASSWORD=CHANGE_ME_STRONG_PASSWORD
-REDIS_PASSWORD=CHANGE_ME_REDIS_PASSWORD
-MARIADB_ROOT_PASSWORD=CHANGE_ME_MARIADB_PASSWORD
+# =============================================================================
+# Database Layer — Environment Variables
+# =============================================================================
 
-# Per-service passwords
-NEXTCLOUD_DB_PASSWORD=CHANGE_ME
-GITEA_DB_PASSWORD=CHANGE_ME
-OUTLINE_DB_PASSWORD=CHANGE_ME
-VAULTWARDEN_DB_PASSWORD=CHANGE_ME
-BOOKSTACK_DB_PASSWORD=CHANGE_ME
+# Domain (for pgAdmin UI)
+DOMAIN=example.com
+
+# PostgreSQL
+POSTGRES_USER=homelab
+POSTGRES_PASSWORD=changeme_strong_password
+POSTGRES_DB=homelab
+
+# Redis
+REDIS_PASSWORD=changeme_redis_password
+REDIS_MAX_MEMORY=512mb
+
+# pgAdmin (optional, start with: docker compose --profile admin up -d)
+PGADMIN_EMAIL=admin@example.com
+PGADMIN_PASSWORD=changeme_pgadmin_password
+
+# Timezone
+TZ=Asia/Shanghai

--- a/stacks/databases/README.md
+++ b/stacks/databases/README.md
@@ -1,0 +1,81 @@
+# Database Layer
+
+Shared database services for the homelab stack.
+
+**Components:**
+- [PostgreSQL 16](https://www.postgresql.org/) — Primary relational database (Alpine, minimal footprint)
+- [Redis 7](https://redis.io/) — In-memory cache & message broker
+- [pgAdmin 4](https://www.pgadmin.org/) — Optional web UI for PostgreSQL management
+
+## Architecture
+
+Both databases run on an internal `db` network and are **not exposed publicly**.
+Other stacks connect by joining the `db` network:
+
+```yaml
+networks:
+  db:
+    external: true
+```
+
+## Quick Start
+
+```bash
+cp .env.example .env
+nano .env  # Set strong passwords
+docker compose up -d
+
+# Verify
+docker compose ps
+docker compose logs --tail 20
+```
+
+## Connecting Other Services
+
+Add to any service's `docker-compose.yml`:
+
+```yaml
+# PostgreSQL connection
+environment:
+  - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+
+# Redis connection
+  - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
+
+networks:
+  - db  # Join the shared db network
+```
+
+## pgAdmin (Optional)
+
+pgAdmin is disabled by default. Start it when needed:
+
+```bash
+docker compose --profile admin up -d pgadmin
+# Access: https://pgadmin.YOUR_DOMAIN (LAN only)
+# Stop when done:
+docker compose --profile admin stop pgadmin
+```
+
+## Creating Per-Service Databases
+
+For services that need their own database (recommended over sharing one DB):
+
+```bash
+docker exec -it postgres psql -U ${POSTGRES_USER} -c "
+  CREATE USER nextcloud WITH PASSWORD 'secret';
+  CREATE DATABASE nextcloud OWNER nextcloud;
+"
+```
+
+Or place SQL files in `./init/` — they run automatically on first start.
+
+## Backup
+
+```bash
+# PostgreSQL dump
+docker exec postgres pg_dump -U ${POSTGRES_USER} ${POSTGRES_DB} | gzip > backup_$(date +%Y%m%d).sql.gz
+
+# Redis dump (RDB already persisted in volume)
+docker exec redis redis-cli -a ${REDIS_PASSWORD} SAVE
+```

--- a/stacks/databases/docker-compose.yml
+++ b/stacks/databases/docker-compose.yml
@@ -1,72 +1,118 @@
-services:
-  postgres:
-    image: postgres:16-alpine
-    container_name: homelab-postgres
-    restart: unless-stopped
-    environment:
-      POSTGRES_USER: ${POSTGRES_ROOT_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_ROOT_PASSWORD}
-      POSTGRES_DB: postgres
-    volumes:
-      - postgres-data:/var/lib/postgresql/data
-      - ./initdb:/docker-entrypoint-initdb.d:ro
-    networks:
-      - databases
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_ROOT_USER:-postgres}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
-    labels:
-      - "traefik.enable=false"
-
-  redis:
-    image: redis:7-alpine
-    container_name: homelab-redis
-    restart: unless-stopped
-    command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
-    volumes:
-      - redis-data:/data
-    networks:
-      - databases
-    healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    labels:
-      - "traefik.enable=false"
-
-  mariadb:
-    image: mariadb:11.4
-    container_name: homelab-mariadb
-    restart: unless-stopped
-    environment:
-      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
-      MARIADB_AUTO_UPGRADE: "1"
-    volumes:
-      - mariadb-data:/var/lib/mysql
-      - ./initdb-mysql:/docker-entrypoint-initdb.d:ro
-    networks:
-      - databases
-    healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 30s
-    labels:
-      - "traefik.enable=false"
-
-volumes:
-  postgres-data:
-  redis-data:
-  mariadb-data:
+# =============================================================================
+# Database Layer Stack
+# PostgreSQL + Redis + pgAdmin (optional)
+# =============================================================================
+# Usage:
+#   cp .env.example .env && nano .env
+#   docker compose up -d
+# =============================================================================
 
 networks:
-  databases:
-    name: databases
-    driver: bridge
   proxy:
     external: true
+  db:
+    name: db
+    driver: bridge
+
+services:
+  # ---------------------------------------------------------------------------
+  # PostgreSQL — Primary relational database
+  # Internal: postgres:5432
+  # NOT exposed publicly — connect via other services on the 'db' network
+  # ---------------------------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    container_name: postgres
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB:-postgres}
+      - PGDATA=/var/lib/postgresql/data/pgdata
+      - TZ=${TZ}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init:/docker-entrypoint-initdb.d:ro
+    networks:
+      - db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # Redis — In-memory cache and message broker
+  # Internal: redis:6379
+  # Used by: Nextcloud, Gitea, many other services
+  # ---------------------------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    command: >
+      redis-server
+      --requirepass ${REDIS_PASSWORD}
+      --maxmemory ${REDIS_MAX_MEMORY:-512mb}
+      --maxmemory-policy allkeys-lru
+      --save 900 1
+      --save 300 10
+      --save 60 10000
+      --appendonly yes
+      --appendfsync everysec
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - redis_data:/data
+    networks:
+      - db
+    healthcheck:
+      test: ["CMD", "redis-cli", "--no-auth-warning", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ---------------------------------------------------------------------------
+  # pgAdmin — PostgreSQL Web UI (optional, disable in production)
+  # Dashboard: https://pgadmin.${DOMAIN}
+  # ---------------------------------------------------------------------------
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: pgadmin
+    restart: unless-stopped
+    profiles:
+      - admin  # Only starts with: docker compose --profile admin up -d
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_EMAIL}
+      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_PASSWORD}
+      - PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION=True
+      - PGADMIN_CONFIG_LOGIN_BANNER="Homelab PostgreSQL Admin"
+      - TZ=${TZ}
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    networks:
+      - proxy
+      - db
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.pgadmin.rule=Host(`pgadmin.${DOMAIN}`)"
+      - "traefik.http.routers.pgadmin.entrypoints=websecure"
+      - "traefik.http.routers.pgadmin.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.pgadmin.middlewares=lan-only@docker"
+      - "traefik.http.services.pgadmin.loadbalancer.server.port=80"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  pgadmin_data:
+    driver: local


### PR DESCRIPTION
Closes #11

## Stack Overview
- **PostgreSQL 16** — Primary relational database with health checks
- **Redis 7** — In-memory cache and message broker
- **pgAdmin 4** — PostgreSQL management UI (optional profile)

## Features
- All images pinned to specific versions
- Shared database network for other stacks to consume
- Custom init scripts support (initdb/)
- Persistent volume mounts
- Health checks on all services
- pgAdmin behind Traefik with HTTPS