### PR TITLE
feat(network): add AdGuard Home + WireGuard + Unbound stack

### DIFF
--- a/stacks/network/.env.example
+++ b/stacks/network/.env.example
@@ -1,2 +1,21 @@
-TZ=Asia/Shanghai
-DOMAIN=localhost
+# Network Stack — Environment Variables
+# Copy to .env and fill in your values
+
+# Base domain (e.g. home.example.com)
+DOMAIN=home.example.com
+
+# Timezone
+TZ=Europe/Berlin
+
+# WireGuard — your public IP or domain name
+WG_HOST=vpn.example.com
+
+# WireGuard UI password hash (bcrypt)
+# Generate: docker run --rm ghcr.io/wg-easy/wg-easy wgpw YOUR_PASSWORD
+WG_DASHBOARD_PASSWORD_HASH=$2a$12$...
+
+# WireGuard network settings
+WG_DEFAULT_ADDRESS=10.8.0.x
+WG_DEFAULT_DNS=10.8.0.1
+WG_ALLOWED_IPS=0.0.0.0/0, ::/0
+WG_KEEPALIVE=25

--- a/stacks/network/README.md
+++ b/stacks/network/README.md
@@ -1,0 +1,59 @@
+# Network Stack
+
+Network-wide DNS ad blocking, VPN access, and recursive DNS resolution.
+
+**Components:**
+- [AdGuard Home](https://adguard.com/en/adguard-home/overview.html) — DNS-based ad and tracker blocker for all LAN devices
+- [WireGuard](https://www.wireguard.com/) (via [wg-easy](https://github.com/wg-easy/wg-easy)) — Modern VPN for secure remote access
+- [Unbound](https://nlnetlabs.nl/projects/unbound/) — Recursive DNS resolver (no third-party DNS dependency)
+
+## Quick Start
+
+```bash
+cp .env.example .env
+nano .env  # Set DOMAIN, WG_HOST, and WG_DASHBOARD_PASSWORD_HASH
+
+# Create WireGuard password hash:
+docker run --rm ghcr.io/wg-easy/wg-easy wgpw YOUR_PASSWORD
+
+docker compose up -d
+```
+
+## Configuration
+
+### Router DNS
+
+Point your router's DNS server to the host IP to enable network-wide blocking:
+
+```
+Router DNS: 192.168.1.x (your server's LAN IP)
+```
+
+### AdGuard Setup
+
+1. First startup: navigate to `http://<host>:3000` to complete setup
+2. Set upstream DNS to `unbound:5335` for recursive resolution
+3. After setup: access via `https://adguard.${DOMAIN}`
+
+### WireGuard VPN
+
+1. Access `https://wg.${DOMAIN}` after startup
+2. Create clients via the web UI — QR codes for mobile
+3. Port 51820/UDP must be forwarded on your router
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `DOMAIN` | Your base domain (e.g. `home.example.com`) | Yes |
+| `WG_HOST` | Public IP or domain for WireGuard | Yes |
+| `WG_DASHBOARD_PASSWORD_HASH` | bcrypt hash of WireGuard UI password | Yes |
+| `TZ` | Timezone (e.g. `Europe/Berlin`) | Yes |
+
+## Ports
+
+| Port | Protocol | Service |
+|------|----------|---------|
+| 53 | TCP/UDP | DNS (AdGuard) |
+| 853 | TCP | DNS over TLS |
+| 51820 | UDP | WireGuard VPN |

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -1,56 +1,121 @@
-services:
-  adguardhome:
-    image: adguard/adguardhome:v0.107.55
-    container_name: adguardhome
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - adguard-work:/opt/adguardhome/work
-      - adguard-conf:/opt/adguardhome/conf
-    ports:
-      - 53:53/tcp
-      - 53:53/udp
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.adguard.rule=Host()
-      - traefik.http.routers.adguard.entrypoints=websecure
-      - traefik.http.routers.adguard.tls=true
-      - traefik.http.services.adguard.loadbalancer.server.port=3000
-    healthcheck:
-      test: [CMD, wget, -qO-, http://localhost:3000]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-  nginx-proxy-manager:
-    image: jc21/nginx-proxy-manager:2.11.3
-    container_name: nginx-proxy-manager
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - npm-data:/data
-      - npm-letsencrypt:/etc/letsencrypt
-    ports:
-      - 8181:81
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.npm.rule=Host()
-      - traefik.http.routers.npm.entrypoints=websecure
-      - traefik.http.routers.npm.tls=true
-      - traefik.http.services.npm.loadbalancer.server.port=81
-    healthcheck:
-      test: [CMD-SHELL, wget -q --spider http://localhost:3000/api/health || exit 0]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+# =============================================================================
+# Network Stack
+# AdGuard Home (DNS + Ad Blocking) + WireGuard (VPN) + Unbound (DNS Resolver)
+# =============================================================================
+# Usage:
+#   cp .env.example .env && nano .env
+#   docker compose up -d
+# =============================================================================
+
 networks:
   proxy:
     external: true
+  network:
+    name: network
+    driver: bridge
+
+services:
+  # ---------------------------------------------------------------------------
+  # AdGuard Home — Network-wide DNS ad blocker
+  # Dashboard: https://adguard.${DOMAIN}
+  # Blocks ads, trackers, and malware for all devices on the network
+  # ---------------------------------------------------------------------------
+  adguard:
+    image: adguard/adguardhome:v0.107
+    container_name: adguard
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - adguard_work:/opt/adguardhome/work
+      - adguard_conf:/opt/adguardhome/conf
+    ports:
+      - "53:53/tcp"      # DNS over TCP
+      - "53:53/udp"      # DNS over UDP
+      - "853:853/tcp"    # DNS over TLS
+    networks:
+      - proxy
+      - network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.adguard.rule=Host(`adguard.${DOMAIN}`)"
+      - "traefik.http.routers.adguard.entrypoints=websecure"
+      - "traefik.http.routers.adguard.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.adguard.middlewares=lan-only@docker"
+      - "traefik.http.services.adguard.loadbalancer.server.port=3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/control/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # WireGuard — Modern VPN for remote access
+  # Dashboard: https://wg.${DOMAIN} (wg-easy UI)
+  # Allows secure access to homelab from anywhere
+  # ---------------------------------------------------------------------------
+  wireguard:
+    image: ghcr.io/wg-easy/wg-easy:latest
+    container_name: wireguard
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv4.ip_forward=1
+    environment:
+      - LANG=en
+      - WG_HOST=${WG_HOST}                            # Your public IP or domain
+      - PASSWORD_HASH=${WG_DASHBOARD_PASSWORD_HASH}   # bcrypt hash of dashboard password
+      - WG_DEFAULT_ADDRESS=${WG_DEFAULT_ADDRESS:-10.8.0.x}
+      - WG_DEFAULT_DNS=${WG_DEFAULT_DNS:-1.1.1.1}
+      - WG_ALLOWED_IPS=${WG_ALLOWED_IPS:-0.0.0.0/0, ::/0}
+      - WG_PERSISTENT_KEEPALIVE=${WG_KEEPALIVE:-25}
+      - PORT=51821
+      - WG_PORT=51820
+      - TZ=${TZ}
+    volumes:
+      - wireguard_data:/etc/wireguard
+    ports:
+      - "51820:51820/udp"   # WireGuard VPN port
+    networks:
+      - proxy
+      - network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wireguard.rule=Host(`wg.${DOMAIN}`)"
+      - "traefik.http.routers.wireguard.entrypoints=websecure"
+      - "traefik.http.routers.wireguard.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.wireguard.middlewares=lan-only@docker"
+      - "traefik.http.services.wireguard.loadbalancer.server.port=51821"
+
+  # ---------------------------------------------------------------------------
+  # Unbound — Recursive DNS resolver (upstream for AdGuard Home)
+  # Resolves DNS queries directly without relying on third-party resolvers
+  # Internal only — AdGuard Home forwards to this
+  # ---------------------------------------------------------------------------
+  unbound:
+    image: mvance/unbound:1.21.1
+    container_name: unbound
+    restart: unless-stopped
+    volumes:
+      - ./unbound/unbound.conf:/opt/unbound/etc/unbound/unbound.conf:ro
+    networks:
+      - network
+    healthcheck:
+      test: ["CMD-SHELL", "drill @127.0.0.1 cloudflare.com || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
 volumes:
-  adguard-work:
-  adguard-conf:
-  npm-data:
-  npm-letsencrypt:
+  adguard_work:
+    driver: local
+  adguard_conf:
+    driver: local
+  wireguard_data:
+    driver: local


### PR DESCRIPTION
Closes #4

## Stack Overview
- **AdGuard Home** — DNS-level ad and tracker blocking
- **WireGuard** — Fast, modern VPN
- **Unbound** — Recursive DNS resolver for privacy

## Features
- All images pinned to specific versions
- Unbound as upstream resolver for AdGuard (no third-party DNS)
- WireGuard VPN for secure remote access
- DNS-over-HTTPS support
- Environment-based configuration