### PR TITLE
[BOUNTY #2] Media Stack — Jellyfin + Sonarr + Radarr + Prowlarr + qBittorrent + Jellyseerr

### DIFF
--- a/stacks/media/.env.example
+++ b/stacks/media/.env.example
@@ -1,7 +1,20 @@
-TZ=Asia/Shanghai
-DOMAIN=localhost
+# Media Stack — Environment Variables
+
+# User/Group IDs (find with: id <username>)
 PUID=1000
 PGID=1000
-# Local paths for media and downloads
-MEDIA_PATH=/mnt/media
-DOWNLOAD_PATH=/mnt/downloads
+
+# Timezone
+TZ=Asia/Shanghai
+
+# Domain (for Traefik subdomains)
+DOMAIN=example.com
+
+# Jellyfin published URL (used by Jellyseerr)
+JELLYFIN_PUBLISHED_URL=https://jellyfin.example.com
+
+# Media root directory
+MEDIA_DIR=/data/media
+
+# Downloads root directory
+DOWNLOAD_DIR=/data/downloads

--- a/stacks/media/README.md
+++ b/stacks/media/README.md
@@ -1,0 +1,122 @@
+# Media Stack
+
+完整的家庭媒体服务栈：自动搜索、下载、整理和播放影视内容。
+
+## 服务概览
+
+| 服务 | 子域名 | 端口 | 用途 |
+|------|--------|------|------|
+| Jellyfin | `jellyfin.{DOMAIN}` | 8096 | 媒体服务器（播放） |
+| Sonarr | `sonarr.{DOMAIN}` | 8989 | 剧集搜索与管理 |
+| Radarr | `radarr.{DOMAIN}` | 7878 | 电影搜索与管理 |
+| Prowlarr | `prowlarr.{DOMAIN}` | 9696 | 索引器聚合管理 |
+| qBittorrent | `qbittorrent.{DOMAIN}` | 8080 | BT 下载客户端 |
+| Jellyseerr | `jellyseerr.{DOMAIN}` | 5055 | 影视请求管理 |
+
+## 架构图
+
+```
+用户请求 → Jellyseerr → Sonarr/Radarr → Prowlarr → 索引器
+                                          ↓
+                                    qBittorrent → 下载到 /data/downloads
+                                          ↓
+                                   Sonarr/Radarr → 整理到 /data/media
+                                          ↓
+                                     Jellyfin → 用户播放
+```
+
+## 前置条件
+
+- Docker + Docker Compose
+- Traefik 反向代理（`proxy` 网络已创建）
+- DNS 记录指向服务器（泛域名 `*.{DOMAIN}`）
+
+## Quick Start
+
+```bash
+cd stacks/media
+cp .env.example .env
+# 编辑 .env 填入实际值
+vim .env
+# 创建数据目录
+mkdir -p /data/media/{movies,tv} /data/downloads/{movies,tv}
+# 启动
+docker compose up -d
+```
+
+## 目录结构
+
+```
+/data/
+├── downloads/          # qBittorrent 下载目录
+│   ├── movies/         # 电影下载
+│   └── tv/             # 剧集下载
+└── media/              # Jellyfin 媒体库
+    ├── movies/         # 电影（Sonarr/Radarr 自动整理）
+    └── tv/             # 剧集（Sonarr/Radarr 自动整理）
+```
+
+> 💡 建议按 [TRaSH Guides](https://trash-guides.info/Hardlinks/How-to-setup-for/Docker/) 配置硬链接，节省磁盘空间。
+
+## 配置步骤
+
+### 1. 配置 Prowlarr（索引器）
+
+1. 访问 `https://prowlarr.{DOMAIN}`
+2. Settings → Indexers → 添加索引器（推荐：PT 站、公共 Tracker）
+3. Settings → Apps → Sonarr/Radarr → 添加连接
+
+### 2. 配置 qBittorrent
+
+1. 访问 `https://qbittorrent.{DOMAIN}`
+2. 默认密码：`adminadmin`，首次登录后修改
+3. Tools → Options → Downloads → 设置默认保存路径为 `/data/downloads`
+
+### 3. 连接 Sonarr ↔ qBittorrent
+
+1. 访问 `https://sonarr.{DOMAIN}`
+2. Settings → Download Clients → 添加 → qBittorrent
+3. Host: `qbittorrent`, Port: `8080`
+4. Settings → Media Management → Root Folders → 添加 `/data/media/tv`
+
+### 4. 连接 Radarr ↔ qBittorrent
+
+1. 访问 `https://radarr.{DOMAIN}`
+2. 同上步骤，Root Folder 设为 `/data/media/movies`
+
+### 5. 配置 Jellyfin 媒体库
+
+1. 访问 `https://jellyfin.{DOMAIN}`
+2. 设置向导 → 添加媒体库
+3. 电影库：`/data/media/movies`
+4. 电视剧集：`/data/media/tv`
+
+### 6. 配置 Jellyseerr
+
+1. 访问 `https://jellyseerr.{DOMAIN}`
+2. 设置向导 → 连接 Jellyfin
+3. 连接 Sonarr + Radarr → 自动处理用户请求
+
+## 验证清单
+
+- [ ] `docker compose ps` — 所有服务显示 healthy
+- [ ] `https://jellyfin.{DOMAIN}` — 可访问
+- [ ] `https://sonarr.{DOMAIN}` — 可访问
+- [ ] `https://radarr.{DOMAIN}` — 可访问
+- [ ] `https://prowlarr.{DOMAIN}` — 可访问
+- [ ] `https://qbittorrent.{DOMAIN}` — 可访问
+- [ ] `https://jellyseerr.{DOMAIN}` — 可访问
+- [ ] Sonarr 能搜索剧集并触发 qBittorrent 下载
+- [ ] Radarr 能搜索电影并触发 qBittorrent 下载
+- [ ] Jellyfin 能识别 `/data/media` 中的媒体文件
+
+## 常见问题
+
+**Q: 硬链接不生效？**
+A: 确保 downloads 和 media 在同一分区，使用 `ls -li` 验证 inode 相同。
+
+**Q: qBittorrent 无法连接？**
+A: 确认端口 6881 已开放（TCP+UDP），防火墙放行。
+
+**Q: Sonarr/Radarr 找不到下载路径？**
+A: 检查容器内路径映射：`/data/downloads` 和 `/data/media` 是否一致。

--- a/stacks/media/docker-compose.yml
+++ b/stacks/media/docker-compose.yml
@@ -1,158 +1,197 @@
+---
+# Media Stack — Jellyfin + Sonarr + Radarr + Prowlarr + qBittorrent + Jellyseerr
+# Requires: proxy network (Traefik) already created
+# Usage: cp .env.example .env && docker compose up -d
+
+services:
+  jellyfin:
+    image: jellyfin/jellyfin:10.9.11
+    container_name: jellyfin
+    restart: unless-stopped
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - jellyfin-config:/config
+      - ${MEDIA_DIR}:/data/media:ro
+      - ${DOWNLOAD_DIR}:/data/downloads:ro
+    networks:
+      - proxy
+      - internal
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.${DOMAIN}`)"
+      - "traefik.http.routers.jellyfin.entrypoints=websecure"
+      - "traefik.http.routers.jellyfin.tls=true"
+      - "traefik.http.routers.jellyfin.tls.certresolver=letsencrypt"
+      - "traefik.http.services.jellyfin.loadbalancer.server.port=8096"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8096/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  sonarr:
+    image: lscr.io/linuxserver/sonarr:4.0.11
+    container_name: sonarr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - sonarr-config:/config
+      - ${MEDIA_DIR}/tv:/data/media/tv
+      - ${DOWNLOAD_DIR}:/data/downloads
+    networks:
+      - proxy
+      - internal
+    depends_on:
+      qbittorrent:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)"
+      - "traefik.http.routers.sonarr.entrypoints=websecure"
+      - "traefik.http.routers.sonarr.tls=true"
+      - "traefik.http.routers.sonarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.sonarr.loadbalancer.server.port=8989"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8989/api/v3/system/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  radarr:
+    image: lscr.io/linuxserver/radarr:5.8.1
+    container_name: radarr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - radarr-config:/config
+      - ${MEDIA_DIR}/movies:/data/media/movies
+      - ${DOWNLOAD_DIR}:/data/downloads
+    networks:
+      - proxy
+      - internal
+    depends_on:
+      qbittorrent:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)"
+      - "traefik.http.routers.radarr.entrypoints=websecure"
+      - "traefik.http.routers.radarr.tls=true"
+      - "traefik.http.routers.radarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.radarr.loadbalancer.server.port=7878"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:7878/api/v3/system/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:1.22.0
+    container_name: prowlarr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+    volumes:
+      - prowlarr-config:/config
+    networks:
+      - proxy
+      - internal
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)"
+      - "traefik.http.routers.prowlarr.entrypoints=websecure"
+      - "traefik.http.routers.prowlarr.tls=true"
+      - "traefik.http.routers.prowlarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.prowlarr.loadbalancer.server.port=9696"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9696/api/v1/system/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:4.6.7
+    container_name: qbittorrent
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID}
+      - PGID=${PGID}
+      - TZ=${TZ}
+      - WEBUI_PORT=8080
+    volumes:
+      - qbittorrent-config:/config
+      - ${DOWNLOAD_DIR}:/data/downloads
+    networks:
+      - proxy
+      - internal
+    ports:
+      - "6881:6881"
+      - "6881:6881/udp"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.${DOMAIN}`)"
+      - "traefik.http.routers.qbittorrent.entrypoints=websecure"
+      - "traefik.http.routers.qbittorrent.tls=true"
+      - "traefik.http.routers.qbittorrent.tls.certresolver=letsencrypt"
+      - "traefik.http.services.qbittorrent.loadbalancer.server.port=8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/api/v2/app/version || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  jellyseerr:
+    image: fallenbagel/jellyseerr:2.1.1
+    container_name: jellyseerr
+    restart: unless-stopped
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - jellyseerr-config:/app/config
+    networks:
+      - proxy
+      - internal
+    depends_on:
+      jellyfin:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jellyseerr.rule=Host(`jellyseerr.${DOMAIN}`)"
+      - "traefik.http.routers.jellyseerr.entrypoints=websecure"
+      - "traefik.http.routers.jellyseerr.tls=true"
+      - "traefik.http.routers.jellyseerr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.jellyseerr.loadbalancer.server.port=5055"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:5055/api/v1/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+volumes:
+  jellyfin-config:
+  sonarr-config:
+  radarr-config:
+  prowlarr-config:
+  qbittorrent-config:
+  jellyseerr-config:
+
 networks:
   proxy:
     external: true
-services:
-  jellyfin:
-    container_name: jellyfin
-    environment:
-    - TZ=${TZ}
-    - JELLYFIN_PublishedServerUrl=https://media.${DOMAIN}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 30s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8096/health
-      timeout: 10s
-    image: jellyfin/jellyfin:10.9.11
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.jellyfin.rule=Host()
-    - traefik.http.routers.jellyfin.entrypoints=websecure
-    - traefik.http.routers.jellyfin.tls=true
-    - traefik.http.services.jellyfin.loadbalancer.server.port=8096
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - jellyfin-config:/config
-    - jellyfin-cache:/cache
-    - ${MEDIA_PATH}:/media:ro
-  prowlarr:
-    container_name: prowlarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:9696/ping
-      timeout: 10s
-    image: linuxserver/prowlarr:1.24.3
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)
-    - traefik.http.routers.prowlarr.entrypoints=websecure
-    - traefik.http.routers.prowlarr.tls=true
-    - traefik.http.services.prowlarr.loadbalancer.server.port=9696
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - prowlarr-config:/config
-  qbittorrent:
-    container_name: qbittorrent
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    - WEBUI_PORT=8080
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8080
-      timeout: 10s
-    image: linuxserver/qbittorrent:4.6.7
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.qbittorrent.rule=Host(`bt.${DOMAIN}`)
-    - traefik.http.routers.qbittorrent.entrypoints=websecure
-    - traefik.http.routers.qbittorrent.tls=true
-    - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - qbittorrent-config:/config
-    - ${DOWNLOAD_PATH}:/downloads
-  radarr:
-    container_name: radarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:7878/ping
-      timeout: 10s
-    image: linuxserver/radarr:5.11.0
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)
-    - traefik.http.routers.radarr.entrypoints=websecure
-    - traefik.http.routers.radarr.tls=true
-    - traefik.http.services.radarr.loadbalancer.server.port=7878
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - radarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
-  sonarr:
-    container_name: sonarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8989/ping
-      timeout: 10s
-    image: linuxserver/sonarr:4.0.9
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)
-    - traefik.http.routers.sonarr.entrypoints=websecure
-    - traefik.http.routers.sonarr.tls=true
-    - traefik.http.services.sonarr.loadbalancer.server.port=8989
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - sonarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
-volumes:
-  jellyfin-cache: null
-  jellyfin-config: null
-  prowlarr-config: null
-  qbittorrent-config: null
-  radarr-config: null
-  sonarr-config: null
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary

Implements Issue #2 — Complete media service stack.

## Services (all pinned versions)
- **Jellyfin** (10.9.11) — Media server
- **Sonarr** (4.0.11) — TV show management
- **Radarr** (5.8.1) — Movie management
- **Prowlarr** (1.22.0) — Indexer management
- **qBittorrent** (4.6.7) — Download client
- **Jellyseerr** (2.1.1) — Request management

## Key Design
- PUID/PGID for linuxserver images
- proxy + internal network topology
- Download → media directory auto-import flow
- Health checks + depends_on ordering
- Traefik reverse proxy labels

## Acceptance Criteria
- [x] All 6 services configured with pinned versions
- [x] Health checks on all containers
- [x] Traefik routing for all web UIs
- [x] .env.example with no hardcoded values
- [x] README with Quick Start + verification

Closes #2