### PR TITLE
feat(network): complete Network Stack — AdGuard Home + WireGuard + Unbound + Cloudflare DDNS + NPM

### DIFF
--- a/scripts/fix-dns-port.sh
+++ b/scripts/fix-dns-port.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Disable systemd-resolved port 53 binding
+# Usage: --check | --apply | --restore
+set -euo pipefail
+SYSTEMD_OVERRIDE_DIR=/etc/systemd/resolved.conf.d
+check_status() {
+  echo "=== systemd-resolved DNS stub listener status ==="
+  ss -lnup 2>/dev/null | grep -q ':53 ' && echo "  Port 53 IN USE" || echo "  Port 53 FREE"
+  systemctl is-active --quiet systemd-resolved 2>/dev/null && echo "  systemd-resolved: ACTIVE" || echo "  systemd-resolved: INACTIVE"
+}
+apply_fix() {
+  [[ $EUID -ne 0 ]] && { echo "ERROR: requires root"; exit 1; }
+  mkdir -p "$SYSTEMD_OVERRIDE_DIR"
+  printf '[Resolve]\nDNSStubListener=no\n' > "$SYSTEMD_OVERRIDE_DIR/no-stub.conf"
+  systemctl restart systemd-resolved
+  echo "Done. Port 53 free."; check_status
+}
+restore() {
+  [[ $EUID -ne 0 ]] && { echo "ERROR: requires root"; exit 1; }
+  rm -f "$SYSTEMD_OVERRIDE_DIR/no-stub.conf"
+  systemctl restart systemd-resolved
+  echo "Restored."; check_status
+}
+case "${1:-}" in
+  --check)   check_status ;;
+  --apply)   apply_fix ;;
+  --restore) restore ;;
+  *)         echo "Usage: $0 [--check|--apply|--restore]"; exit 1 ;;
+esac

--- a/stacks/network/.env.example
+++ b/stacks/network/.env.example
@@ -1,2 +1,11 @@
+# Network Stack — Environment Variables
+DOMAIN=yourdomain.com
 TZ=Asia/Shanghai
-DOMAIN=localhost
+# WireGuard Easy
+WG_HOST=
+WG_PASSWORD=
+WG_PORT=51820
+# Cloudflare DDNS
+CF_API_TOKEN=
+CF_ZONE_ID=
+CF_RECORD_NAME=

--- a/stacks/network/.env.example
+++ b/stacks/network/.env.example
@@ -1,11 +1,16 @@
 # Network Stack — Environment Variables
+# Copy to .env and fill ALL values before running.
+
 DOMAIN=yourdomain.com
 TZ=Asia/Shanghai
+
 # WireGuard Easy
-WG_HOST=
-WG_PASSWORD=
-WG_PORT=51820
+WG_HOST=          # Your public IP or domain for WireGuard
+WG_EASY_PASSWORD= # Web UI password for wg-easy
+WG_DEFAULT_DNS=10.8.1.1  # Internal DNS for VPN clients (Unbound IP)
+
 # Cloudflare DDNS
-CF_API_TOKEN=
-CF_ZONE_ID=
-CF_RECORD_NAME=
+CF_API_TOKEN=     # Cloudflare API token with Zone:DNS:Edit permission
+DDNS_DOMAINS=     # Comma-separated domains to update e.g. home.example.com
+DDNS_PROXIED=false
+DDNS_CRON=@every 5m

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+
   adguardhome:
     image: adguard/adguardhome:v0.107.55
     container_name: adguardhome
@@ -9,20 +10,90 @@ services:
       - adguard-work:/opt/adguardhome/work
       - adguard-conf:/opt/adguardhome/conf
     ports:
-      - 53:53/tcp
-      - 53:53/udp
+      - "53:53/tcp"
+      - "53:53/udp"
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
     labels:
       - traefik.enable=true
-      - traefik.http.routers.adguard.rule=Host()
+      - "traefik.http.routers.adguard.rule=Host(`adguard.${DOMAIN}`)"
       - traefik.http.routers.adguard.entrypoints=websecure
       - traefik.http.routers.adguard.tls=true
       - traefik.http.services.adguard.loadbalancer.server.port=3000
     healthcheck:
-      test: [CMD, wget, -qO-, http://localhost:3000]
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  wg-easy:
+    image: ghcr.io/wg-easy/wg-easy:14
+    container_name: wg-easy
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv4.ip_forward=1
+    networks:
+      - proxy
+    volumes:
+      - wg-easy-data:/etc/wireguard
+    ports:
+      - "${WG_PORT:-51820}:51820/udp"
+    environment:
+      - WG_HOST=${WG_HOST}
+      - PASSWORD=${WG_PASSWORD}
+      - WG_PORT=${WG_PORT:-51820}
+      - WG_DEFAULT_DNS=adguardhome
+      - WG_ALLOWED_IPS=0.0.0.0/0, ::/0
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.wg-easy.rule=Host(`vpn.${DOMAIN}`)"
+      - traefik.http.routers.wg-easy.entrypoints=websecure
+      - traefik.http.routers.wg-easy.tls=true
+      - traefik.http.services.wg-easy.loadbalancer.server.port=51821
+    healthcheck:
+      test: ["CMD-SHELL", "wg show || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  unbound:
+    image: mvance/unbound:1.21.1
+    container_name: unbound
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - unbound-conf:/opt/unbound/etc/unbound
+    healthcheck:
+      test: ["CMD-SHELL", "drill @127.0.0.1 cloudflare.com || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  cloudflare-ddns:
+    image: ghcr.io/favonia/cloudflare-ddns:1.14.0
+    container_name: cloudflare-ddns
+    restart: unless-stopped
+    environment:
+      - CF_API_TOKEN=${CF_API_TOKEN}
+      - DOMAINS=${CF_RECORD_NAME}
+      - PROXIED=false
+      - TZ=${TZ:-Asia/Shanghai}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
   nginx-proxy-manager:
     image: jc21/nginx-proxy-manager:2.11.3
     container_name: nginx-proxy-manager
@@ -33,24 +104,30 @@ services:
       - npm-data:/data
       - npm-letsencrypt:/etc/letsencrypt
     ports:
-      - 8181:81
+      - "8181:81"
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
     labels:
       - traefik.enable=true
-      - traefik.http.routers.npm.rule=Host()
+      - "traefik.http.routers.npm.rule=Host(`npm.${DOMAIN}`)"
       - traefik.http.routers.npm.entrypoints=websecure
       - traefik.http.routers.npm.tls=true
       - traefik.http.services.npm.loadbalancer.server.port=81
     healthcheck:
-      test: [CMD-SHELL, wget -q --spider http://localhost:3000/api/health || exit 0]
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:81/ || exit 0"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+
 networks:
   proxy:
     external: true
+
 volumes:
   adguard-work:
   adguard-conf:
+  wg-easy-data:
+  unbound-conf:
   npm-data:
   npm-letsencrypt:

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -19,77 +19,11 @@ services:
       - "traefik.http.routers.adguard.rule=Host(`adguard.${DOMAIN}`)"
       - traefik.http.routers.adguard.entrypoints=websecure
       - traefik.http.routers.adguard.tls=true
+      - traefik.http.routers.adguard.tls.certresolver=letsencrypt
       - traefik.http.services.adguard.loadbalancer.server.port=3000
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:3000"]
       interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-
-  wg-easy:
-    image: ghcr.io/wg-easy/wg-easy:14
-    container_name: wg-easy
-    restart: unless-stopped
-    cap_add:
-      - NET_ADMIN
-      - SYS_MODULE
-    sysctls:
-      - net.ipv4.conf.all.src_valid_mark=1
-      - net.ipv4.ip_forward=1
-    networks:
-      - proxy
-    volumes:
-      - wg-easy-data:/etc/wireguard
-    ports:
-      - "${WG_PORT:-51820}:51820/udp"
-    environment:
-      - WG_HOST=${WG_HOST}
-      - PASSWORD=${WG_PASSWORD}
-      - WG_PORT=${WG_PORT:-51820}
-      - WG_DEFAULT_DNS=adguardhome
-      - WG_ALLOWED_IPS=0.0.0.0/0, ::/0
-      - TZ=${TZ:-Asia/Shanghai}
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.wg-easy.rule=Host(`vpn.${DOMAIN}`)"
-      - traefik.http.routers.wg-easy.entrypoints=websecure
-      - traefik.http.routers.wg-easy.tls=true
-      - traefik.http.services.wg-easy.loadbalancer.server.port=51821
-    healthcheck:
-      test: ["CMD-SHELL", "wg show || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
-
-  unbound:
-    image: mvance/unbound:1.21.1
-    container_name: unbound
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - unbound-conf:/opt/unbound/etc/unbound
-    healthcheck:
-      test: ["CMD-SHELL", "drill @127.0.0.1 cloudflare.com || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 20s
-
-  cloudflare-ddns:
-    image: ghcr.io/favonia/cloudflare-ddns:1.14.0
-    container_name: cloudflare-ddns
-    restart: unless-stopped
-    environment:
-      - CF_API_TOKEN=${CF_API_TOKEN}
-      - DOMAINS=${CF_RECORD_NAME}
-      - PROXIED=false
-      - TZ=${TZ:-Asia/Shanghai}
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
-      interval: 60s
       timeout: 10s
       retries: 3
       start_period: 30s
@@ -112,6 +46,7 @@ services:
       - "traefik.http.routers.npm.rule=Host(`npm.${DOMAIN}`)"
       - traefik.http.routers.npm.entrypoints=websecure
       - traefik.http.routers.npm.tls=true
+      - traefik.http.routers.npm.tls.certresolver=letsencrypt
       - traefik.http.services.npm.loadbalancer.server.port=81
     healthcheck:
       test: ["CMD-SHELL", "wget -q --spider http://localhost:81/ || exit 0"]
@@ -119,6 +54,75 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  wg-easy:
+    image: ghcr.io/wg-easy/wg-easy:14
+    container_name: wg-easy
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv4.ip_forward=1
+    networks:
+      - proxy
+    volumes:
+      - wg-easy-data:/etc/wireguard
+    ports:
+      - "51820:51820/udp"
+    environment:
+      - WG_HOST=${WG_HOST}
+      - PASSWORD=${WG_EASY_PASSWORD}
+      - WG_DEFAULT_DNS=${WG_DEFAULT_DNS:-10.8.1.1}
+      - WG_DEFAULT_ADDRESS=10.8.0.x
+      - WG_PERSISTENT_KEEPALIVE=25
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.wg-easy.rule=Host(`vpn.${DOMAIN}`)"
+      - traefik.http.routers.wg-easy.entrypoints=websecure
+      - traefik.http.routers.wg-easy.tls=true
+      - traefik.http.routers.wg-easy.tls.certresolver=letsencrypt
+      - traefik.http.services.wg-easy.loadbalancer.server.port=51821
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:51821/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  unbound:
+    image: mvance/unbound:1.21.1
+    container_name: unbound
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - unbound-conf:/etc/unbound/custom.conf.d
+    healthcheck:
+      test: ["CMD-SHELL", "drill @127.0.0.1 cloudflare.com || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  cloudflare-ddns:
+    image: ghcr.io/favonia/cloudflare-ddns:1.14.0
+    container_name: cloudflare-ddns
+    restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      - CF_API_TOKEN=${CF_API_TOKEN}
+      - DOMAINS=${DDNS_DOMAINS}
+      - PROXIED=${DDNS_PROXIED:-false}
+      - UPDATE_CRON=${DDNS_CRON:-@every 5m}
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep cloudflare-ddns || exit 1"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
 networks:
   proxy:


### PR DESCRIPTION
## Summary
- Complete Network Stack implementation resolving issue #4
- All services configured with healthchecks and follow repo conventions
- QA CLEAR — Final Gate APPROVED

## Changes
- **AdGuard Home + NPM**: Fixed broken Traefik Host() labels on AdGuard and Nginx Proxy Manager
- **WireGuard Easy**: Added WireGuard with UDP tunnel and web UI for VPN access
- **Unbound**: Added Unbound as recursive DNS resolver for privacy
- **Cloudflare DDNS**: Added dynamic IP update support for homelab domains
- **scripts/fix-dns-port.sh**: Created script to resolve systemd-resolved port 53 conflict
- **.env.example**: Updated with all required environment variables

## Testing
Deploy with `docker compose up -d` — all services have healthchecks, certresolver, and follow repo conventions. Run `scripts/fix-dns-port.sh` if port 53 conflict occurs.

Resolves #4

@greptile