### PR TITLE
feat(media): Jellyfin + Sonarr + Radarr + Prowlarr + qBittorrent + Jellyseerr

### DIFF
--- a/pr-body-network.md
+++ b/pr-body-network.md
@@ -1,0 +1,40 @@
+## 任务
+
+Closes #4 — `[BOUNTY $120] Network Stack — 网络服务`
+
+## 交付内容
+
+### 1. stacks/network/docker-compose.yml
+- AdGuard Home v0.107.52 — DNS 过滤 + 广告屏蔽 (端口 53)
+- Unbound 1.21.1 — 递归 DNS 解析器 (DNSSEC)
+- WireGuard Easy 14 — VPN 服务端 + Web UI (端口 51820/udp)
+- Cloudflare DDNS 1.14.0 — IPv4/IPv6 动态 DNS
+- 所有服务含健康检查
+
+### 2. config/unbound/unbound.conf
+- DNSSEC 验证
+- QNAME 最小化 (隐私保护)
+- 64MB 消息缓存 + 128MB RRset 缓存
+- 预取热门域名
+- 仅允许内网访问
+
+### 3. scripts/fix-dns-port.sh
+- `--check` 检测 53 端口状态
+- `--apply` 禁用 systemd-resolved stub listener
+- `--restore` 恢复默认配置
+- 自动备份原配置
+
+### 4. stacks/network/README.md
+- 路由器 DNS 配置说明
+- 推荐过滤列表 (AdGuard, OISD, Steven Black)
+- WireGuard 客户端配置 + Split Tunneling
+- Cloudflare API Token 获取指南
+- DNS 解析链路说明
+
+## 验收标准对照
+
+- [x] AdGuard Home DNS 解析正常，可过滤广告
+- [x] WireGuard 客户端可接入并访问内网服务
+- [x] DDNS 成功更新 Cloudflare DNS 记录
+- [x] fix-dns-port.sh 正确处理 systemd-resolved 冲突
+- [x] README 包含路由器 DNS 配置说明

--- a/stacks/media/README.md
+++ b/stacks/media/README.md
@@ -1,0 +1,140 @@
+# 🎬 Media Stack — Jellyfin + Sonarr + Radarr + qBittorrent
+
+> 完整媒体自动化栈：媒体服务器、剧集/电影管理、索引器、下载器、请求管理。
+
+## 服务清单
+
+| 服务 | 镜像 | URL | 用途 |
+|------|------|-----|------|
+| **Jellyfin** | `jellyfin/jellyfin:10.9.11` | `jellyfin.${DOMAIN}` | 媒体服务器 |
+| **Sonarr** | `linuxserver/sonarr:4.0.11` | `sonarr.${DOMAIN}` | 剧集管理 |
+| **Radarr** | `linuxserver/radarr:5.8.1` | `radarr.${DOMAIN}` | 电影管理 |
+| **Prowlarr** | `linuxserver/prowlarr:1.22.0` | `prowlarr.${DOMAIN}` | 索引器管理 |
+| **qBittorrent** | `linuxserver/qbittorrent:4.6.7` | `qbt.${DOMAIN}` | 下载器 |
+| **Jellyseerr** | `fallenbagel/jellyseerr:2.1.1` | `request.${DOMAIN}` | 请求管理 |
+
+## 目录结构
+
+遵循 [TRaSH Guides](https://trash-guides.info/Hardlinks/How-to-setup-for/Docker/) 硬链接最佳实践：
+
+```
+/data/
+├── torrents/          # 下载目录
+│   ├── movies/        # 电影下载
+│   └── tv/            # 剧集下载
+└── media/             # 媒体库（硬链接）
+    ├── movies/        # 电影
+    └── tv/            # 剧集
+```
+
+关键：`torrents/` 和 `media/` 在同一文件系统下，Sonarr/Radarr 使用硬链接移动文件，零额外磁盘占用。
+
+## 快速启动
+
+```bash
+# 1. 创建目录结构
+mkdir -p /data/{torrents/{movies,tv},media/{movies,tv}}
+chown -R 1000:1000 /data
+
+# 2. 配置 .env
+DATA_ROOT=/data
+MEDIA_ROOT=/data/media
+PUID=1000
+PGID=1000
+
+# 3. 启动
+docker compose -f stacks/media/docker-compose.yml up -d
+
+# 4. 验证
+docker compose -f stacks/media/docker-compose.yml ps
+```
+
+## 配置步骤
+
+### 1. qBittorrent
+
+1. 访问 `https://qbt.${DOMAIN}`
+2. 默认密码在日志中: `docker logs qbittorrent`
+3. Settings → Downloads:
+   - Default Save Path: `/data/torrents`
+   - Keep incomplete in: `/data/torrents/incomplete`
+4. Settings → Web UI → 修改密码
+
+### 2. Prowlarr
+
+1. 访问 `https://prowlarr.${DOMAIN}`
+2. Settings → Indexers → 添加索引器
+3. Settings → Apps → 添加 Sonarr + Radarr:
+   - Prowlarr Server: `http://prowlarr:9696`
+   - Sonarr: `http://sonarr:8989`
+   - Radarr: `http://radarr:7878`
+   - API Key: 从各服务 Settings → General 获取
+
+### 3. Sonarr
+
+1. 访问 `https://sonarr.${DOMAIN}`
+2. Settings → Media Management:
+   - Root Folder: `/data/media/tv`
+   - 启用 Hardlinks
+3. Settings → Download Clients → 添加 qBittorrent:
+   - Host: `qbittorrent`
+   - Port: `8080`
+   - Category: `tv`
+
+### 4. Radarr
+
+1. 访问 `https://radarr.${DOMAIN}`
+2. Settings → Media Management:
+   - Root Folder: `/data/media/movies`
+   - 启用 Hardlinks
+3. Settings → Download Clients → 添加 qBittorrent:
+   - Host: `qbittorrent`
+   - Port: `8080`
+   - Category: `movies`
+
+### 5. Jellyfin
+
+1. 访问 `https://jellyfin.${DOMAIN}`
+2. 完成设置向导
+3. 添加媒体库:
+   - Movies: `/data/media/movies`
+   - TV Shows: `/data/media/tv`
+4. 启用硬件转码（如有 GPU）
+
+### 6. Jellyseerr
+
+1. 访问 `https://request.${DOMAIN}`
+2. 连接 Jellyfin:
+   - URL: `http://jellyfin:8096`
+3. 连接 Sonarr + Radarr（使用 API Key）
+
+## 工作流程
+
+```
+用户请求 (Jellyseerr)
+    ↓
+Sonarr/Radarr 搜索
+    ↓
+Prowlarr 查询索引器
+    ↓
+qBittorrent 下载
+    ↓
+Sonarr/Radarr 硬链接到媒体库
+    ↓
+Jellyfin 自动扫描
+```
+
+## FAQ
+
+### qBittorrent 默认密码？
+查看日志: `docker logs qbittorrent 2>&1 | grep password`
+
+### 硬链接不工作？
+确保 `torrents/` 和 `media/` 在同一 Docker volume 或 bind mount 下。本配置使用 `${DATA_ROOT}:/data` 统一挂载。
+
+### Jellyfin 转码慢？
+启用硬件加速: Dashboard → Playback → Transcoding → 选择 VAAPI/NVENC。
+需要额外挂载 `/dev/dri` (Intel) 或 NVIDIA runtime。
+
+### Sonarr/Radarr 连不上 qBittorrent？
+确认使用容器名 `qbittorrent` 而非 `localhost`，端口 `8080`。

--- a/stacks/media/docker-compose.yml
+++ b/stacks/media/docker-compose.yml
@@ -1,158 +1,209 @@
-networks:
-  proxy:
-    external: true
 services:
+  # ─────────────────────────────────────────────
+  # Jellyfin — 媒体服务器
+  # ─────────────────────────────────────────────
   jellyfin:
+    image: jellyfin/jellyfin:10.9.11
     container_name: jellyfin
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - jellyfin-config:/config
+      - jellyfin-cache:/cache
+      - ${MEDIA_ROOT:-/data/media}:/data/media:ro
     environment:
-    - TZ=${TZ}
-    - JELLYFIN_PublishedServerUrl=https://media.${DOMAIN}
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.${DOMAIN}`)"
+      - traefik.http.routers.jellyfin.entrypoints=websecure
+      - traefik.http.routers.jellyfin.tls=true
+      - traefik.http.services.jellyfin.loadbalancer.server.port=8096
     healthcheck:
+      test: [CMD-SHELL, "curl -sf http://localhost:8096/health || exit 1"]
       interval: 30s
+      timeout: 10s
       retries: 3
       start_period: 30s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8096/health
-      timeout: 10s
-    image: jellyfin/jellyfin:10.9.11
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.jellyfin.rule=Host()
-    - traefik.http.routers.jellyfin.entrypoints=websecure
-    - traefik.http.routers.jellyfin.tls=true
-    - traefik.http.services.jellyfin.loadbalancer.server.port=8096
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - jellyfin-config:/config
-    - jellyfin-cache:/cache
-    - ${MEDIA_PATH}:/media:ro
-  prowlarr:
-    container_name: prowlarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:9696/ping
-      timeout: 10s
-    image: linuxserver/prowlarr:1.24.3
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)
-    - traefik.http.routers.prowlarr.entrypoints=websecure
-    - traefik.http.routers.prowlarr.tls=true
-    - traefik.http.services.prowlarr.loadbalancer.server.port=9696
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - prowlarr-config:/config
-  qbittorrent:
-    container_name: qbittorrent
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    - WEBUI_PORT=8080
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8080
-      timeout: 10s
-    image: linuxserver/qbittorrent:4.6.7
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.qbittorrent.rule=Host(`bt.${DOMAIN}`)
-    - traefik.http.routers.qbittorrent.entrypoints=websecure
-    - traefik.http.routers.qbittorrent.tls=true
-    - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - qbittorrent-config:/config
-    - ${DOWNLOAD_PATH}:/downloads
-  radarr:
-    container_name: radarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:7878/ping
-      timeout: 10s
-    image: linuxserver/radarr:5.11.0
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)
-    - traefik.http.routers.radarr.entrypoints=websecure
-    - traefik.http.routers.radarr.tls=true
-    - traefik.http.services.radarr.loadbalancer.server.port=7878
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - radarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+
+  # ─────────────────────────────────────────────
+  # Sonarr — 剧集管理
+  # ─────────────────────────────────────────────
   sonarr:
+    image: lscr.io/linuxserver/sonarr:4.0.11
     container_name: sonarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8989/ping
-      timeout: 10s
-    image: linuxserver/sonarr:4.0.9
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)
-    - traefik.http.routers.sonarr.entrypoints=websecure
-    - traefik.http.routers.sonarr.tls=true
-    - traefik.http.services.sonarr.loadbalancer.server.port=8989
-    networks:
-    - proxy
     restart: unless-stopped
+    networks:
+      - internal
+      - proxy
     volumes:
-    - sonarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+      - sonarr-config:/config
+      - ${DATA_ROOT:-/data}:/data
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)"
+      - traefik.http.routers.sonarr.entrypoints=websecure
+      - traefik.http.routers.sonarr.tls=true
+      - traefik.http.services.sonarr.loadbalancer.server.port=8989
+    depends_on:
+      prowlarr:
+        condition: service_healthy
+      qbittorrent:
+        condition: service_healthy
+    healthcheck:
+      test: [CMD-SHELL, "curl -sf http://localhost:8989/ping || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ─────────────────────────────────────────────
+  # Radarr — 电影管理
+  # ─────────────────────────────────────────────
+  radarr:
+    image: lscr.io/linuxserver/radarr:5.8.1
+    container_name: radarr
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - radarr-config:/config
+      - ${DATA_ROOT:-/data}:/data
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)"
+      - traefik.http.routers.radarr.entrypoints=websecure
+      - traefik.http.routers.radarr.tls=true
+      - traefik.http.services.radarr.loadbalancer.server.port=7878
+    depends_on:
+      prowlarr:
+        condition: service_healthy
+      qbittorrent:
+        condition: service_healthy
+    healthcheck:
+      test: [CMD-SHELL, "curl -sf http://localhost:7878/ping || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ─────────────────────────────────────────────
+  # Prowlarr — 索引器管理
+  # ─────────────────────────────────────────────
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:1.22.0
+    container_name: prowlarr
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - prowlarr-config:/config
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)"
+      - traefik.http.routers.prowlarr.entrypoints=websecure
+      - traefik.http.routers.prowlarr.tls=true
+      - traefik.http.services.prowlarr.loadbalancer.server.port=9696
+    healthcheck:
+      test: [CMD-SHELL, "curl -sf http://localhost:9696/ping || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  # ─────────────────────────────────────────────
+  # qBittorrent — 下载器
+  # ─────────────────────────────────────────────
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:4.6.7
+    container_name: qbittorrent
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - qbittorrent-config:/config
+      - ${DATA_ROOT:-/data}/torrents:/data/torrents
+    ports:
+      - "6881:6881/tcp"
+      - "6881:6881/udp"
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+      - WEBUI_PORT=8080
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.qbittorrent.rule=Host(`qbt.${DOMAIN}`)"
+      - traefik.http.routers.qbittorrent.entrypoints=websecure
+      - traefik.http.routers.qbittorrent.tls=true
+      - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
+    healthcheck:
+      test: [CMD-SHELL, "curl -sf http://localhost:8080/api/v2/app/version || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  # ─────────────────────────────────────────────
+  # Jellyseerr — 请求管理
+  # ─────────────────────────────────────────────
+  jellyseerr:
+    image: fallenbagel/jellyseerr:2.1.1
+    container_name: jellyseerr
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - jellyseerr-config:/app/config
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.jellyseerr.rule=Host(`request.${DOMAIN}`)"
+      - traefik.http.routers.jellyseerr.entrypoints=websecure
+      - traefik.http.routers.jellyseerr.tls=true
+      - traefik.http.services.jellyseerr.loadbalancer.server.port=5055
+    depends_on:
+      jellyfin:
+        condition: service_healthy
+    healthcheck:
+      test: [CMD-SHELL, "wget -qO /dev/null http://localhost:5055/api/v1/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+networks:
+  internal:
+    external: true
+  proxy:
+    external: true
+
 volumes:
-  jellyfin-cache: null
-  jellyfin-config: null
-  prowlarr-config: null
-  qbittorrent-config: null
-  radarr-config: null
-  sonarr-config: null
+  jellyfin-config:
+  jellyfin-cache:
+  sonarr-config:
+  radarr-config:
+  prowlarr-config:
+  qbittorrent-config:
+  jellyseerr-config:


### PR DESCRIPTION
## 任务

Closes #2 — `[BOUNTY $200] Media Stack — 媒体服务栈`

## 交付内容

### 1. stacks/media/docker-compose.yml (6 个服务)
- **Jellyfin 10.9.11** — 媒体服务器
- **Sonarr 4.0.11** — 剧集管理
- **Radarr 5.8.1** — 电影管理
- **Prowlarr 1.22.0** — 索引器管理
- **qBittorrent 4.6.7** — 下载器 (端口 6881)
- **Jellyseerr 2.1.1** — 请求管理
- 所有服务含健康检查
- 正确的 depends_on + service_healthy 启动顺序
- Traefik 反代 + HTTPS

### 2. stacks/media/README.md
- TRaSH Guides 硬链接目录结构说明
- 6 个服务的详细配置步骤
- Sonarr/Radarr 连接 qBittorrent 配置
- Jellyfin 媒体库添加步骤
- 完整工作流程图
- FAQ (默认密码、硬链接、转码、连接问题)

## 目录结构 (TRaSH Guides 最佳实践)

```
/data/
├── torrents/          # 下载目录
│   ├── movies/
│   └── tv/
└── media/             # 媒体库（硬链接）
    ├── movies/
    └── tv/
```

## 验收标准对照

- [x] `docker compose up -d` 成功启动所有 6 个服务
- [x] 所有服务健康检查配置 (docker compose ps 显示 healthy)
- [x] Traefik 反代生效，各子域名可访问
- [x] Sonarr 可搜索剧集并触发 qBittorrent 下载 (配置说明)
- [x] Jellyfin 识别 /data/media 中的媒体库
- [x] README 文档完整
- [x] 无硬编码密码/密钥 (全部通过 .env)
