### PR TITLE
[BOUNTY #7] Home Automation — HA + Node-RED + Mosquitto + Zigbee2MQTT

### DIFF
--- a/stacks/home-automation/.env.example
+++ b/stacks/home-automation/.env.example
@@ -1,0 +1,10 @@
+# =============================================================================
+# Home Automation Stack — Environment Variables
+# Copy to .env: cp .env.example .env
+# =============================================================================
+
+# Timezone
+TZ=Asia/Shanghai
+
+# Domain (used by Traefik labels)
+DOMAIN=yourdomain.com

--- a/stacks/home-automation/README.md
+++ b/stacks/home-automation/README.md
@@ -1,0 +1,115 @@
+# 🏠 Home Automation Stack
+
+智能家居自动化栈，集成 Home Assistant、Node-RED、Mosquitto 和 Zigbee2MQTT。
+
+## 服务概览
+
+| 服务 | 镜像 | 端口 | 用途 | Traefik |
+|------|------|------|------|---------|
+| Home Assistant | `homeassistant/home-assistant:2024.12.5` | 8123 (host) | 智能家居中枢 | ✅ host 模式直连 |
+| Node-RED | `nodered/node-red:3.1.9` | 1883 | 可视化流程编排 | ✅ `nodered.${DOMAIN}` |
+| Mosquitto | `eclipse-mosquitto:2.0.20` | 1883 | MQTT Broker | ❌ 仅内部网络 |
+| Zigbee2MQTT | `koenkk/zigbee2mqtt:1.40.0` | — | Zigbee 设备桥接 | ❌ 仅内部网络 |
+
+## 网络架构
+
+```
+proxy (external)          homeautomation (bridge)
+┌──────────────────┐      ┌──────────────────┐
+│  Node-RED ◄──────┼──────┤  Node-RED        │
+│                  │      │  Mosquitto       │
+└──────────────────┘      │  Zigbee2MQTT     │
+                          │  Home Assistant  │
+                          └──────────────────┘
+```
+
+- **proxy**: 外部网络，Traefik 反向代理使用
+- **homeautomation**: 内部桥接网络，服务间通信
+- **Mosquitto** 仅在 homeautomation 网络，不暴露到 proxy
+- **Home Assistant** 使用 host 网络模式（见下方说明）
+
+## Home Assistant 网络模式说明
+
+### 为什么使用 `network_mode: host`？
+
+Home Assistant 需要通过 **mDNS** 和 **UPnP/SSDP** 协议发现和控制设备（如 Chromecast、HomeKit、某些 Zigbee/Z-Wave 适配器）。这些协议依赖多播（multicast），Docker bridge 网络默认**不支持多播**。
+
+使用 host 模式可以让 HA 直接访问宿主机的网络栈，完整支持所有设备发现协议。
+
+### Bridge 模式替代
+
+`docker-compose.yml` 中提供了注释掉的 bridge 模式配置。如果启用：
+
+- ✅ 可通过 Traefik 反代访问（`ha.${DOMAIN}`）
+- ❌ **不支持** mDNS/UPnP 设备发现
+- ❌ Chromecast、AirPlay、部分智能家居桥接功能受限
+- ❌ 某些 Zigbee 适配器可能无法正常工作
+
+## 前置准备
+
+1. **Zigbee 适配器**: 确认 USB Zigbee 适配器设备路径（默认 `/dev/ttyACM0`）
+   ```bash
+   ls /dev/ttyACM*
+   ```
+   如路径不同，修改 `docker-compose.yml` 中 `zigbee2mqtt.devices`。
+
+2. **Mosquitto 配置**: 确保 `config/mosquitto/mosquitto.conf` 存在（仓库已提供）。
+
+3. **Traefik 网络**: 确保 `proxy` 外部网络已创建：
+   ```bash
+   docker network create proxy
+   ```
+
+## 快速启动
+
+```bash
+cd stacks/home-automation
+cp .env.example .env
+# 编辑 .env，设置 DOMAIN=yourdomain.com
+docker compose up -d
+```
+
+## 初始配置
+
+### Home Assistant
+- 访问 `http://<HOST_IP>:8123` 完成初始化向导
+- 添加 Mosquitto MQTT 集成（broker: `mosquitto`, port: `1883`）
+- 添加 Zigbee2MQTT 集成
+
+### Node-RED
+- 访问 `https://nodered.${DOMAIN}`
+- 安装 `node-red-contrib-home-assistant` 插件连接 HA
+- 配置 MQTT 节点连接 `mosquitto:1883`
+
+### Zigbee2MQTT
+- 编辑 `zigbee2mqtt_data/configuration.yaml` 设置适配器和 MQTT 参数
+- 前端访问需通过 Node-RED 或 HA 集成
+
+## 数据持久化
+
+所有数据存储在 Docker 命名卷中：
+
+| 卷 | 说明 |
+|----|------|
+| `ha_config` | Home Assistant 配置和自定义组件 |
+| `nodered_data` | Node-RED 流程和节点 |
+| `mosquitto_data` | MQTT 持久化消息 |
+| `mosquitto_log` | Mosquitto 日志 |
+| `zigbee2mqtt_data` | Zigbee2MQTT 配置和设备数据库 |
+
+## 维护
+
+```bash
+# 查看日志
+docker compose logs -f homeassistant
+docker compose logs -f nodered
+docker compose logs -f mosquitto
+docker compose logs -f zigbee2mqtt
+
+# 备份
+docker run --rm -v ha_config:/data -v $(pwd):/backup alpine tar czf /backup/ha_config.tar.gz -C /data .
+
+# 更新
+docker compose pull
+docker compose up -d
+```

--- a/stacks/home-automation/docker-compose.yml
+++ b/stacks/home-automation/docker-compose.yml
@@ -1,103 +1,153 @@
 services:
+  # ---------------------------------------------------------------------------
+  # Home Assistant — 智能家居中枢
+  # ---------------------------------------------------------------------------
+  # ⚠️ network_mode: host is REQUIRED for mDNS/UPnP device discovery.
+  #    Bridge mode breaks SSDP, mDNS, and some Zigbee/Z-Wave integrations.
+  #    See the bridge-mode alternative below (commented out).
   homeassistant:
-    image: homeassistant/home-assistant:2024.11.3
+    image: homeassistant/home-assistant:2024.12.5
     container_name: homeassistant
     restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - ha-config:/config
+    # === Recommended: host mode (full mDNS / UPnP / discovery support) ===
+    network_mode: host
     environment:
       - TZ=${TZ:-Asia/Shanghai}
-    privileged: true
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.ha.rule=Host(`ha.${DOMAIN}`)"
-      - traefik.http.routers.ha.entrypoints=websecure
-      - traefik.http.routers.ha.tls=true
-      - traefik.http.services.ha.loadbalancer.server.port=8123
+    volumes:
+      - ha_config:/config
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8123/ || exit 1"]
+      test: ["CMD", "curl", "-f", "http://localhost:8123"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 60s
+    depends_on:
+      mosquitto:
+        condition: service_healthy
 
-  node-red:
-    image: nodered/node-red:3.1.14
-    container_name: node-red
+  # ---------------------------------------------------------------------------
+  # Alternative: Home Assistant in bridge mode
+  # Uncomment below and comment out the host-mode service above.
+  # NOTE: Bridge mode does NOT support mDNS/UPnP device discovery.
+  #       Some integrations (Cast, HomeKit, certain Zigbee dongles) may not work.
+  # ---------------------------------------------------------------------------
+  # homeassistant:
+  #   image: homeassistant/home-assistant:2024.12.5
+  #   container_name: homeassistant
+  #   restart: unless-stopped
+  #   environment:
+  #     - TZ=${TZ:-Asia/Shanghai}
+  #   volumes:
+  #     - ha_config:/config
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-f", "http://localhost:8123"]
+  #     interval: 30s
+  #     timeout: 10s
+  #     retries: 3
+  #     start_period: 60s
+  #   depends_on:
+  #     mosquitto:
+  #       condition: service_healthy
+  #   labels:
+  #     - traefik.enable=true
+  #     - traefik.http.routers.homeassistant.rule=Host(`ha.${DOMAIN}`)
+  #     - traefik.http.routers.homeassistant.entrypoints=websecure
+  #     - traefik.http.routers.homeassistant.tls=true
+  #     - traefik.http.routers.homeassistant.middlewares=authentik@file
+  #     - traefik.http.services.homeassistant.loadbalancer.server.port=8123
+  #   networks:
+  #     - homeautomation
+  #     - proxy
+
+  # ---------------------------------------------------------------------------
+  # Node-RED — 可视化流程编排
+  # ---------------------------------------------------------------------------
+  nodered:
+    image: nodered/node-red:3.1.9
+    container_name: nodered
     restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - node-red-data:/data
     environment:
       - TZ=${TZ:-Asia/Shanghai}
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.nodered.rule=Host(`nodered.${DOMAIN}`)"
-      - traefik.http.routers.nodered.entrypoints=websecure
-      - traefik.http.routers.nodered.tls=true
-      - traefik.http.services.nodered.loadbalancer.server.port=1880
+    volumes:
+      - nodered_data:/data
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:1880/ || exit 1"]
+      test: ["CMD", "curl", "-f", "http://localhost:1880"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
-
-  mosquitto:
-    image: eclipse-mosquitto:2.0.20
-    container_name: mosquitto
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - mosquitto-data:/mosquitto/data
-      - mosquitto-logs:/mosquitto/log
-      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
-    ports:
-      - "1883:1883"
-    healthcheck:
-      test: [CMD-SHELL, "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
-
-  zigbee2mqtt:
-    image: koenkk/zigbee2mqtt:1.41.0
-    container_name: zigbee2mqtt
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - zigbee2mqtt-data:/app/data
-    environment:
-      - TZ=${TZ:-Asia/Shanghai}
     depends_on:
       mosquitto:
         condition: service_healthy
     labels:
       - traefik.enable=true
-      - "traefik.http.routers.zigbee2mqtt.rule=Host(`zigbee.${DOMAIN}`)"
-      - traefik.http.routers.zigbee2mqtt.entrypoints=websecure
-      - traefik.http.routers.zigbee2mqtt.tls=true
-      - traefik.http.services.zigbee2mqtt.loadbalancer.server.port=8080
+      - traefik.http.routers.nodered.rule=Host(`nodered.${DOMAIN}`)
+      - traefik.http.routers.nodered.entrypoints=websecure
+      - traefik.http.routers.nodered.tls=true
+      - traefik.http.routers.nodered.middlewares=authentik@file
+      - traefik.http.services.nodered.loadbalancer.server.port=1880
+    networks:
+      - homeautomation
+      - proxy
+
+  # ---------------------------------------------------------------------------
+  # Mosquitto — MQTT Broker (internal only, no proxy exposure)
+  # ---------------------------------------------------------------------------
+  mosquitto:
+    image: eclipse-mosquitto:2.0.20
+    container_name: mosquitto
+    restart: unless-stopped
+    ports:
+      - "1883:1883"
+    volumes:
+      - ../../config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - mosquitto_data:/mosquitto/data
+      - mosquitto_log:/mosquitto/log
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8080/ || exit 1"]
+      test: ["CMD", "mosquitto_pub", "-h", "localhost", "-t", "health", "-m", "ok"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - homeautomation
+
+  # ---------------------------------------------------------------------------
+  # Zigbee2MQTT — Zigbee 设备桥接
+  # ---------------------------------------------------------------------------
+  zigbee2mqtt:
+    image: koenkk/zigbee2mqtt:1.40.0
+    container_name: zigbee2mqtt
+    restart: unless-stopped
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    volumes:
+      - zigbee2mqtt_data:/app/data
+    devices:
+      - /dev/ttyACM0:/dev/ttyACM0  # USB Zigbee adapter — adjust as needed
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+    networks:
+      - homeautomation
 
 networks:
+  homeautomation:
+    driver: bridge
   proxy:
     external: true
 
 volumes:
-  ha-config:
-  node-red-data:
-  mosquitto-data:
-  mosquitto-logs:
-  zigbee2mqtt-data:
+  ha_config:
+  nodered_data:
+  mosquitto_data:
+  mosquitto_log:
+  zigbee2mqtt_data:


### PR DESCRIPTION
## Summary

Implements Issue #7 — Complete home automation stack.

## Services
- **Home Assistant** (2024.12.5) — Smart home hub (network_mode: host)
- **Node-RED** (3.1.9) — Visual flow automation
- **Mosquitto** (2.0.20) — MQTT broker (internal only)
- **Zigbee2MQTT** (1.40.0) — Zigbee device bridge

## Key Design
- HA in host mode for mDNS/UPnP/discovery
- Mosquitto internal-only (no Traefik)
- Zigbee2MQTT USB device mapping
- MQTT integration: HA ↔ Mosquitto ↔ Zigbee2MQTT

Closes #7