### PR TITLE
feat(observability): Prometheus + Grafana + Loki + Tempo + Alerting + Uptime Kuma

### DIFF
--- a/config/grafana/provisioning/dashboards/dashboards.yml
+++ b/config/grafana/provisioning/dashboards/dashboards.yml
@@ -1,12 +1,12 @@
 apiVersion: 1
+
 providers:
-  - name: homelab
+  - name: default
     orgId: 1
-    folder: HomeLab
+    folder: ""
     type: file
     disableDeletion: false
-    updateIntervalSeconds: 30
-    allowUiUpdates: true
+    editable: true
     options:
       path: /var/lib/grafana/dashboards
-      foldersFromFilesStructure: true
+      foldersFromFilesStructure: false

--- a/config/grafana/provisioning/datasources/datasources.yml
+++ b/config/grafana/provisioning/datasources/datasources.yml
@@ -1,18 +1,18 @@
 apiVersion: 1
+
 datasources:
   - name: Prometheus
     type: prometheus
-    uid: prometheus
+    access: proxy
     url: http://prometheus:9090
     isDefault: true
-    editable: false
-    jsonData:
-      timeInterval: 15s
 
   - name: Loki
     type: loki
-    uid: loki
+    access: proxy
     url: http://loki:3100
-    editable: false
-    jsonData:
-      maxLines: 1000
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200

--- a/config/loki/loki.yml
+++ b/config/loki/loki.yml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h  # 7 days
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h

--- a/config/prometheus/alerts/containers.yml
+++ b/config/prometheus/alerts/containers.yml
@@ -1,0 +1,29 @@
+groups:
+  - name: containers
+    rules:
+      - alert: ContainerHighRestarts
+        expr: increase(container_restart_count[1h]) > 3
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container {{ $labels.name }} restarting frequently"
+          description: "Container has restarted {{ $value }} times in the last hour"
+
+      - alert: ContainerOOMKilled
+        expr: container_oom_events_total > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Container {{ $labels.name }} OOM killed"
+          description: "Container was killed due to out of memory"
+
+      - alert: ContainerHealthCheckFailed
+        expr: container_health_status{status="unhealthy"} == 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Container {{ $labels.name }} health check failing"
+          description: "Container health check has been failing for 5 minutes"

--- a/config/prometheus/alerts/host.yml
+++ b/config/prometheus/alerts/host.yml
@@ -1,0 +1,38 @@
+groups:
+  - name: host
+    rules:
+      - alert: HighCpuUsage
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CPU usage on {{ $labels.instance }}"
+          description: "CPU usage is above 80% for 5 minutes (current: {{ $value }}%)"
+
+      - alert: HighMemoryUsage
+        expr: (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 90
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High memory usage on {{ $labels.instance }}"
+          description: "Memory usage is above 90% (current: {{ $value }}%)"
+
+      - alert: HighDiskUsage
+        expr: (1 - (node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"})) * 100 > 85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High disk usage on {{ $labels.instance }}"
+          description: "Disk usage is above 85% (current: {{ $value }}%)"
+
+      - alert: HighDiskIOWait
+        expr: rate(node_cpu_seconds_total{mode="iowait"}[5m]) * 100 > 20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High disk IO wait on {{ $labels.instance }}"
+          description: "IO wait is above 20% for 10 minutes"

--- a/config/prometheus/alerts/services.yml
+++ b/config/prometheus/alerts/services.yml
@@ -1,0 +1,20 @@
+groups:
+  - name: services
+    rules:
+      - alert: TraefikHighErrorRate
+        expr: sum(rate(traefik_service_requests_total{code=~"5.."}[5m])) / sum(rate(traefik_service_requests_total[5m])) * 100 > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Traefik high 5xx error rate"
+          description: "5xx error rate is above 1% (current: {{ $value }}%)"
+
+      - alert: ServiceHighLatency
+        expr: histogram_quantile(0.99, sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (le, service)) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Service {{ $labels.service }} high latency"
+          description: "P99 latency is above 2 seconds (current: {{ $value }}s)"

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -1,34 +1,36 @@
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
-  external_labels:
-    cluster: homelab
 
 rule_files:
-  - /etc/prometheus/rules/*.yml
+  - /etc/prometheus/alerts/*.yml
 
 alerting:
   alertmanagers:
     - static_configs:
-        - targets: [alertmanager:9093]
+        - targets: ["alertmanager:9093"]
 
 scrape_configs:
   - job_name: prometheus
     static_configs:
-      - targets: [localhost:9090]
-
-  - job_name: node-exporter
-    static_configs:
-      - targets: [node-exporter:9100]
+      - targets: ["localhost:9090"]
 
   - job_name: cadvisor
     static_configs:
-      - targets: [cadvisor:8080]
+      - targets: ["cadvisor:8080"]
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ["node-exporter:9100"]
 
   - job_name: traefik
     static_configs:
-      - targets: [traefik:8080]
+      - targets: ["traefik:8080"]
 
   - job_name: loki
     static_configs:
-      - targets: [loki:3100]
+      - targets: ["loki:3100"]
+
+  - job_name: tempo
+    static_configs:
+      - targets: ["tempo:3200"]

--- a/config/promtail/promtail.yml
+++ b/config/promtail/promtail.yml
@@ -1,0 +1,31 @@
+server:
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # Docker container logs (auto-discovery)
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        target_label: container
+        regex: /(.*)
+      - source_labels: ["__meta_docker_container_log_stream"]
+        target_label: stream
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+
+  # System logs
+  - job_name: syslog
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: syslog
+          __path__: /var/log/syslog

--- a/config/tempo/tempo.yml
+++ b/config/tempo/tempo.yml
@@ -1,0 +1,33 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+compactor:
+  compaction:
+    block_retention: 72h  # 3 days
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true

--- a/pr-body-ai.md
+++ b/pr-body-ai.md
@@ -1,0 +1,10 @@
+﻿## 任务
+Closes #6
+
+## 交付
+- Ollama 0.3.12 LLM推理 (NVIDIA/AMD/CPU自适应)
+- Open WebUI 0.3.32 LLM界面
+- Stable Diffusion WebUI 图像生成
+- Perplexica AI搜索引擎
+- GPU配置注释切换
+- README含模型推荐、API示例、资源需求

--- a/stacks/observability/README.md
+++ b/stacks/observability/README.md
@@ -1,0 +1,101 @@
+# 📊 Observability Stack — Prometheus + Grafana + Loki + Tempo + Alerting
+
+> 完整可观测性三支柱：Metrics + Logs + Traces + Alerting + Uptime 监控。
+
+## 服务清单 (10 个)
+
+| 服务 | 镜像 | URL | 用途 |
+|------|------|-----|------|
+| **Prometheus** | `prom/prometheus:v2.54.1` | `prometheus.${DOMAIN}` | 指标采集 |
+| **Grafana** | `grafana/grafana:11.2.2` | `grafana.${DOMAIN}` | 可视化面板 |
+| **Loki** | `grafana/loki:3.2.0` | internal | 日志聚合 |
+| **Promtail** | `grafana/promtail:3.2.0` | — | 日志采集 Agent |
+| **Tempo** | `grafana/tempo:2.6.0` | internal | 分布式链路追踪 |
+| **Alertmanager** | `prom/alertmanager:v0.27.0` | internal | 告警路由 |
+| **cAdvisor** | `gcr.io/cadvisor/cadvisor:v0.50.0` | internal | 容器指标 |
+| **Node Exporter** | `prom/node-exporter:v1.8.2` | internal | 主机指标 |
+| **Uptime Kuma** | `louislam/uptime-kuma:1.23.15` | `status.${DOMAIN}` | 服务可用性 |
+
+## 快速启动
+
+```bash
+docker compose -f stacks/observability/docker-compose.yml up -d
+```
+
+## Prometheus 采集目标
+
+| Job | Target | 指标 |
+|-----|--------|------|
+| prometheus | localhost:9090 | 自监控 |
+| cadvisor | cadvisor:8080 | 容器 CPU/内存/网络 |
+| node-exporter | node-exporter:9100 | 主机 CPU/内存/磁盘 |
+| traefik | traefik:8080 | 请求量/延迟/错误率 |
+| loki | loki:3100 | 日志系统指标 |
+| tempo | tempo:3200 | 追踪系统指标 |
+
+## Grafana Dashboard (自动加载)
+
+通过 provisioning 自动加载，无需手动导入：
+
+| Dashboard | ID | 说明 |
+|-----------|-----|------|
+| Node Exporter Full | 1860 | 主机资源详情 |
+| Docker Containers | 179 | 容器资源监控 |
+| Traefik | 17346 | 反代流量分析 |
+| Loki | 13639 | 日志查询面板 |
+
+Dashboard JSON 文件放在 `config/grafana/dashboards/`。
+
+下载方式：
+```bash
+# 从 Grafana.com 下载
+curl -o config/grafana/dashboards/node-exporter.json \
+  "https://grafana.com/api/dashboards/1860/revisions/latest/download"
+```
+
+## 告警规则
+
+### 主机告警 (host.yml)
+- CPU > 80% 持续 5 分钟
+- 内存 > 90%
+- 磁盘 > 85%
+- IO Wait > 20% 持续 10 分钟
+
+### 容器告警 (containers.yml)
+- 重启次数 > 3 次/小时
+- OOM 被杀
+- 健康检查失败 5 分钟
+
+### 服务告警 (services.yml)
+- Traefik 5xx 错误率 > 1%
+- 服务 P99 延迟 > 2s
+
+告警路由: Prometheus → Alertmanager → ntfy 推送
+
+## Loki 日志
+
+Promtail 自动采集：
+- 所有 Docker 容器日志 (docker_sd_configs)
+- 系统日志 (/var/log/syslog)
+
+Grafana 中查询: Explore → Loki → `{container="nginx"}`
+
+## Grafana Authentik OIDC
+
+已预配置 OIDC 环境变量：
+- `homelab-admins` 组 → Grafana Admin
+- `homelab-users` 组 → Grafana Viewer
+
+## 数据保留
+
+| 数据 | 保留时间 | 配置 |
+|------|---------|------|
+| Prometheus 指标 | 30 天 | `PROMETHEUS_RETENTION` |
+| Loki 日志 | 7 天 | `config/loki/loki.yml` |
+| Tempo 追踪 | 3 天 | `config/tempo/tempo.yml` |
+
+## Uptime Kuma
+
+访问 `https://status.${DOMAIN}` 查看服务状态页。
+
+首次访问创建管理员账号，然后添加监控项。

--- a/stacks/observability/docker-compose.yml
+++ b/stacks/observability/docker-compose.yml
@@ -1,0 +1,250 @@
+services:
+  # ─────────────────────────────────────────────
+  # Prometheus — 指标采集
+  # ─────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: prometheus
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - prometheus-data:/prometheus
+      - ../../config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../../config/prometheus/alerts:/etc/prometheus/alerts:ro
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-30d}"
+      - "--web.enable-lifecycle"
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.prometheus.rule=Host(`prometheus.${DOMAIN}`)"
+      - traefik.http.routers.prometheus.entrypoints=websecure
+      - traefik.http.routers.prometheus.tls=true
+      - traefik.http.services.prometheus.loadbalancer.server.port=9090
+    healthcheck:
+      test: [CMD-SHELL, "wget -qO /dev/null http://localhost:9090/-/healthy || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  # ─────────────────────────────────────────────
+  # Grafana — 可视化面板
+  # ─────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:11.2.2
+    container_name: grafana
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ../../config/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../../config/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    environment:
+      - GF_SERVER_ROOT_URL=https://grafana.${DOMAIN}
+      - GF_DATABASE_TYPE=postgres
+      - GF_DATABASE_HOST=postgres:5432
+      - GF_DATABASE_NAME=grafana
+      - GF_DATABASE_USER=grafana
+      - GF_DATABASE_PASSWORD=${GRAFANA_DB_PASSWORD:-changeme}
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
+      - GF_AUTH_GENERIC_OAUTH_NAME=Authentik
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=${GRAFANA_OIDC_CLIENT_ID:-}
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${GRAFANA_OIDC_CLIENT_SECRET:-}
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid profile email
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://auth.${DOMAIN}/application/o/authorize/
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://auth.${DOMAIN}/application/o/token/
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://auth.${DOMAIN}/application/o/userinfo/
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups[*], 'homelab-admins') && 'Admin' || 'Viewer'
+      - TZ=${TZ:-Asia/Shanghai}
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.grafana.rule=Host(`grafana.${DOMAIN}`)"
+      - traefik.http.routers.grafana.entrypoints=websecure
+      - traefik.http.routers.grafana.tls=true
+      - traefik.http.services.grafana.loadbalancer.server.port=3000
+    healthcheck:
+      test: [CMD-SHELL, "curl -sf http://localhost:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ─────────────────────────────────────────────
+  # Loki — 日志聚合
+  # ─────────────────────────────────────────────
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: loki
+    restart: unless-stopped
+    networks:
+      - internal
+    volumes:
+      - loki-data:/loki
+      - ../../config/loki/loki.yml:/etc/loki/local-config.yaml:ro
+    command: -config.file=/etc/loki/local-config.yaml
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    healthcheck:
+      test: [CMD-SHELL, "wget -qO /dev/null http://localhost:3100/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ─────────────────────────────────────────────
+  # Promtail — 日志采集 Agent
+  # ─────────────────────────────────────────────
+  promtail:
+    image: grafana/promtail:3.2.0
+    container_name: promtail
+    restart: unless-stopped
+    networks:
+      - internal
+    volumes:
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ../../config/promtail/promtail.yml:/etc/promtail/config.yml:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      loki:
+        condition: service_healthy
+
+  # ─────────────────────────────────────────────
+  # Tempo — 分布式链路追踪
+  # ─────────────────────────────────────────────
+  tempo:
+    image: grafana/tempo:2.6.0
+    container_name: tempo
+    restart: unless-stopped
+    networks:
+      - internal
+    volumes:
+      - tempo-data:/var/tempo
+      - ../../config/tempo/tempo.yml:/etc/tempo/tempo.yml:ro
+    command: -config.file=/etc/tempo/tempo.yml
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    healthcheck:
+      test: [CMD-SHELL, "wget -qO /dev/null http://localhost:3200/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  # ─────────────────────────────────────────────
+  # Alertmanager — 告警路由
+  # ─────────────────────────────────────────────
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: alertmanager
+    restart: unless-stopped
+    networks:
+      - internal
+    volumes:
+      - alertmanager-data:/alertmanager
+      - ../../config/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    healthcheck:
+      test: [CMD-SHELL, "wget -qO /dev/null http://localhost:9093/-/healthy || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ─────────────────────────────────────────────
+  # cAdvisor — 容器指标
+  # ─────────────────────────────────────────────
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.50.0
+    container_name: cadvisor
+    restart: unless-stopped
+    networks:
+      - internal
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+    privileged: true
+    healthcheck:
+      test: [CMD-SHELL, "wget -qO /dev/null http://localhost:8080/healthz || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ─────────────────────────────────────────────
+  # Node Exporter — 主机指标
+  # ─────────────────────────────────────────────
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: node-exporter
+    restart: unless-stopped
+    networks:
+      - internal
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+    healthcheck:
+      test: [CMD-SHELL, "wget -qO /dev/null http://localhost:9100/metrics || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # ─────────────────────────────────────────────
+  # Uptime Kuma — 服务可用性监控
+  # ─────────────────────────────────────────────
+  uptime-kuma:
+    image: louislam/uptime-kuma:1.23.15
+    container_name: uptime-kuma
+    restart: unless-stopped
+    networks:
+      - internal
+      - proxy
+    volumes:
+      - uptime-kuma-data:/app/data
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.uptime.rule=Host(`status.${DOMAIN}`)"
+      - traefik.http.routers.uptime.entrypoints=websecure
+      - traefik.http.routers.uptime.tls=true
+      - traefik.http.services.uptime.loadbalancer.server.port=3001
+    healthcheck:
+      test: [CMD-SHELL, "curl -sf http://localhost:3001/api/status-page/heartbeat/default || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+networks:
+  internal:
+    external: true
+  proxy:
+    external: true
+
+volumes:
+  prometheus-data:
+  grafana-data:
+  loki-data:
+  tempo-data:
+  alertmanager-data:
+  uptime-kuma-data:


### PR DESCRIPTION
﻿## 任务
Closes #10

## 交付 (10个服务)
- Prometheus v2.54.1 指标采集 + scrape configs
- Grafana 11.2.2 可视化 + Authentik OIDC + 自动provisioning
- Loki 3.2.0 日志聚合 (7天保留)
- Promtail 3.2.0 Docker自动发现 + syslog
- Tempo 2.6.0 分布式追踪 (3天保留)
- Alertmanager v0.27.0 告警路由 → ntfy
- cAdvisor v0.50.0 容器指标
- Node Exporter v1.8.2 主机指标
- Uptime Kuma 1.23.15 服务可用性
- 告警规则: host/containers/services
- Grafana dashboard provisioning
