### PR TITLE
Implement Notifications Stack (ntfy + gotify + unified notify.sh)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,8 +103,12 @@ OLLAMA_GPU_ENABLED=false       # Set to true if you have NVIDIA GPU
 # -----------------------------------------------------------------------------
 # NOTIFICATIONS
 # -----------------------------------------------------------------------------
-GOTIFY_PASSWORD=               # REQUIRED
+GOTIFY_PASSWORD=               # REQUIRED for gotify bootstrap/admin
+GOTIFY_TOKEN=                  # token used by scripts/notify.sh fallback
+GOTIFY_BASE_URL=https://gotify.${DOMAIN}
+NTFY_BASE_URL=https://ntfy.${DOMAIN}
 NTFY_AUTH_ENABLED=true
+WATCHTOWER_NOTIFICATION_URL=ntfy://ntfy.${DOMAIN}/homelab-alerts
 
 # -----------------------------------------------------------------------------
 # NETWORK PROXY (optional — for CN users with local proxy)

--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -7,21 +7,20 @@ route:
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h
-  receiver: default
+  receiver: ntfy
   routes:
     - match:
         severity: critical
-      receiver: default
+      receiver: ntfy
       continue: true
 
 receivers:
+  - name: ntfy
+    webhook_configs:
+      - url: 'https://ntfy.${DOMAIN}/homelab-alerts'
+        send_resolved: true
+
   - name: default
-    # Uncomment and configure one of the following:
-    # webhook_configs:
-    #   - url: http://gotify:80/message?token=YOUR_TOKEN
-    # slack_configs:
-    #   - api_url: YOUR_SLACK_WEBHOOK
-    #     channel: #alerts
 
 inhibit_rules:
   - source_match:

--- a/config/ntfy/server.yml
+++ b/config/ntfy/server.yml
@@ -1,0 +1,8 @@
+base-url: https://ntfy.${DOMAIN}
+auth-default-access: deny-all
+behind-proxy: true
+cache-file: /var/cache/ntfy/cache.db
+auth-file: /var/lib/ntfy/user.db
+attachment-cache-dir: /var/cache/ntfy/attachments
+upstream-base-url: https://ntfy.sh
+enable-login: true

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Unified notification entrypoint for HomeLab Stack
+# Usage: ./scripts/notify.sh <topic> <title> <message> [priority]
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <topic> <title> <message> [priority]" >&2
+  exit 1
+fi
+
+TOPIC="$1"
+TITLE="$2"
+MESSAGE="$3"
+PRIORITY="${4:-default}"
+
+# optional .env loading
+if [[ -f .env ]]; then
+  # shellcheck disable=SC2046
+  export $(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' .env | xargs)
+fi
+
+NTFY_BASE="${NTFY_BASE_URL:-https://ntfy.${DOMAIN:-localhost}}"
+GOTIFY_BASE="${GOTIFY_BASE_URL:-https://gotify.${DOMAIN:-localhost}}"
+
+publish_ntfy() {
+  local url="${NTFY_BASE%/}/${TOPIC}"
+  curl -fsS -X POST "$url" \
+    -H "Title: ${TITLE}" \
+    -H "Priority: ${PRIORITY}" \
+    -H "Tags: warning" \
+    -d "${MESSAGE}" >/dev/null
+}
+
+publish_gotify() {
+  if [[ -z "${GOTIFY_TOKEN:-}" ]]; then
+    return 1
+  fi
+
+  local prio=5
+  case "$PRIORITY" in
+    min|low|1|2) prio=2 ;;
+    default|3) prio=5 ;;
+    high|4) prio=7 ;;
+    max|urgent|5) prio=9 ;;
+  esac
+
+  curl -fsS -X POST "${GOTIFY_BASE%/}/message?token=${GOTIFY_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -d "{\"title\":\"${TITLE}\",\"message\":\"${MESSAGE}\",\"priority\":${prio}}" >/dev/null
+}
+
+if publish_ntfy; then
+  echo "[OK] ntfy notification sent: ${TOPIC}"
+  exit 0
+fi
+
+if publish_gotify; then
+  echo "[OK] gotify notification sent: ${TOPIC}"
+  exit 0
+fi
+
+echo "[ERR] failed to publish notification to ntfy and gotify" >&2
+exit 1

--- a/stacks/notifications/README.md
+++ b/stacks/notifications/README.md
@@ -1,0 +1,79 @@
+# Notifications Stack
+
+This stack provides a unified notification center for HomeLab services.
+
+## Services
+
+- **ntfy** (`ntfy.${DOMAIN}`) - primary push notification server
+- **Gotify** (`gotify.${DOMAIN}`) - fallback/secondary push notification server
+- **Apprise** (`apprise.${DOMAIN}`) - optional outbound notification gateway
+
+## Start
+
+```bash
+./scripts/stack-manager.sh up notifications
+```
+
+## Unified notify script
+
+Use one script for all internal notification calls:
+
+```bash
+./scripts/notify.sh homelab-test "Test" "Hello World" high
+```
+
+Parameters:
+
+1. `topic` (e.g. `homelab-alerts`)
+2. `title`
+3. `message`
+4. `priority` (optional: `low|default|high|max`)
+
+## Integrations
+
+### Alertmanager -> ntfy
+
+Configure `config/alertmanager/alertmanager.yml` receiver to point to:
+
+```yaml
+receivers:
+  - name: ntfy
+    webhook_configs:
+      - url: 'https://ntfy.${DOMAIN}/homelab-alerts'
+        send_resolved: true
+```
+
+### Watchtower -> ntfy
+
+Set env in base stack (watchtower service):
+
+```env
+WATCHTOWER_NOTIFICATION_URL=ntfy://ntfy.${DOMAIN}/homelab-alerts
+```
+
+### Gitea -> ntfy
+
+Configure a webhook in Gitea repo settings:
+
+- Target URL: `https://ntfy.${DOMAIN}/gitea-events`
+- Method: `POST`
+
+### Home Assistant -> ntfy
+
+Add ntfy integration/notify target in Home Assistant:
+
+- Server: `https://ntfy.${DOMAIN}`
+- Topic: `homeassistant-events`
+
+### Uptime Kuma -> ntfy
+
+Create an ntfy notification channel:
+
+- Host: `https://ntfy.${DOMAIN}`
+- Topic: `uptime-alerts`
+
+## Health checks
+
+- ntfy: `https://ntfy.${DOMAIN}/v1/health`
+- gotify: `https://gotify.${DOMAIN}/health`
+- apprise: `https://apprise.${DOMAIN}/`

--- a/stacks/notifications/docker-compose.yml
+++ b/stacks/notifications/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ntfy-data:/var/lib/ntfy
       - ntfy-cache:/var/cache/ntfy
+      - ../../config/ntfy/server.yml:/etc/ntfy/server.yml:ro
     environment:
       - TZ=${TZ:-Asia/Shanghai}
     command: serve
@@ -23,6 +24,29 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+
+  gotify:
+    image: gotify/server:2.5.0
+    container_name: gotify
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - gotify-data:/app/data
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.gotify.rule=Host(`gotify.${DOMAIN}`)"
+      - traefik.http.routers.gotify.entrypoints=websecure
+      - traefik.http.routers.gotify.tls=true
+      - traefik.http.services.gotify.loadbalancer.server.port=80
+    healthcheck:
+      test: [CMD-SHELL, "wget -q -O- http://localhost:80/health | grep -q healthy || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   apprise:
     image: caronc/apprise:v1.1.6
@@ -54,4 +78,5 @@ networks:
 volumes:
   ntfy-data:
   ntfy-cache:
+  gotify-data:
   apprise-config:


### PR DESCRIPTION
Closes #13

## What I implemented
- Added `config/ntfy/server.yml` with required server options (`base-url`, `auth-default-access`, `behind-proxy`, `cache-file`, `auth-file`).
- Updated `stacks/notifications/docker-compose.yml`:
  - mounted ntfy config file
  - added **gotify** service (`gotify/server:2.5.0`) with traefik labels + healthcheck
  - kept apprise for optional outbound routing
- Added unified script: `scripts/notify.sh <topic> <title> <message> [priority]`
  - tries ntfy first
  - falls back to gotify when configured
- Updated `config/alertmanager/alertmanager.yml` with an `ntfy` receiver webhook (`https://ntfy.${DOMAIN}/homelab-alerts`).
- Added docs: `stacks/notifications/README.md` including integration notes for Alertmanager/Watchtower/Gitea/Home Assistant/Uptime Kuma.
- Extended `.env.example` notification section with `NTFY_BASE_URL`, `GOTIFY_BASE_URL`, `GOTIFY_TOKEN`, and `WATCHTOWER_NOTIFICATION_URL`.

## Validation
- YAML parsing validated for:
  - `stacks/notifications/docker-compose.yml`
  - `config/alertmanager/alertmanager.yml`
  - `config/ntfy/server.yml`

If you want, I can also add a lightweight CI check for `scripts/notify.sh --help` + yaml lint in a follow-up PR.