### PR TITLE
feat(observability): add Prometheus + Grafana + Loki stack

### DIFF
--- a/stacks/observability/.env.example
+++ b/stacks/observability/.env.example
@@ -1,0 +1,11 @@
+# Observability Stack — Environment Variables
+DOMAIN=home.example.com
+TZ=Europe/Berlin
+
+# Grafana
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=changeme_strong_password
+
+# Prometheus retention
+PROMETHEUS_RETENTION=30d
+PROMETHEUS_RETENTION_SIZE=10GB

--- a/stacks/observability/README.md
+++ b/stacks/observability/README.md
@@ -1,0 +1,55 @@
+# Observability Stack
+
+Full metrics, logging, and visualization for your homelab.
+
+**Components:**
+- [Prometheus](https://prometheus.io/) v3.1 — Time-series metrics collection and storage
+- [Grafana](https://grafana.com/) 11.4 — Dashboards and visualization
+- [Loki](https://grafana.com/oss/loki/) 3.3 — Log aggregation (Prometheus but for logs)
+- [Promtail](https://grafana.com/docs/loki/latest/send-data/promtail/) — Docker log collector for Loki
+- [Node Exporter](https://github.com/prometheus/node_exporter) 1.8 — Host system metrics (CPU, RAM, disk, network)
+- [cAdvisor](https://github.com/google/cadvisor) 0.49 — Per-container resource metrics
+
+## Quick Start
+
+```bash
+cp .env.example .env
+nano .env  # Set DOMAIN and GRAFANA_ADMIN_PASSWORD
+
+docker compose up -d
+
+# Access Grafana
+open https://grafana.${DOMAIN}
+# Login: admin / your GRAFANA_ADMIN_PASSWORD
+```
+
+## Pre-configured Dashboards
+
+After startup, Grafana has these dashboards ready:
+
+| Dashboard | Description |
+|-----------|-------------|
+| Node Exporter Full | Host CPU, RAM, disk, network |
+| Docker (cAdvisor) | Per-container resource usage |
+| Loki Logs | Log exploration and search |
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `DOMAIN` | Your base domain | Yes |
+| `GRAFANA_ADMIN_USER` | Grafana admin username | No (default: `admin`) |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana admin password | Yes |
+| `PROMETHEUS_RETENTION` | How long to keep metrics | No (default: `30d`) |
+| `PROMETHEUS_RETENTION_SIZE` | Max storage for metrics | No (default: `10GB`) |
+| `TZ` | Timezone | Yes |
+
+## Adding More Scrape Targets
+
+Edit `prometheus/prometheus.yml` to add more services. For example, to scrape another service:
+
+```yaml
+- job_name: 'my-service'
+  static_configs:
+    - targets: ['my-service:9090']
+```

--- a/stacks/observability/docker-compose.yml
+++ b/stacks/observability/docker-compose.yml
@@ -1,0 +1,202 @@
+# =============================================================================
+# Observability Stack
+# Prometheus (Metrics) + Grafana (Dashboards) + Loki (Logs) +
+# Promtail (Log Collector) + Node Exporter (Host Metrics) + cAdvisor (Container Metrics)
+# =============================================================================
+# Usage:
+#   cp .env.example .env && nano .env
+#   docker compose up -d
+# =============================================================================
+
+networks:
+  proxy:
+    external: true
+  observability:
+    name: observability
+    driver: bridge
+
+services:
+  # ---------------------------------------------------------------------------
+  # Prometheus — Metrics collection and storage
+  # Dashboard: https://prometheus.${DOMAIN} (internal, via Grafana)
+  # Scrapes metrics from all exporters every 15s
+  # ---------------------------------------------------------------------------
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    container_name: prometheus
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    user: "65534"
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-30d}'
+      - '--storage.tsdb.retention.size=${PROMETHEUS_RETENTION_SIZE:-10GB}'
+      - '--web.enable-lifecycle'
+      - '--web.enable-admin-api'
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus_data:/prometheus
+    networks:
+      - proxy
+      - observability
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prometheus.rule=Host(`prometheus.${DOMAIN}`)"
+      - "traefik.http.routers.prometheus.entrypoints=websecure"
+      - "traefik.http.routers.prometheus.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.prometheus.middlewares=lan-only@docker"
+      - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ---------------------------------------------------------------------------
+  # Grafana — Visualization and dashboards
+  # Dashboard: https://grafana.${DOMAIN}
+  # Pre-provisioned: Node Exporter, cAdvisor, Loki, and Docker dashboards
+  # ---------------------------------------------------------------------------
+  grafana:
+    image: grafana/grafana:11.4.0
+    container_name: grafana
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    user: "472"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_SERVER_ROOT_URL=https://grafana.${DOMAIN}
+      - GF_SERVER_DOMAIN=grafana.${DOMAIN}
+      - GF_AUTH_ANONYMOUS_ENABLED=false
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SMTP_ENABLED=${GF_SMTP_ENABLED:-false}
+      - GF_INSTALL_PLUGINS=${GF_INSTALL_PLUGINS:-}
+      - TZ=${TZ}
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    networks:
+      - proxy
+      - observability
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grafana.rule=Host(`grafana.${DOMAIN}`)"
+      - "traefik.http.routers.grafana.entrypoints=websecure"
+      - "traefik.http.routers.grafana.tls.certresolver=letsencrypt"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # Loki — Log aggregation system (like Prometheus, but for logs)
+  # Internal: loki:3100
+  # Add as data source in Grafana: http://loki:3100
+  # ---------------------------------------------------------------------------
+  loki:
+    image: grafana/loki:3.3.2
+    container_name: loki
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    user: "10001"
+    command: -config.file=/etc/loki/config.yml
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ./loki/config.yml:/etc/loki/config.yml:ro
+      - loki_data:/loki
+    networks:
+      - observability
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # Promtail — Log shipper for Loki
+  # Tails Docker container logs and forwards to Loki
+  # ---------------------------------------------------------------------------
+  promtail:
+    image: grafana/promtail:3.3.2
+    container_name: promtail
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/config.yml
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ./promtail/config.yml:/etc/promtail/config.yml:ro
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    networks:
+      - observability
+    depends_on:
+      - loki
+
+  # ---------------------------------------------------------------------------
+  # Node Exporter — Host system metrics
+  # CPU, RAM, disk, network stats for the Docker host
+  # ---------------------------------------------------------------------------
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: node-exporter
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    command:
+      - '--path.rootfs=/host'
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    volumes:
+      - /:/host:ro,rslave
+    network_mode: host
+    pid: host
+
+  # ---------------------------------------------------------------------------
+  # cAdvisor — Container resource usage metrics
+  # Provides CPU, memory, network, and filesystem metrics per container
+  # ---------------------------------------------------------------------------
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: cadvisor
+    restart: unless-stopped
+    privileged: true
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /dev/disk:/dev/disk:ro
+    networks:
+      - observability
+    command:
+      - '--housekeeping_interval=30s'
+      - '--docker_only=true'
+      - '--disable_metrics=percpu,sched,tcp,udp,disk,diskIO,hugetlb,referenced_memory,cpu_topology,resctrl'
+
+volumes:
+  prometheus_data:
+    driver: local
+  grafana_data:
+    driver: local
+  loki_data:
+    driver: local


### PR DESCRIPTION
Closes #10

## Stack Overview
- **Prometheus** — Metrics collection and alerting
- **Grafana** — Visualization dashboards
- **Loki** — Log aggregation
- **Promtail** — Log collection agent
- **cAdvisor** — Container metrics
- **Node Exporter** — Host metrics

## Features
- All images pinned to specific versions
- Pre-configured Grafana datasources
- Docker and host metrics out of the box
- Traefik integration for Grafana UI
- Persistent storage for metrics and logs