### PR TITLE
feat(base): Docker Socket Proxy, env template, comprehensive docs

### DIFF
--- a/stacks/base/.env.example
+++ b/stacks/base/.env.example
@@ -1,0 +1,41 @@
+# =============================================================================
+# HomeLab Stack — Base Infrastructure Environment Variables
+# Copy this file to .env and fill in the required values:
+#   cp .env.example .env
+# =============================================================================
+
+# ── Required ──────────────────────────────────────────────────────────────────
+
+# Your domain name (all services will be at *.DOMAIN)
+# Example: home.example.com → traefik.home.example.com, portainer.home.example.com
+DOMAIN=example.com
+
+# Email for Let's Encrypt certificate notifications
+ACME_EMAIL=admin@example.com
+
+# Traefik dashboard credentials
+# Generate: htpasswd -nbB admin 'yourpassword' | sed -e 's/\$/\$\$/g'
+TRAEFIK_DASHBOARD_USER=admin
+TRAEFIK_DASHBOARD_PASSWORD_HASH=$$apr1$$placeholder$$change-me
+
+# ── Timezone ──────────────────────────────────────────────────────────────────
+
+TZ=Asia/Shanghai
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+
+# Watchtower update schedule (cron format, default: daily at 3 AM)
+WATCHTOWER_SCHEDULE=0 0 3 * * *
+
+# Watchtower notification URL (ntfy/gotify/slack)
+# Examples:
+#   ntfy:   shoutrrr://ntfy/homelab-updates
+#   gotify: gotify://gotify.example.com/token
+# Leave empty to disable notifications
+WATCHTOWER_NOTIFICATION_URL=
+
+# ── CN Mode (China Network) ──────────────────────────────────────────────────
+
+# Set to 'true' to use CN Docker registry mirrors
+# Runs scripts/setup-cn-mirrors.sh automatically
+CN_MODE=false

--- a/stacks/base/README.md
+++ b/stacks/base/README.md
@@ -6,9 +6,10 @@ The foundation of HomeLab Stack. Must be deployed **before any other stack**.
 
 | Service | Version | URL | Purpose |
 |---------|---------|-----|---------|
-| Traefik | 3.1 | `traefik.<DOMAIN>` | Reverse proxy + TLS termination |
-| Portainer CE | 2.21 | `portainer.<DOMAIN>` | Docker management UI |
-| Watchtower | latest-stable | — | Automatic container updates |
+| Docker Socket Proxy | 0.2.0 | — | Secure Docker API gateway |
+| Traefik | 3.1.6 | `traefik.<DOMAIN>` | Reverse proxy + TLS termination |
+| Portainer CE | 2.21.4 | `portainer.<DOMAIN>` | Docker management UI |
+| Watchtower | 1.7.1 | — | Automatic container updates (daily 3 AM) |
 
 ## Architecture
 
@@ -16,61 +17,245 @@ The foundation of HomeLab Stack. Must be deployed **before any other stack**.
 Internet
     │
     ▼
-[Traefik :443]
-    │  TLS termination (Let's Encrypt)
-    │  ForwardAuth → Authentik (optional)
+[Traefik :80/:443]
+    │  HTTP→HTTPS redirect (port 80)
+    │  TLS termination via Let's Encrypt (port 443)
+    │  ForwardAuth → Authentik (optional, via SSO stack)
     │
-    ├──► portainer.<DOMAIN>  → Portainer
-    ├──► traefik.<DOMAIN>    → Traefik Dashboard
-    └──► *..<DOMAIN>         → Other stacks via 'proxy' network
+    ├──► traefik.<DOMAIN>    → Dashboard (BasicAuth protected)
+    ├──► portainer.<DOMAIN>  → Portainer CE
+    └──► *.<DOMAIN>          → Other stacks via 'proxy' network
 
-[proxy] ← shared Docker network — all stacks attach here
+[socket-proxy] ← internal network (no external access)
+    │
+    └──► docker-socket-proxy:2375 → Docker API (read-only, filtered)
+            │
+            ├── Traefik (container discovery)
+            ├── Portainer (management)
+            └── Watchtower (update checks)
+
+[proxy] ← shared external Docker network — all stacks attach here
 ```
+
+### Security: Docker Socket Proxy
+
+> **No container directly mounts `/var/run/docker.sock`.**
+
+All Docker API access goes through `docker-socket-proxy` (tecnativa/docker-socket-proxy):
+- Runs on an **internal network** (no external access)
+- Read-only Docker socket mount
+- API filtering: only allowed endpoints are proxied
+- Container is `read_only` with tmpfs for runtime files
+
+| API | Allowed | Consumer |
+|-----|---------|----------|
+| Containers | ✅ | Traefik, Portainer, Watchtower |
+| Networks | ✅ | Traefik |
+| Services/Tasks | ✅ | Traefik |
+| Images/Volumes | ✅ | Portainer |
+| Events | ✅ | Portainer, Watchtower |
+| Exec | ✅ | Portainer |
+| Info/Version | ✅ | All |
+| Secrets | ❌ | — |
+| Swarm | ❌ | — |
+| Build/Commit | ❌ | — |
+| Auth | ❌ | — |
 
 ## Prerequisites
 
-- Docker >= 24.0 with Compose v2 plugin
-- Ports 80 and 443 open on your firewall
-- A domain pointing to your server's IP (A record)
-- `./scripts/setup-env.sh` completed (creates `.env` and `acme.json`)
+- Docker ≥ 24.0 with Compose v2 plugin
+- Ports **80** and **443** open on your firewall
+- A domain pointing to your server's IP (DNS A record)
 
 ## Quick Start
 
 ```bash
-# From repo root — recommended (runs check-deps + setup-env first)
-./install.sh
+# 1. Clone and navigate
+cd homelab-stack
 
-# Or manually:
-cd stacks/base
-ln -sf ../../.env .env       # share root .env
-docker compose up -d
+# 2. Create environment
+cp stacks/base/.env.example .env
+# Edit .env — set DOMAIN, ACME_EMAIL, and generate TRAEFIK_DASHBOARD_PASSWORD_HASH
+
+# 3. Create shared network
+docker network create proxy
+
+# 4. Prepare ACME certificate storage
+touch config/traefik/acme.json && chmod 600 config/traefik/acme.json
+
+# 5. Deploy
+docker compose -f stacks/base/docker-compose.yml up -d
+
+# 6. Verify
+docker compose -f stacks/base/docker-compose.yml ps
+```
+
+Or use the automated installer:
+
+```bash
+./install.sh
 ```
 
 ## Configuration
 
 ### Environment Variables (`.env`)
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DOMAIN` | ✅ | Base domain, e.g. `home.example.com` |
-| `ACME_EMAIL` | ✅ | Email for Let's Encrypt notifications |
-| `TRAEFIK_DASHBOARD_USER` | ✅ | Dashboard login username |
-| `TRAEFIK_DASHBOARD_PASSWORD_HASH` | ✅ | Bcrypt hash — see below |
-| `TZ` | ✅ | Timezone, e.g. `Asia/Shanghai` |
-| `CN_MODE` | — | `true` to use CN Docker mirrors |
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DOMAIN` | ✅ | — | Base domain, e.g. `home.example.com` |
+| `ACME_EMAIL` | ✅ | — | Email for Let's Encrypt notifications |
+| `TRAEFIK_DASHBOARD_USER` | ✅ | `admin` | Dashboard login username |
+| `TRAEFIK_DASHBOARD_PASSWORD_HASH` | ✅ | — | Bcrypt hash (see below) |
+| `TZ` | ✅ | `Asia/Shanghai` | Timezone |
+| `WATCHTOWER_SCHEDULE` | — | `0 0 3 * * *` | Update check cron (default: 3 AM daily) |
+| `WATCHTOWER_NOTIFICATION_URL` | — | — | Shoutrrr URL for update notifications |
+| `CN_MODE` | — | `false` | Use CN Docker registry mirrors |
 
 ### Generate Dashboard Password Hash
 
 ```bash
-# Install htpasswd (Debian/Ubuntu)
+# Install htpasswd (Ubuntu/Debian)
 sudo apt-get install -y apache2-utils
 
 # Generate hash (replace 'yourpassword')
-htpasswd -nbB admin 'yourpassword' | sed -e 's/\$$/\$\$\$/g'
+htpasswd -nbB admin 'yourpassword' | sed -e 's/\$/\$\$/g'
 
 # Paste output into .env as TRAEFIK_DASHBOARD_PASSWORD_HASH
 ```
 
-### TLS Certificates
+### DNS Configuration
 
-Traefik uses Let's Encrypt HTTP-01 challenge by default. Certificates are stored in
+Point these records to your server's public IP:
+
+| Record Type | Name | Value |
+|-------------|------|-------|
+| A | `DOMAIN` | `YOUR_SERVER_IP` |
+| A (or CNAME) | `*.DOMAIN` | `YOUR_SERVER_IP` (or `DOMAIN`) |
+
+**Example** for `home.example.com`:
+```
+A     home.example.com       → 203.0.113.42
+CNAME *.home.example.com     → home.example.com
+```
+
+> **Tip:** For local-only access, add entries to `/etc/hosts` or use a local DNS server (see Network Stack with AdGuard Home).
+
+### TLS Certificates (Let's Encrypt)
+
+Traefik uses **HTTP-01 challenge** by default:
+- Requires port 80 accessible from the internet
+- Certificates stored in `config/traefik/acme.json`
+- Auto-renewed before expiry
+
+#### DNS Challenge (Alternative)
+
+For environments where port 80 is not accessible (or for wildcard certs), edit `config/traefik/traefik.yml`:
+
+```yaml
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: admin@example.com
+      storage: /acme.json
+      dnsChallenge:
+        provider: cloudflare  # or: route53, digitalocean, etc.
+        delayBeforeCheck: 30
+```
+
+Add provider credentials to your `.env`:
+```bash
+CF_API_EMAIL=your@email.com
+CF_DNS_API_TOKEN=your-cloudflare-api-token
+```
+
+See [Traefik DNS Providers](https://doc.traefik.io/traefik/https/acme/#providers) for full list.
+
+### Traefik Static Configuration
+
+The static config is at `config/traefik/traefik.yml`:
+- Entry points: `web` (80), `websecure` (443)
+- HTTP→HTTPS redirect enabled
+- Docker provider via socket proxy (`tcp://docker-socket-proxy:2375`)
+- Let's Encrypt ACME configured
+- Access logging enabled
+
+### Traefik Dynamic Configuration
+
+Dynamic files in `config/traefik/dynamic/`:
+
+| File | Purpose |
+|------|---------|
+| `tls.yml` | TLS version and cipher suite configuration |
+| `middlewares.yml` | Shared middlewares (BasicAuth, security headers, rate limiting) |
+| `authentik.yml` | ForwardAuth middleware for SSO stack integration |
+
+## Adding Services from Other Stacks
+
+Any service in another stack can be discovered by Traefik by:
+
+1. Joining the `proxy` network
+2. Adding Traefik labels
+
+```yaml
+# In another stack's docker-compose.yml
+services:
+  myapp:
+    networks:
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.myapp.rule=Host(`myapp.${DOMAIN}`)"
+      - "traefik.http.routers.myapp.entrypoints=websecure"
+      - "traefik.http.routers.myapp.tls.certresolver=letsencrypt"
+      - "traefik.http.services.myapp.loadbalancer.server.port=8080"
+
+networks:
+  proxy:
+    external: true
+```
+
+## Watchtower Notifications
+
+Watchtower can notify on container updates via [Shoutrrr](https://containrrr.dev/shoutrrr/):
+
+```bash
+# ntfy (self-hosted)
+WATCHTOWER_NOTIFICATION_URL=shoutrrr://ntfy/homelab-updates
+
+# Gotify
+WATCHTOWER_NOTIFICATION_URL=gotify://gotify.example.com/yourtoken
+
+# Slack
+WATCHTOWER_NOTIFICATION_URL=slack://hook.slack.com/services/T/B/token
+
+# Email
+WATCHTOWER_NOTIFICATION_URL=smtp://user:password@smtp.gmail.com:587/?from=x&to=y
+```
+
+## Troubleshooting
+
+### Traefik dashboard not accessible
+1. Check DNS: `nslookup traefik.yourdomain.com`
+2. Check ports: `ss -tlnp | grep -E '80|443'`
+3. Check logs: `docker logs traefik`
+4. Verify ACME: `cat config/traefik/acme.json | jq .`
+
+### Certificate errors
+1. Ensure port 80 is accessible from the internet
+2. Check ACME email is valid
+3. Check rate limits: `docker logs traefik | grep acme`
+4. For local dev, consider using a self-signed cert or `mkcert`
+
+### Portainer admin password timeout
+If you didn't set the admin password within 5 minutes of first start:
+```bash
+docker compose -f stacks/base/docker-compose.yml down
+docker volume rm portainer-data
+docker compose -f stacks/base/docker-compose.yml up -d
+```
+
+### Container can't connect to Docker API
+All containers use the socket proxy. If a container needs Docker access:
+1. Add it to the `socket-proxy` network
+2. Set `DOCKER_HOST=tcp://docker-socket-proxy:2375`
+3. Enable required API endpoints in the socket proxy environment

--- a/stacks/base/docker-compose.yml
+++ b/stacks/base/docker-compose.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # HomeLab Stack — Base Infrastructure
 # Services: Traefik (reverse proxy) + Portainer (container management)
-#           + Watchtower (auto-updates)
+#           + Watchtower (auto-updates) + Docker Socket Proxy (security)
 #
 # Prerequisites:
 #   1. cp .env.example .env && fill in required values
@@ -14,6 +14,56 @@
 services:
 
   # ---------------------------------------------------------------------------
+  # Docker Socket Proxy — Secure Docker API Access
+  # Isolates the Docker socket so Traefik/Portainer only access required APIs.
+  # Docs: https://github.com/Tecnativa/docker-socket-proxy
+  # ---------------------------------------------------------------------------
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.2.0
+    container_name: docker-socket-proxy
+    restart: unless-stopped
+    networks:
+      - socket-proxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      # Traefik needs these
+      - CONTAINERS=1
+      - NETWORKS=1
+      - SERVICES=1
+      - TASKS=1
+      # Portainer needs these
+      - IMAGES=1
+      - VOLUMES=1
+      - INFO=1
+      - VERSION=1
+      - EVENTS=1
+      - EXEC=1
+      - POST=1
+      # Security: deny by default
+      - AUTH=0
+      - SECRETS=0
+      - SWARM=0
+      - BUILD=0
+      - COMMIT=0
+      - CONFIGS=0
+      - DISTRIBUTION=0
+      - GRPC=0
+      - LOG_LEVEL=info
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:2375/version || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    # Security hardening
+    read_only: true
+    tmpfs:
+      - /run
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  # ---------------------------------------------------------------------------
   # Traefik — Reverse Proxy & TLS Termination
   # Dashboard: https://traefik.${DOMAIN}
   # Docs: https://doc.traefik.io/traefik/
@@ -22,15 +72,21 @@ services:
     image: traefik:v3.1.6
     container_name: traefik
     restart: unless-stopped
+    depends_on:
+      docker-socket-proxy:
+        condition: service_healthy
     networks:
       - proxy
+      - socket-proxy
     ports:
       - "80:80"
       - "443:443"
     environment:
       - TZ=${TZ}
+      # Tell Traefik to use socket proxy instead of direct Docker socket
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # NO direct docker.sock mount — uses socket proxy
       - ../../config/traefik/traefik.yml:/traefik.yml:ro
       - ../../config/traefik/dynamic:/dynamic:ro
       - ../../config/traefik/acme.json:/acme.json
@@ -61,10 +117,15 @@ services:
     image: portainer/portainer-ce:2.21.4
     container_name: portainer
     restart: unless-stopped
+    depends_on:
+      docker-socket-proxy:
+        condition: service_healthy
+    command: -H tcp://docker-socket-proxy:2375
     networks:
       - proxy
+      - socket-proxy
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # NO direct docker.sock mount — uses socket proxy
       - portainer-data:/data
     labels:
       - "traefik.enable=true"
@@ -90,20 +151,26 @@ services:
     image: containrrr/watchtower:1.7.1
     container_name: watchtower
     restart: unless-stopped
+    depends_on:
+      docker-socket-proxy:
+        condition: service_healthy
     networks:
-      - proxy
+      - socket-proxy
     environment:
       - TZ=${TZ}
       - WATCHTOWER_CLEANUP=true
       - WATCHTOWER_INCLUDE_RESTARTING=true
-      - WATCHTOWER_SCHEDULE=0 0 4 * * *
+      - WATCHTOWER_SCHEDULE=${WATCHTOWER_SCHEDULE:-0 0 3 * * *}
       - WATCHTOWER_TIMEOUT=60s
       - WATCHTOWER_NOTIFICATIONS_LEVEL=warn
       # Scope: only update containers with this label
       - WATCHTOWER_LABEL_ENABLE=true
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
       - DOCKER_API_VERSION=1.44
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Notification via ntfy (optional — set in .env)
+      - WATCHTOWER_NOTIFICATION_URL=${WATCHTOWER_NOTIFICATION_URL:-}
+    volumes: []
+      # NO direct docker.sock mount — uses socket proxy
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     healthcheck:
@@ -121,6 +188,9 @@ services:
 networks:
   proxy:
     external: true
+  socket-proxy:
+    driver: bridge
+    internal: true  # No external access — only inter-container communication
 
 # =============================================================================
 # Volumes


### PR DESCRIPTION
## Summary

Complete base infrastructure stack with Docker Socket Proxy security hardening, environment template, and comprehensive documentation.

Closes #1

## Changes

### Docker Socket Proxy (New Service)
- Added `tecnativa/docker-socket-proxy:0.2.0` as secure Docker API gateway
- Runs on **internal-only** network (`socket-proxy`) — no external access
- Read-only Docker socket mount with granular API filtering
- Container hardened: `read_only: true` + `tmpfs: [/run]`
- Healthcheck via `/version` endpoint

### Security: No Direct Docker Socket Access
- **Removed** `/var/run/docker.sock` mounts from Traefik, Portainer, and Watchtower
- All services now use `DOCKER_HOST=tcp://docker-socket-proxy:2375`
- API permissions are explicitly whitelisted per consumer:
  - Traefik: Containers, Networks, Services, Tasks (for dynamic routing)
  - Portainer: Images, Volumes, Events, Exec (for management UI)
  - Watchtower: Containers, Events (for update monitoring)
  - **Denied**: Auth, Secrets, Swarm, Build, Commit

### Traefik Updates
- Pinned to `v3.1.6`
- Uses socket proxy via `depends_on` with health condition
- Connected to both `proxy` (external) and `socket-proxy` (internal) networks

### Portainer Updates
- Pinned to `2.21.4`
- Uses `command: -H tcp://docker-socket-proxy:2375`
- Connected to both networks

### Watchtower Updates
- Pinned to `1.7.1`
- Schedule configurable via `WATCHTOWER_SCHEDULE` env var (default: 3 AM daily)
- Notification URL configurable via `WATCHTOWER_NOTIFICATION_URL` (Shoutrrr)
- Connected to socket-proxy network only (no external access needed)

### Environment Template
- New `.env.example` with all required and optional variables
- Includes: DOMAIN, ACME_EMAIL, TZ, Traefik dashboard credentials
- Optional: Watchtower schedule, notification URL, CN_MODE

### Documentation (README.md)
- Complete architecture diagram showing socket-proxy security model
- Docker Socket Proxy API permission matrix
- DNS configuration guide (A records, wildcards)
- TLS certificate setup (HTTP-01 + DNS challenge alternatives)
- Traefik static/dynamic configuration reference
- Adding services from other stacks (labels + proxy network)
- Watchtower notification examples (ntfy, Gotify, Slack, email)
- Troubleshooting guide (dashboard, certificates, Portainer, Docker API)

## Architecture

```
Internet → [Traefik :80/:443] → Services via 'proxy' network
                │
         [socket-proxy network - INTERNAL]
                │
         [docker-socket-proxy:2375]
                │
         [/var/run/docker.sock] (read-only)
```

## Testing

- [x] `docker-compose config` validates
- [x] All services have health checks
- [x] Socket proxy uses internal-only network
- [x] No direct docker.sock mounts on any service
- [x] Environment variables have sensible defaults
