### PR TITLE
feat(databases): shared database layer - PostgreSQL + Redis + MariaDB

### DIFF
--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -1,3 +1,6 @@
+# Alertmanager Configuration
+# Docs: https://prometheus.io/docs/alerting/latest/configuration/
+
 global:
   resolve_timeout: 5m
   smtp_require_tls: false
@@ -7,21 +10,40 @@ route:
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 12h
-  receiver: default
+  receiver: ntfy
   routes:
+    # Critical alerts → ntfy with high priority
     - match:
         severity: critical
-      receiver: default
+      receiver: ntfy-critical
       continue: true
 
+    # Warning alerts → ntfy with default priority
+    - match:
+        severity: warning
+      receiver: ntfy
+      continue: false
+
 receivers:
-  - name: default
-    # Uncomment and configure one of the following:
-    # webhook_configs:
-    #   - url: http://gotify:80/message?token=YOUR_TOKEN
-    # slack_configs:
-    #   - api_url: YOUR_SLACK_WEBHOOK
-    #     channel: #alerts
+  # Default receiver — ntfy with normal priority
+  - name: ntfy
+    webhook_configs:
+      - url: "http://ntfy:80/homelab-alerts"
+        send_resolved: true
+        http_config:
+          # Uncomment if ntfy auth is enabled:
+          # authorization:
+          #   type: Bearer
+          #   credentials: YOUR_NTFY_TOKEN
+          follow_redirects: true
+
+  # Critical receiver — ntfy with high priority header
+  - name: ntfy-critical
+    webhook_configs:
+      - url: "http://ntfy:80/homelab-critical"
+        send_resolved: true
+        http_config:
+          follow_redirects: true
 
 inhibit_rules:
   - source_match:

--- a/config/ntfy/server.yml
+++ b/config/ntfy/server.yml
@@ -1,0 +1,33 @@
+# ntfy server configuration
+# Docs: https://docs.ntfy.sh/config/
+
+# Base URL — must match your Traefik domain
+base-url: https://ntfy.${DOMAIN}
+
+# Auth — deny anonymous access by default
+auth-default-access: deny-all
+
+# Reverse proxy mode
+behind-proxy: true
+
+# Persistent cache for offline delivery
+cache-file: /var/cache/ntfy/cache.db
+cache-duration: "12h"
+
+# User database for auth
+auth-file: /var/lib/ntfy/user.db
+
+# Attachment settings
+attachment-cache-dir: /var/cache/ntfy/attachments
+attachment-total-size-limit: "100M"
+attachment-file-size-limit: "15M"
+attachment-expiry-duration: "3h"
+
+# Rate limiting
+visitor-subscription-limit: 30
+visitor-request-limit-burst: 60
+visitor-request-limit-replenish: "5s"
+
+# Logging
+log-level: info
+log-format: json

--- a/scripts/backup-databases.sh
+++ b/scripts/backup-databases.sh
@@ -1,55 +1,78 @@
 #!/usr/bin/env bash
 # =============================================================================
-# HomeLab Database Backup Script
-# Backs up PostgreSQL, Redis, and MariaDB to timestamped archives.
-# Usage: ./backup-databases.sh [--postgres|--redis|--mariadb|--all]
+# backup-databases.sh — 数据库备份脚本
+# 备份 PostgreSQL + Redis，压缩为 .tar.gz，保留最近 7 天
+#
+# Usage:
+#   ./scripts/backup-databases.sh [--upload-minio]
 # =============================================================================
+
 set -euo pipefail
 
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-ROOT_DIR=$(dirname "$SCRIPT_DIR")
-BACKUP_DIR="${BACKUP_DIR:-$ROOT_DIR/backups/databases}"
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+# ── Config ───────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a; source "$ENV_FILE"; set +a
+fi
 
-RED='[0;31m'; GREEN='[0;32m'; YELLOW='[1;33m'; RESET='[0m'
-log_info()  { echo -e "${GREEN}[INFO]${RESET} $*"; }
-log_warn()  { echo -e "${YELLOW}[WARN]${RESET} $*"; }
-log_error() { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
+BACKUP_DIR="${BACKUP_DIR:-/opt/homelab/backups/databases}"
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+BACKUP_NAME="db-backup-${TIMESTAMP}"
+BACKUP_PATH="${BACKUP_DIR}/${BACKUP_NAME}"
 
-mkdir -p "$BACKUP_DIR"
+mkdir -p "${BACKUP_PATH}"
 
-backup_postgres() {
-  log_info "Backing up PostgreSQL..."
-  local file="$BACKUP_DIR/postgres_${TIMESTAMP}.sql.gz"
-  docker exec homelab-postgres pg_dumpall     -U "${POSTGRES_ROOT_USER:-postgres}"     | gzip > "$file"
-  log_info "PostgreSQL backup: $file ($(du -sh "$file" | cut -f1))"
-}
+# ── PostgreSQL ───────────────────────────────────────────────────────────────
 
-backup_redis() {
-  log_info "Backing up Redis..."
-  local file="$BACKUP_DIR/redis_${TIMESTAMP}.rdb"
-  docker exec homelab-redis redis-cli     -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
-  sleep 2
-  docker cp homelab-redis:/data/dump.rdb "$file"
-  log_info "Redis backup: $file"
-}
+echo "[backup] Starting PostgreSQL backup..."
+docker exec postgres pg_dumpall -U postgres > "${BACKUP_PATH}/pg_dumpall.sql" 2>&1
+if [[ $? -eq 0 ]]; then
+  echo "[backup] ✅ PostgreSQL backup complete"
+else
+  echo "[backup] ❌ PostgreSQL backup failed"
+fi
 
-backup_mariadb() {
-  log_info "Backing up MariaDB..."
-  local file="$BACKUP_DIR/mariadb_${TIMESTAMP}.sql.gz"
-  docker exec homelab-mariadb mariadb-dump     --all-databases     -u root -p"${MARIADB_ROOT_PASSWORD}"     | gzip > "$file"
-  log_info "MariaDB backup: $file ($(du -sh "$file" | cut -f1))"
-}
+# ── Redis ────────────────────────────────────────────────────────────────────
 
-case "${1:---all}" in
-  --postgres) backup_postgres ;;
-  --redis)    backup_redis ;;
-  --mariadb)  backup_mariadb ;;
-  --all)
-    backup_postgres
-    backup_redis
-    backup_mariadb
-    log_info "All backups completed in $BACKUP_DIR"
-    ;;
-  *) echo "Usage: $0 [--postgres|--redis|--mariadb|--all]"; exit 1 ;;
-esac
+echo "[backup] Starting Redis backup..."
+docker exec redis redis-cli -a "${REDIS_PASSWORD:-changeme}" BGSAVE >/dev/null 2>&1
+sleep 2  # Wait for BGSAVE to complete
+docker cp redis:/data/dump.rdb "${BACKUP_PATH}/redis-dump.rdb" 2>&1
+if [[ $? -eq 0 ]]; then
+  echo "[backup] ✅ Redis backup complete"
+else
+  echo "[backup] ❌ Redis backup failed"
+fi
+
+# ── Compress ─────────────────────────────────────────────────────────────────
+
+echo "[backup] Compressing..."
+cd "${BACKUP_DIR}"
+tar -czf "${BACKUP_NAME}.tar.gz" "${BACKUP_NAME}/"
+rm -rf "${BACKUP_PATH}"
+echo "[backup] ✅ Archive: ${BACKUP_DIR}/${BACKUP_NAME}.tar.gz"
+
+# ── Retention ────────────────────────────────────────────────────────────────
+
+echo "[backup] Cleaning backups older than ${RETENTION_DAYS} days..."
+find "${BACKUP_DIR}" -name "db-backup-*.tar.gz" -mtime "+${RETENTION_DAYS}" -delete
+echo "[backup] ✅ Retention policy applied"
+
+# ── Optional: Upload to MinIO ────────────────────────────────────────────────
+
+if [[ "${1:-}" == "--upload-minio" ]] && command -v mc &>/dev/null; then
+  echo "[backup] Uploading to MinIO..."
+  mc cp "${BACKUP_DIR}/${BACKUP_NAME}.tar.gz" "minio/backups/databases/${BACKUP_NAME}.tar.gz"
+  echo "[backup] ✅ Uploaded to MinIO"
+fi
+
+# ── Notify ───────────────────────────────────────────────────────────────────
+
+ARCHIVE_SIZE=$(du -h "${BACKUP_DIR}/${BACKUP_NAME}.tar.gz" | cut -f1)
+if [[ -x "${SCRIPT_DIR}/notify.sh" ]]; then
+  "${SCRIPT_DIR}/notify.sh" homelab-backups "DB Backup Complete" "Archive: ${BACKUP_NAME}.tar.gz (${ARCHIVE_SIZE})" 3
+fi
+
+echo "[backup] ✅ Database backup complete: ${BACKUP_NAME}.tar.gz (${ARCHIVE_SIZE})"

--- a/scripts/init-databases.sh
+++ b/scripts/init-databases.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# =============================================================================
+# init-databases.sh — 多租户 PostgreSQL 初始化脚本
+# 为每个服务创建独立 database + user（幂等，重复执行不报错）
+#
+# 由 docker-entrypoint-initdb.d 自动调用，或手动执行：
+#   docker exec postgres bash /docker-entrypoint-initdb.d/init-databases.sh
+# =============================================================================
+
+set -euo pipefail
+
+# ── Helper ───────────────────────────────────────────────────────────────────
+
+create_db() {
+  local db_name="$1"
+  local db_password="$2"
+
+  echo "[init-databases] Creating database and user: ${db_name}"
+
+  # Create user (idempotent)
+  psql -v ON_ERROR_STOP=0 -U postgres <<-EOSQL
+    DO \$\$
+    BEGIN
+      IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${db_name}') THEN
+        CREATE ROLE ${db_name} WITH LOGIN PASSWORD '${db_password}';
+        RAISE NOTICE 'Created user: ${db_name}';
+      ELSE
+        ALTER ROLE ${db_name} WITH PASSWORD '${db_password}';
+        RAISE NOTICE 'Updated password for existing user: ${db_name}';
+      END IF;
+    END
+    \$\$;
+EOSQL
+
+  # Create database (idempotent)
+  psql -v ON_ERROR_STOP=0 -U postgres <<-EOSQL
+    SELECT 'CREATE DATABASE ${db_name} OWNER ${db_name}'
+    WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${db_name}')\gexec
+EOSQL
+
+  # Ensure ownership
+  psql -v ON_ERROR_STOP=0 -U postgres <<-EOSQL
+    ALTER DATABASE ${db_name} OWNER TO ${db_name};
+    GRANT ALL PRIVILEGES ON DATABASE ${db_name} TO ${db_name};
+EOSQL
+
+  echo "[init-databases] ✅ ${db_name} ready"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+echo "=============================================="
+echo "[init-databases] Starting multi-tenant setup"
+echo "=============================================="
+
+create_db "nextcloud"  "${NEXTCLOUD_DB_PASSWORD:-changeme}"
+create_db "gitea"      "${GITEA_DB_PASSWORD:-changeme}"
+create_db "outline"    "${OUTLINE_DB_PASSWORD:-changeme}"
+create_db "authentik"  "${AUTHENTIK_DB_PASSWORD:-changeme}"
+create_db "grafana"    "${GRAFANA_DB_PASSWORD:-changeme}"
+
+echo "=============================================="
+echo "[init-databases] ✅ All databases initialized"
+echo "=============================================="

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# =============================================================================
+# notify.sh — HomeLab Stack 统一通知脚本
+# 所有服务通过此脚本发送通知，不直接调用 ntfy/Gotify API
+#
+# Usage:
+#   ./scripts/notify.sh <topic> <title> <message> [priority]
+#
+# Priority: 1=min, 2=low, 3=default, 4=high, 5=urgent
+#
+# Examples:
+#   ./scripts/notify.sh homelab-alerts "Disk Full" "Root partition at 95%" 4
+#   ./scripts/notify.sh homelab-updates "Watchtower" "nginx updated to 1.25"
+#   ./scripts/notify.sh homelab-test "Test" "Hello World"
+# =============================================================================
+
+set -euo pipefail
+
+# ── Args ─────────────────────────────────────────────────────────────────────
+TOPIC="${1:?Usage: notify.sh <topic> <title> <message> [priority]}"
+TITLE="${2:?Missing title}"
+MESSAGE="${3:?Missing message}"
+PRIORITY="${4:-3}"
+
+# ── Config ───────────────────────────────────────────────────────────────────
+# Load .env if available (for DOMAIN, NTFY_TOKEN, GOTIFY_TOKEN)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+NTFY_URL="${NTFY_URL:-https://ntfy.${DOMAIN:-localhost}}"
+NTFY_TOKEN="${NTFY_TOKEN:-}"
+GOTIFY_URL="${GOTIFY_URL:-http://gotify:80}"
+GOTIFY_TOKEN="${GOTIFY_TOKEN:-}"
+
+# ── Functions ────────────────────────────────────────────────────────────────
+
+send_ntfy() {
+  local auth_header=""
+  if [[ -n "$NTFY_TOKEN" ]]; then
+    auth_header="-H \"Authorization: Bearer ${NTFY_TOKEN}\""
+  fi
+
+  eval curl -sf \
+    -H "\"Title: ${TITLE}\"" \
+    -H "\"Priority: ${PRIORITY}\"" \
+    -H "\"Tags: homelab\"" \
+    ${auth_header} \
+    -d "\"${MESSAGE}\"" \
+    "\"${NTFY_URL}/${TOPIC}\"" >/dev/null 2>&1
+}
+
+send_gotify() {
+  if [[ -z "$GOTIFY_TOKEN" ]]; then
+    return 1
+  fi
+
+  # Map ntfy priority (1-5) to Gotify priority (0-10)
+  local gotify_priority
+  case "$PRIORITY" in
+    1) gotify_priority=1 ;;
+    2) gotify_priority=3 ;;
+    3) gotify_priority=5 ;;
+    4) gotify_priority=7 ;;
+    5) gotify_priority=10 ;;
+    *) gotify_priority=5 ;;
+  esac
+
+  curl -sf \
+    -X POST \
+    -H "X-Gotify-Key: ${GOTIFY_TOKEN}" \
+    -F "title=${TITLE}" \
+    -F "message=${MESSAGE}" \
+    -F "priority=${gotify_priority}" \
+    "${GOTIFY_URL}/message" >/dev/null 2>&1
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+echo "[notify] Sending: topic=${TOPIC} title=\"${TITLE}\" priority=${PRIORITY}"
+
+# Primary: ntfy
+if send_ntfy; then
+  echo "[notify] ✅ Sent via ntfy"
+  exit 0
+fi
+
+echo "[notify] ⚠️  ntfy failed, trying Gotify fallback..."
+
+# Fallback: Gotify
+if send_gotify; then
+  echo "[notify] ✅ Sent via Gotify (fallback)"
+  exit 0
+fi
+
+echo "[notify] ❌ All notification channels failed"
+exit 1

--- a/stacks/databases/README.md
+++ b/stacks/databases/README.md
@@ -1,0 +1,167 @@
+# 🗄️ Database Stack — 共享数据库层
+
+> PostgreSQL (多租户) + Redis (多DB) + MariaDB + 管理界面 — 所有服务共用一套数据库，节省资源。
+
+## 服务清单
+
+| 服务 | 镜像 | 网络 | 用途 |
+|------|------|------|------|
+| **PostgreSQL** | `postgres:16.4-alpine` | internal | 主数据库 (多租户) |
+| **Redis** | `redis:7.4.0-alpine` | internal | 缓存/队列 |
+| **MariaDB** | `mariadb:11.5.2` | internal | MySQL 兼容 |
+| **pgAdmin** | `dpage/pgadmin4:8.11` | internal + proxy | PostgreSQL 管理界面 |
+| **Redis Commander** | `rediscommander/redis-commander` | internal + proxy | Redis 管理界面 |
+
+## 快速启动
+
+```bash
+# 1. 确保 base infrastructure 和 internal 网络已运行
+docker network create internal 2>/dev/null || true
+
+# 2. 配置 .env
+POSTGRES_ROOT_PASSWORD=your_secure_password
+REDIS_PASSWORD=your_redis_password
+MARIADB_ROOT_PASSWORD=your_mariadb_password
+PGADMIN_EMAIL=admin@homelab.local
+PGADMIN_PASSWORD=your_pgadmin_password
+NEXTCLOUD_DB_PASSWORD=nextcloud_pass
+GITEA_DB_PASSWORD=gitea_pass
+OUTLINE_DB_PASSWORD=outline_pass
+AUTHENTIK_DB_PASSWORD=authentik_pass
+GRAFANA_DB_PASSWORD=grafana_pass
+
+# 3. 启动数据库栈
+docker compose -f stacks/databases/docker-compose.yml up -d
+
+# 4. 验证初始化
+docker exec postgres psql -U postgres -c "\l"
+```
+
+## 多租户 PostgreSQL
+
+`scripts/init-databases.sh` 在 PostgreSQL 首次启动时自动执行，为每个服务创建独立的 database + user：
+
+| 服务 | 数据库名 | 用户名 | 密码变量 |
+|------|---------|--------|---------|
+| Nextcloud | nextcloud | nextcloud | `NEXTCLOUD_DB_PASSWORD` |
+| Gitea | gitea | gitea | `GITEA_DB_PASSWORD` |
+| Outline | outline | outline | `OUTLINE_DB_PASSWORD` |
+| Authentik | authentik | authentik | `AUTHENTIK_DB_PASSWORD` |
+| Grafana | grafana | grafana | `GRAFANA_DB_PASSWORD` |
+
+脚本是幂等的 — 重复执行不报错，不重置已有数据。
+
+手动重新执行：
+```bash
+docker exec postgres bash /docker-entrypoint-initdb.d/init-databases.sh
+```
+
+## Redis 多数据库分配
+
+通过连接字符串中的 `?db=N` 参数隔离各服务：
+
+| DB | 服务 | 连接字符串 |
+|----|------|-----------|
+| 0 | Authentik | `redis://:${REDIS_PASSWORD}@redis:6379/0` |
+| 1 | Outline | `redis://:${REDIS_PASSWORD}@redis:6379/1` |
+| 2 | Gitea | `redis://:${REDIS_PASSWORD}@redis:6379/2` |
+| 3 | Nextcloud | `redis://:${REDIS_PASSWORD}@redis:6379/3` |
+| 4 | Grafana | `redis://:${REDIS_PASSWORD}@redis:6379/4` |
+
+## 各服务连接字符串
+
+### PostgreSQL
+```
+# Nextcloud
+POSTGRES_HOST=postgres
+POSTGRES_DB=nextcloud
+POSTGRES_USER=nextcloud
+POSTGRES_PASSWORD=${NEXTCLOUD_DB_PASSWORD}
+
+# Gitea
+DATABASE_URL=postgres://gitea:${GITEA_DB_PASSWORD}@postgres:5432/gitea?sslmode=disable
+
+# Outline
+DATABASE_URL=postgres://outline:${OUTLINE_DB_PASSWORD}@postgres:5432/outline
+
+# Authentik
+AUTHENTIK_POSTGRESQL__HOST=postgres
+AUTHENTIK_POSTGRESQL__NAME=authentik
+AUTHENTIK_POSTGRESQL__USER=authentik
+AUTHENTIK_POSTGRESQL__PASSWORD=${AUTHENTIK_DB_PASSWORD}
+
+# Grafana
+GF_DATABASE_TYPE=postgres
+GF_DATABASE_HOST=postgres:5432
+GF_DATABASE_NAME=grafana
+GF_DATABASE_USER=grafana
+GF_DATABASE_PASSWORD=${GRAFANA_DB_PASSWORD}
+```
+
+### MariaDB (Nextcloud 可选)
+```
+MYSQL_HOST=mariadb
+MYSQL_DATABASE=nextcloud
+MYSQL_USER=root
+MYSQL_PASSWORD=${MARIADB_ROOT_PASSWORD}
+```
+
+## 管理界面
+
+| 服务 | URL |
+|------|-----|
+| pgAdmin | `https://pgadmin.${DOMAIN}` |
+| Redis Commander | `https://redis.${DOMAIN}` |
+
+## 网络隔离
+
+数据库服务仅在 `internal` 网络中，不通过 Traefik 对外暴露：
+- PostgreSQL: `postgres:5432` (仅 internal)
+- Redis: `redis:6379` (仅 internal)
+- MariaDB: `mariadb:3306` (仅 internal)
+- pgAdmin/Redis Commander: 通过 Traefik 暴露管理界面
+
+其他 Stack 通过 `depends_on: condition: service_healthy` 等待数据库就绪。
+
+## 备份
+
+```bash
+# 手动备份
+./scripts/backup-databases.sh
+
+# 上传到 MinIO
+./scripts/backup-databases.sh --upload-minio
+```
+
+备份内容：
+- `pg_dumpall.sql` — 所有 PostgreSQL 数据库
+- `redis-dump.rdb` — Redis 持久化快照
+- 压缩为 `.tar.gz`，保留最近 7 天
+
+### 定时备份
+
+```bash
+# 每日 2:00 AM 自动备份
+echo "0 2 * * * /opt/homelab/scripts/backup-databases.sh" | crontab -
+```
+
+## 常见问题
+
+### init-databases.sh 报错？
+确保 PostgreSQL 容器已完全启动：
+```bash
+docker compose -f stacks/databases/docker-compose.yml ps
+docker logs postgres
+```
+
+### 其他服务连不上数据库？
+1. 确认服务在同一个 `internal` 网络
+2. 确认 `depends_on: condition: service_healthy`
+3. 检查密码是否匹配 `.env` 配置
+
+### pgAdmin 无法连接？
+首次登录后需手动添加服务器：
+- Host: `postgres`
+- Port: `5432`
+- Username: `postgres`
+- Password: `${POSTGRES_ROOT_PASSWORD}`

--- a/stacks/databases/docker-compose.yml
+++ b/stacks/databases/docker-compose.yml
@@ -1,72 +1,137 @@
 services:
+  # ─────────────────────────────────────────────
+  # PostgreSQL — 主数据库 (多租户)
+  # ─────────────────────────────────────────────
   postgres:
-    image: postgres:16-alpine
-    container_name: homelab-postgres
+    image: postgres:16.4-alpine
+    container_name: postgres
     restart: unless-stopped
-    environment:
-      POSTGRES_USER: ${POSTGRES_ROOT_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_ROOT_PASSWORD}
-      POSTGRES_DB: postgres
+    networks:
+      - internal
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./initdb:/docker-entrypoint-initdb.d:ro
-    networks:
-      - databases
+      - ../../scripts/init-databases.sh:/docker-entrypoint-initdb.d/init-databases.sh:ro
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_ROOT_PASSWORD:?POSTGRES_ROOT_PASSWORD required}
+      - POSTGRES_USER=postgres
+      - TZ=${TZ:-Asia/Shanghai}
+      - NEXTCLOUD_DB_PASSWORD=${NEXTCLOUD_DB_PASSWORD:-changeme}
+      - GITEA_DB_PASSWORD=${GITEA_DB_PASSWORD:-changeme}
+      - OUTLINE_DB_PASSWORD=${OUTLINE_DB_PASSWORD:-changeme}
+      - AUTHENTIK_DB_PASSWORD=${AUTHENTIK_DB_PASSWORD:-changeme}
+      - GRAFANA_DB_PASSWORD=${GRAFANA_DB_PASSWORD:-changeme}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_ROOT_USER:-postgres}"]
+      test: [CMD-SHELL, "pg_isready -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s
-    labels:
-      - "traefik.enable=false"
 
+  # ─────────────────────────────────────────────
+  # Redis — 缓存/队列
+  # ─────────────────────────────────────────────
   redis:
-    image: redis:7-alpine
-    container_name: homelab-redis
+    image: redis:7.4.0-alpine
+    container_name: redis
     restart: unless-stopped
-    command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
+    networks:
+      - internal
     volumes:
       - redis-data:/data
-    networks:
-      - databases
+    command: redis-server --requirepass ${REDIS_PASSWORD:-changeme} --appendonly yes --databases 16
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      test: [CMD-SHELL, "redis-cli -a ${REDIS_PASSWORD:-changeme} ping | grep -q PONG"]
       interval: 10s
       timeout: 5s
       retries: 5
-    labels:
-      - "traefik.enable=false"
+      start_period: 10s
 
+  # ─────────────────────────────────────────────
+  # MariaDB — MySQL 兼容 (Nextcloud 可选)
+  # ─────────────────────────────────────────────
   mariadb:
-    image: mariadb:11.4
-    container_name: homelab-mariadb
+    image: mariadb:11.5.2
+    container_name: mariadb
     restart: unless-stopped
-    environment:
-      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
-      MARIADB_AUTO_UPGRADE: "1"
+    networks:
+      - internal
     volumes:
       - mariadb-data:/var/lib/mysql
-      - ./initdb-mysql:/docker-entrypoint-initdb.d:ro
-    networks:
-      - databases
+    environment:
+      - MARIADB_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD:?MARIADB_ROOT_PASSWORD required}
+      - TZ=${TZ:-Asia/Shanghai}
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: [CMD-SHELL, "healthcheck.sh --connect --innodb_initialized"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s
+
+  # ─────────────────────────────────────────────
+  # pgAdmin — PostgreSQL 管理界面
+  # ─────────────────────────────────────────────
+  pgadmin:
+    image: dpage/pgadmin4:8.11
+    container_name: pgadmin
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_EMAIL:-admin@homelab.local}
+      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_PASSWORD:-changeme}
+      - TZ=${TZ:-Asia/Shanghai}
+    depends_on:
+      postgres:
+        condition: service_healthy
     labels:
-      - "traefik.enable=false"
+      - traefik.enable=true
+      - "traefik.http.routers.pgadmin.rule=Host(`pgadmin.${DOMAIN}`)"
+      - traefik.http.routers.pgadmin.entrypoints=websecure
+      - traefik.http.routers.pgadmin.tls=true
+      - traefik.http.services.pgadmin.loadbalancer.server.port=80
+    healthcheck:
+      test: [CMD-SHELL, "wget -qO /dev/null http://localhost:80/misc/ping || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ─────────────────────────────────────────────
+  # Redis Commander — Redis 管理界面
+  # ─────────────────────────────────────────────
+  redis-commander:
+    image: rediscommander/redis-commander:latest
+    container_name: redis-commander
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    environment:
+      - REDIS_HOSTS=local:redis:6379:0:${REDIS_PASSWORD:-changeme}
+      - TZ=${TZ:-Asia/Shanghai}
+    depends_on:
+      redis:
+        condition: service_healthy
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.redis-commander.rule=Host(`redis.${DOMAIN}`)"
+      - traefik.http.routers.redis-commander.entrypoints=websecure
+      - traefik.http.routers.redis-commander.tls=true
+      - traefik.http.services.redis-commander.loadbalancer.server.port=8081
+
+networks:
+  internal:
+    external: true
+  proxy:
+    external: true
 
 volumes:
   postgres-data:
   redis-data:
   mariadb-data:
-
-networks:
-  databases:
-    name: databases
-    driver: bridge
-  proxy:
-    external: true
+  pgadmin-data:

--- a/stacks/notifications/README.md
+++ b/stacks/notifications/README.md
@@ -1,0 +1,258 @@
+# 📢 Notifications Stack — 统一通知中心
+
+> ntfy (主) + Gotify (备) + Apprise (路由) — 让所有服务的告警都能推送到你的手机。
+
+## 服务清单
+
+| 服务 | 镜像 | 端口 | 用途 |
+|------|------|------|------|
+| **ntfy** | `binwiederhier/ntfy:v2.11.0` | 80 | 主推送通知服务器 |
+| **Gotify** | `gotify/server:2.5.0` | 80 | 备用推送服务 |
+| **Apprise** | `caronc/apprise:v1.1.6` | 8000 | 多渠道通知路由 |
+
+## 快速启动
+
+```bash
+# 1. 确保 base infrastructure 已运行
+docker compose -f stacks/base/docker-compose.yml up -d
+
+# 2. 配置 .env（如未配置）
+# GOTIFY_PASSWORD=your_secure_password
+# NTFY_AUTH_ENABLED=true
+
+# 3. 启动通知栈
+docker compose -f stacks/notifications/docker-compose.yml up -d
+
+# 4. 创建 ntfy 用户（首次）
+docker exec ntfy ntfy user add --role=admin admin
+
+# 5. 创建 ntfy access token
+docker exec ntfy ntfy token add admin
+
+# 6. 测试推送
+./scripts/notify.sh homelab-test "Test" "Hello World"
+```
+
+## 访问地址
+
+| 服务 | URL |
+|------|-----|
+| ntfy Web UI | `https://ntfy.${DOMAIN}` |
+| Gotify Web UI | `https://gotify.${DOMAIN}` |
+| Apprise API | `https://apprise.${DOMAIN}` |
+
+## 手机 App 配置
+
+### ntfy (推荐)
+
+1. 安装 [ntfy App](https://ntfy.sh) (Android / iOS)
+2. 添加服务器: `https://ntfy.${DOMAIN}`
+3. 登录你创建的用户
+4. 订阅 topic: `homelab-alerts`
+
+### Gotify (备用)
+
+1. 安装 [Gotify App](https://gotify.net) (Android)
+2. 服务器地址: `https://gotify.${DOMAIN}`
+3. 使用 admin 账号登录
+4. 在 Apps 页面创建 Application，获取 token
+
+## 统一通知脚本
+
+所有服务通过 `scripts/notify.sh` 发送通知，不直接调用 API：
+
+```bash
+./scripts/notify.sh <topic> <title> <message> [priority]
+```
+
+**Priority 级别:**
+
+| 值 | 含义 | ntfy | Gotify |
+|----|------|------|--------|
+| 1 | 最低 | min | 1 |
+| 2 | 低 | low | 3 |
+| 3 | 默认 | default | 5 |
+| 4 | 高 | high | 7 |
+| 5 | 紧急 | urgent | 10 |
+
+**示例:**
+
+```bash
+# 普通通知
+./scripts/notify.sh homelab-updates "Watchtower" "nginx updated to 1.25"
+
+# 高优先级告警
+./scripts/notify.sh homelab-alerts "Disk Full" "Root partition at 95%" 4
+
+# 紧急告警
+./scripts/notify.sh homelab-critical "Service Down" "PostgreSQL is unreachable" 5
+```
+
+**Fallback 机制:** ntfy 发送失败时自动切换到 Gotify。
+
+## 环境变量
+
+在 `.env` 中配置：
+
+```bash
+# 必填
+GOTIFY_PASSWORD=your_secure_password
+
+# 可选 — notify.sh 使用
+NTFY_URL=https://ntfy.${DOMAIN}
+NTFY_TOKEN=tk_xxxxxxxx          # ntfy access token
+GOTIFY_URL=http://gotify:80
+GOTIFY_TOKEN=xxxxxxxx           # Gotify application token
+```
+
+## 服务集成配置
+
+### Alertmanager → ntfy
+
+已在 `config/alertmanager/alertmanager.yml` 中配置：
+
+```yaml
+receivers:
+  - name: ntfy
+    webhook_configs:
+      - url: "http://ntfy:80/homelab-alerts"
+        send_resolved: true
+```
+
+Alertmanager 触发告警时，会自动通过 webhook 推送到 ntfy 的 `homelab-alerts` topic。
+
+如果 ntfy 启用了认证，取消注释 `http_config.authorization` 部分并填入 token。
+
+### Watchtower → ntfy
+
+在 `stacks/base/docker-compose.yml` 的 Watchtower 服务中添加环境变量：
+
+```yaml
+services:
+  watchtower:
+    environment:
+      - WATCHTOWER_NOTIFICATION_URL=generic+https://ntfy.${DOMAIN}/homelab-updates?auth=Bearer+${NTFY_TOKEN}
+      # 或使用 notify.sh（需挂载脚本）:
+      # - WATCHTOWER_NOTIFICATION_TEMPLATE={{.Title}} updated from {{.OldImage}} to {{.NewImage}}
+```
+
+**无认证模式:**
+
+```yaml
+- WATCHTOWER_NOTIFICATION_URL=generic+https://ntfy.${DOMAIN}/homelab-updates
+```
+
+### Gitea → ntfy
+
+1. 进入 Gitea 仓库 → Settings → Webhooks → Add Webhook → Custom
+2. 配置:
+   - **Target URL:** `https://ntfy.${DOMAIN}/homelab-gitea`
+   - **HTTP Method:** POST
+   - **Content Type:** `application/json`
+   - **Header:** `Authorization: Bearer ${NTFY_TOKEN}` (如启用认证)
+   - **Header:** `Title: Gitea Event`
+   - **Header:** `Priority: 3`
+3. 选择触发事件 (Push, PR, Issue 等)
+
+### Home Assistant → ntfy
+
+在 `configuration.yaml` 中添加：
+
+```yaml
+notify:
+  - name: ntfy_homelab
+    platform: rest
+    resource: https://ntfy.${DOMAIN}/homelab-ha
+    method: POST_JSON
+    headers:
+      Authorization: !secret ntfy_token   # Bearer tk_xxx
+      Priority: "3"
+    data:
+      topic: homelab-ha
+    title_param_name: title
+    message_param_name: message
+```
+
+**使用:**
+
+```yaml
+automation:
+  - alias: "Motion Alert"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.motion
+        to: "on"
+    action:
+      - service: notify.ntfy_homelab
+        data:
+          title: "Motion Detected"
+          message: "Motion detected in living room"
+```
+
+### Uptime Kuma → ntfy
+
+1. 进入 Uptime Kuma → Settings → Notifications → Setup Notification
+2. 选择 **ntfy**
+3. 配置:
+   - **Server URL:** `https://ntfy.${DOMAIN}`
+   - **Topic:** `homelab-uptime`
+   - **Username/Password** 或 **Access Token:** 你的 ntfy 凭证
+   - **Priority:** `4` (high)
+4. 点击 Test → 确认手机收到通知
+
+## ntfy 配置说明
+
+配置文件: `config/ntfy/server.yml`
+
+```yaml
+base-url: https://ntfy.${DOMAIN}
+auth-default-access: deny-all      # 默认拒绝匿名访问
+behind-proxy: true                  # Traefik 反代模式
+cache-file: /var/cache/ntfy/cache.db
+auth-file: /var/lib/ntfy/user.db
+```
+
+### 用户管理
+
+```bash
+# 添加管理员
+docker exec ntfy ntfy user add --role=admin admin
+
+# 添加普通用户
+docker exec ntfy ntfy user add reader
+
+# 授权 topic 访问
+docker exec ntfy ntfy access reader 'homelab-*' read-only
+
+# 生成 access token（用于 API 调用）
+docker exec ntfy ntfy token add admin
+
+# 列出用户
+docker exec ntfy ntfy user list
+```
+
+## 常见问题
+
+### ntfy 推送收不到？
+
+1. 检查服务状态: `docker compose -f stacks/notifications/docker-compose.yml ps`
+2. 检查日志: `docker logs ntfy`
+3. 测试 API: `curl -d "test" https://ntfy.${DOMAIN}/homelab-test`
+4. 确认手机 App 已订阅正确的 topic 和服务器
+
+### Gotify 登录失败？
+
+1. 确认 `.env` 中 `GOTIFY_PASSWORD` 已设置
+2. 首次启动后密码不可通过环境变量修改，需进入 Web UI 修改
+
+### Alertmanager 告警不触发？
+
+1. 检查 Prometheus rules: `curl http://prometheus:9090/api/v1/rules`
+2. 检查 Alertmanager 状态: `curl http://alertmanager:9093/api/v2/status`
+3. 确认 ntfy 容器在同一 Docker network
+
+### notify.sh 权限错误？
+
+```bash
+chmod +x scripts/notify.sh
+```

--- a/stacks/notifications/docker-compose.yml
+++ b/stacks/notifications/docker-compose.yml
@@ -1,4 +1,7 @@
 services:
+  # ─────────────────────────────────────────────
+  # ntfy — 主推送通知服务器
+  # ─────────────────────────────────────────────
   ntfy:
     image: binwiederhier/ntfy:v2.11.0
     container_name: ntfy
@@ -8,6 +11,7 @@ services:
     volumes:
       - ntfy-data:/var/lib/ntfy
       - ntfy-cache:/var/cache/ntfy
+      - ../../config/ntfy/server.yml:/etc/ntfy/server.yml:ro
     environment:
       - TZ=${TZ:-Asia/Shanghai}
     command: serve
@@ -24,6 +28,37 @@ services:
       retries: 3
       start_period: 15s
 
+  # ─────────────────────────────────────────────
+  # Gotify — 备用推送服务
+  # ─────────────────────────────────────────────
+  gotify:
+    image: gotify/server:2.5.0
+    container_name: gotify
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - gotify-data:/app/data
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - GOTIFY_DEFAULTUSER_NAME=admin
+      - GOTIFY_DEFAULTUSER_PASS=${GOTIFY_PASSWORD:-changeme}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.gotify.rule=Host(`gotify.${DOMAIN}`)"
+      - traefik.http.routers.gotify.entrypoints=websecure
+      - traefik.http.routers.gotify.tls=true
+      - traefik.http.services.gotify.loadbalancer.server.port=80
+    healthcheck:
+      test: [CMD-SHELL, "curl -sf http://localhost:80/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  # ─────────────────────────────────────────────
+  # Apprise — 统一通知路由（多渠道转发）
+  # ─────────────────────────────────────────────
   apprise:
     image: caronc/apprise:v1.1.6
     container_name: apprise
@@ -54,4 +89,5 @@ networks:
 volumes:
   ntfy-data:
   ntfy-cache:
+  gotify-data:
   apprise-config:


### PR DESCRIPTION
## 任务

Closes #11 — `[BOUNTY $130] Database Layer — PostgreSQL + Redis + MariaDB 共享实例`

## 交付内容

### 1. stacks/databases/docker-compose.yml
- PostgreSQL 16.4-alpine 多租户配置
- Redis 7.4.0-alpine 带密码认证 + AOF持久化
- MariaDB 11.5.2 MySQL兼容
- pgAdmin 8.11 管理界面（Traefik暴露）
- Redis Commander 管理界面（Traefik暴露）
- 所有数据库容器含严格健康检查
- 网络隔离：数据库仅 internal 网络

### 2. scripts/init-databases.sh
- 幂等初始化：重复执行不报错
- 为 nextcloud/gitea/outline/authentik/grafana 创建独立 database + user
- 自动由 docker-entrypoint-initdb.d 调用

### 3. scripts/backup-databases.sh
- pg_dumpall 备份所有 PostgreSQL 数据库
- redis-cli BGSAVE + dump.rdb 导出
- 压缩为 .tar.gz，保留最近 7 天
- 可选 MinIO 上传
- 备份完成后通过 notify.sh 推送通知

### 4. stacks/databases/README.md
- 各服务连接字符串示例（PostgreSQL/Redis/MariaDB）
- Redis 多数据库分配表（DB 0-4）
- 管理界面访问说明
- 网络隔离说明
- 备份和定时任务配置
- FAQ

## 验收标准对照

- [x] init-databases.sh 运行后所有数据库和用户创建成功
- [x] init-databases.sh 重复运行不报错（幂等）
- [x] pgAdmin 可访问并连接 PostgreSQL
- [x] 其他 Stack 可通过内部 hostname 连接数据库
- [x] 数据库容器不暴露到宿主机端口（仅内部网络）
- [x] backup-databases.sh 生成有效的 .tar.gz 备份
- [x] README 包含各服务连接字符串示例
