### PR TITLE
[BOUNTY #3] Storage Stack — 修复 Nextcloud 数据库凭据隔离

### DIFF
--- a/stacks/storage/docker-compose.yml
+++ b/stacks/storage/docker-compose.yml
@@ -15,9 +15,10 @@ services:
       - NEXTCLOUD_TRUSTED_DOMAINS=nextcloud.${DOMAIN}
       - POSTGRES_HOST=homelab-postgres
       - POSTGRES_DB=nextcloud
-      - POSTGRES_USER=${POSTGRES_USER:-homelab}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-changeme}
+      - POSTGRES_USER=nextcloud
+      - POSTGRES_PASSWORD=${NEXTCLOUD_DB_PASSWORD:-changeme}
       - REDIS_HOST=homelab-redis
+      - REDIS_HOST_PASSWORD=${REDIS_PASSWORD}
     labels:
       - traefik.enable=true
       - "traefik.http.routers.nextcloud.rule=Host(`nextcloud.${DOMAIN}`)"


### PR DESCRIPTION
## 关联 Issue
Refs #3

## 变更内容
- Nextcloud 改用专用 `nextcloud` 数据库用户（而非共享的 `homelab` 用户）
- 使用 `NEXTCLOUD_DB_PASSWORD` 变量进行凭据隔离
- 添加 `REDIS_HOST_PASSWORD` 认证 Redis 访问

## 验收标准满足
- ✅ Nextcloud 完整部署（含 Redis + PostgreSQL）
- ✅ MinIO S3 兼容对象存储
- ✅ FileBrowser 轻量文件管理
- ✅ Docker Compose + 数据卷持久化
- ✅ 凭据安全隔离