### PR TITLE
[BOUNTY 60] feat(media): implement media stack — Jellyfin + Sonarr + Radarr + Prowlarr + qBittorrent + Jellyseerr

### DIFF
--- a/stacks/media/.env.example
+++ b/stacks/media/.env.example
@@ -1,7 +1,21 @@
+# ─────────────────────────────────────────────────────────
+# Media Stack — Environment Variables
+# Copy to .env and fill in your values
+# ─────────────────────────────────────────────────────────
+
+# Domain (inherited from base stack, override here if needed)
+DOMAIN=example.com
+
+# Timezone
 TZ=Asia/Shanghai
-DOMAIN=localhost
+
+# User/Group IDs for LinuxServer containers
+# Find yours with: id $(whoami)
 PUID=1000
 PGID=1000
-# Local paths for media and downloads
-MEDIA_PATH=/mnt/media
-DOWNLOAD_PATH=/mnt/downloads
+
+# Media directory (Jellyfin reads from here)
+MEDIA_ROOT=/data/media
+
+# Downloads directory (qBittorrent downloads here, arr-stack moves files to MEDIA_ROOT)
+DOWNLOADS_ROOT=/data/torrents

--- a/stacks/media/README.md
+++ b/stacks/media/README.md
@@ -1,0 +1,164 @@
+# 🎬 Media Stack
+
+Complete self-hosted media management suite. Automatically searches, downloads, organizes, and streams your media library.
+
+## Services
+
+| Service | Image | URL | Purpose |
+|---------|-------|-----|---------|
+| Jellyfin | `jellyfin/jellyfin:10.9.11` | `jellyfin.example.com` | Media streaming server |
+| Sonarr | `lscr.io/linuxserver/sonarr:4.0.11` | `sonarr.example.com` | TV series management |
+| Radarr | `lscr.io/linuxserver/radarr:5.8.1` | `radarr.example.com` | Movie management |
+| Prowlarr | `lscr.io/linuxserver/prowlarr:1.22.0` | `prowlarr.example.com` | Indexer management |
+| qBittorrent | `lscr.io/linuxserver/qbittorrent:4.6.7` | `qbittorrent.example.com` | Torrent downloader |
+| Jellyseerr | `fallenbagel/jellyseerr:2.1.1` | `jellyseerr.example.com` | Media request portal |
+
+## Prerequisites
+
+- Base infrastructure stack running (`proxy` network must exist)
+- Host directories created (see below)
+
+## Directory Structure
+
+Following [TRaSH Guides](https://trash-guides.info/Hardlinks/How-to-setup-for/Docker/) hardlink best practice — **all data on the same filesystem** enables instant hardlinks (no copying):
+
+```
+/data/
+├── torrents/              # qBittorrent download root (DOWNLOADS_ROOT)
+│   ├── movies/            # radarr category
+│   └── tv/                # sonarr category
+└── media/                 # Jellyfin library root (MEDIA_ROOT)
+    ├── movies/
+    └── tv/
+```
+
+```bash
+# Create directories
+sudo mkdir -p /data/{torrents/{movies,tv},media/{movies,tv}}
+sudo chown -R $USER:$USER /data
+```
+
+## Quick Start
+
+```bash
+# 1. Create host directories
+sudo mkdir -p /data/{torrents/{movies,tv},media/{movies,tv}}
+sudo chown -R $(id -u):$(id -g) /data
+
+# 2. Configure environment
+cp stacks/media/.env.example stacks/media/.env
+# Edit DOMAIN, MEDIA_ROOT, DOWNLOADS_ROOT, PUID, PGID
+
+# 3. Start the stack (order is managed by depends_on)
+cd stacks/media
+docker compose up -d
+
+# 4. Check health
+docker compose ps
+```
+
+## Post-Start Configuration
+
+### 1. qBittorrent — Initial Setup
+
+Default credentials: `admin` / `adminadmin` (change immediately!)
+
+In qBittorrent Settings:
+- **Downloads → Save files to location**: `/downloads`
+- **BitTorrent → Categories**: add `movies` → `/downloads/movies`, `tv` → `/downloads/tv`
+- **Web UI**: set a strong password
+- **Advanced → Network interface**: (optional) bind to VPN if using one
+
+### 2. Prowlarr — Add Indexers
+
+1. Go to `https://prowlarr.example.com`
+2. **Indexers → Add Indexer**: add your preferred torrent/usenet indexers
+3. **Settings → Apps → Add App**: connect to Sonarr and Radarr (auto-sync indexers)
+
+### 3. Sonarr — Connect to qBittorrent
+
+1. Go to `https://sonarr.example.com`
+2. **Settings → Download Clients → Add**: qBittorrent
+   - Host: `qbittorrent` (container name)
+   - Port: `8080`
+   - Username/Password: your qBittorrent credentials
+   - Category: `tv`
+3. **Settings → Media Management**: set root folder to `/data/media/tv`
+4. Prowlarr will auto-sync indexers after step 2 above
+
+### 4. Radarr — Connect to qBittorrent
+
+Same as Sonarr, but:
+- Category: `movies`
+- Root folder: `/data/media/movies`
+
+### 5. Jellyfin — Add Media Library
+
+1. Go to `https://jellyfin.example.com` → complete initial setup wizard
+2. **Dashboard → Libraries → Add Media Library**:
+   - Type: Movies → Folder: `/data/media/movies`
+   - Type: TV Shows → Folder: `/data/media/tv`
+3. Trigger a library scan
+
+### 6. Jellyseerr — Connect to Jellyfin + Arr Stack
+
+1. Go to `https://jellyseerr.example.com`
+2. Sign in with Jellyfin credentials
+3. Configure Sonarr/Radarr under **Settings → Services**
+
+## Hardware Acceleration (Optional)
+
+### Intel Quick Sync (iGPU)
+
+Uncomment in `docker-compose.yml`:
+```yaml
+devices:
+  - /dev/dri:/dev/dri
+```
+
+In Jellyfin Dashboard → Playback → Transcoding: select "Intel Quick Sync Video"
+
+### NVIDIA GPU
+
+```yaml
+runtime: nvidia
+environment:
+  NVIDIA_VISIBLE_DEVICES: all
+```
+
+Requires: [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+
+## Network Architecture
+
+```
+Internet → Traefik (proxy network)
+             ├── jellyfin.domain → Jellyfin:8096
+             ├── sonarr.domain → Sonarr:8989
+             ├── radarr.domain → Radarr:7878
+             ├── prowlarr.domain → Prowlarr:9696
+             ├── qbittorrent.domain → qBittorrent:8080
+             └── jellyseerr.domain → Jellyseerr:5055
+
+Internal (media_internal network — services communicate here):
+  Sonarr ←→ qBittorrent
+  Radarr ←→ qBittorrent
+  Prowlarr → Sonarr, Radarr (indexer sync)
+  Jellyseerr → Jellyfin, Sonarr, Radarr
+```
+
+## FAQ
+
+**Q: Sonarr says "Unable to connect to qBittorrent"**
+A: Use container name `qbittorrent` as the host (not `localhost` or an IP). Both containers must be on `media_internal` network.
+
+**Q: Hardlinks not working / Radarr copies instead of moving**
+A: Ensure `MEDIA_ROOT` and `DOWNLOADS_ROOT` are on the **same filesystem** and the same physical disk. If they're on different volumes, hardlinks are impossible and files will be copied.
+
+**Q: Jellyfin is slow / transcoding fails**
+A: Enable hardware acceleration (see above). Without it, Jellyfin transcodes in software which is CPU-intensive.
+
+**Q: qBittorrent WebUI not accessible**
+A: Check logs: `docker compose logs qbittorrent`. The initial password is printed to logs on first run if you haven't set one.
+
+**Q: How do I update service versions?**
+A: Watchtower handles auto-updates for containers with `com.centurylinklabs.watchtower.enable: "true"` label. To manually update: `docker compose pull && docker compose up -d`

--- a/stacks/media/docker-compose.yml
+++ b/stacks/media/docker-compose.yml
@@ -1,158 +1,244 @@
+---
+# Media Stack
+# Services: Jellyfin, Sonarr, Radarr, Prowlarr, qBittorrent, Jellyseerr
+# Depends on: base stack (proxy network + Traefik)
+
 networks:
   proxy:
     external: true
+  media_internal:
+    name: media_internal
+    driver: bridge
+    internal: true
+
+volumes:
+  jellyfin_config:
+  sonarr_config:
+  radarr_config:
+  prowlarr_config:
+  qbittorrent_config:
+  jellyseerr_config:
+
 services:
-  jellyfin:
-    container_name: jellyfin
+  # ─────────────────────────────────────────────
+  # qBittorrent — torrent downloader
+  # Must start first as arr-stack depends on it
+  # ─────────────────────────────────────────────
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:4.6.7
+    container_name: qbittorrent
+    restart: unless-stopped
+    networks:
+      - proxy
+      - media_internal
     environment:
-    - TZ=${TZ}
-    - JELLYFIN_PublishedServerUrl=https://media.${DOMAIN}
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
+      TZ: ${TZ:-Asia/Shanghai}
+      WEBUI_PORT: 8080
+    volumes:
+      - qbittorrent_config:/config
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/downloads
+      - ${DOWNLOADS_ROOT:-/data/torrents}/movies:/downloads/movies
+      - ${DOWNLOADS_ROOT:-/data/torrents}/tv:/downloads/tv
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.qbittorrent.rule: "Host(`qbittorrent.${DOMAIN}`)"
+      traefik.http.routers.qbittorrent.entrypoints: "websecure"
+      traefik.http.routers.qbittorrent.tls: "true"
+      traefik.http.routers.qbittorrent.tls.certresolver: "letsencrypt"
+      traefik.http.services.qbittorrent.loadbalancer.server.port: "8080"
+      com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v2/app/version"]
       interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  # ─────────────────────────────────────────────
+  # Prowlarr — indexer manager (feeds Sonarr/Radarr)
+  # ─────────────────────────────────────────────
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:1.22.0
+    container_name: prowlarr
+    restart: unless-stopped
+    depends_on:
+      qbittorrent:
+        condition: service_healthy
+    networks:
+      - proxy
+      - media_internal
+    environment:
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
+      TZ: ${TZ:-Asia/Shanghai}
+    volumes:
+      - prowlarr_config:/config
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.prowlarr.rule: "Host(`prowlarr.${DOMAIN}`)"
+      traefik.http.routers.prowlarr.entrypoints: "websecure"
+      traefik.http.routers.prowlarr.tls: "true"
+      traefik.http.routers.prowlarr.tls.certresolver: "letsencrypt"
+      traefik.http.services.prowlarr.loadbalancer.server.port: "9696"
+      com.centurylinklabs.watchtower.enable: "true"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9696/ping"]
+      interval: 30s
+      timeout: 10s
       retries: 3
       start_period: 30s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8096/health
-      timeout: 10s
-    image: jellyfin/jellyfin:10.9.11
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.jellyfin.rule=Host()
-    - traefik.http.routers.jellyfin.entrypoints=websecure
-    - traefik.http.routers.jellyfin.tls=true
-    - traefik.http.services.jellyfin.loadbalancer.server.port=8096
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - jellyfin-config:/config
-    - jellyfin-cache:/cache
-    - ${MEDIA_PATH}:/media:ro
-  prowlarr:
-    container_name: prowlarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:9696/ping
-      timeout: 10s
-    image: linuxserver/prowlarr:1.24.3
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)
-    - traefik.http.routers.prowlarr.entrypoints=websecure
-    - traefik.http.routers.prowlarr.tls=true
-    - traefik.http.services.prowlarr.loadbalancer.server.port=9696
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - prowlarr-config:/config
-  qbittorrent:
-    container_name: qbittorrent
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    - WEBUI_PORT=8080
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8080
-      timeout: 10s
-    image: linuxserver/qbittorrent:4.6.7
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.qbittorrent.rule=Host(`bt.${DOMAIN}`)
-    - traefik.http.routers.qbittorrent.entrypoints=websecure
-    - traefik.http.routers.qbittorrent.tls=true
-    - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - qbittorrent-config:/config
-    - ${DOWNLOAD_PATH}:/downloads
-  radarr:
-    container_name: radarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:7878/ping
-      timeout: 10s
-    image: linuxserver/radarr:5.11.0
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)
-    - traefik.http.routers.radarr.entrypoints=websecure
-    - traefik.http.routers.radarr.tls=true
-    - traefik.http.services.radarr.loadbalancer.server.port=7878
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - radarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+
+  # ─────────────────────────────────────────────
+  # Sonarr — TV series management
+  # ─────────────────────────────────────────────
   sonarr:
+    image: lscr.io/linuxserver/sonarr:4.0.11
     container_name: sonarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8989/ping
-      timeout: 10s
-    image: linuxserver/sonarr:4.0.9
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)
-    - traefik.http.routers.sonarr.entrypoints=websecure
-    - traefik.http.routers.sonarr.tls=true
-    - traefik.http.services.sonarr.loadbalancer.server.port=8989
-    networks:
-    - proxy
     restart: unless-stopped
+    depends_on:
+      qbittorrent:
+        condition: service_healthy
+      prowlarr:
+        condition: service_healthy
+    networks:
+      - proxy
+      - media_internal
+    environment:
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
+      TZ: ${TZ:-Asia/Shanghai}
     volumes:
-    - sonarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
-volumes:
-  jellyfin-cache: null
-  jellyfin-config: null
-  prowlarr-config: null
-  qbittorrent-config: null
-  radarr-config: null
-  sonarr-config: null
+      - sonarr_config:/config
+      - ${MEDIA_ROOT:-/data/media}:/data/media
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/data/torrents
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.sonarr.rule: "Host(`sonarr.${DOMAIN}`)"
+      traefik.http.routers.sonarr.entrypoints: "websecure"
+      traefik.http.routers.sonarr.tls: "true"
+      traefik.http.routers.sonarr.tls.certresolver: "letsencrypt"
+      traefik.http.services.sonarr.loadbalancer.server.port: "8989"
+      com.centurylinklabs.watchtower.enable: "true"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8989/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ─────────────────────────────────────────────
+  # Radarr — movie management
+  # ─────────────────────────────────────────────
+  radarr:
+    image: lscr.io/linuxserver/radarr:5.8.1
+    container_name: radarr
+    restart: unless-stopped
+    depends_on:
+      qbittorrent:
+        condition: service_healthy
+      prowlarr:
+        condition: service_healthy
+    networks:
+      - proxy
+      - media_internal
+    environment:
+      PUID: ${PUID:-1000}
+      PGID: ${PGID:-1000}
+      TZ: ${TZ:-Asia/Shanghai}
+    volumes:
+      - radarr_config:/config
+      - ${MEDIA_ROOT:-/data/media}:/data/media
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/data/torrents
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.radarr.rule: "Host(`radarr.${DOMAIN}`)"
+      traefik.http.routers.radarr.entrypoints: "websecure"
+      traefik.http.routers.radarr.tls: "true"
+      traefik.http.routers.radarr.tls.certresolver: "letsencrypt"
+      traefik.http.services.radarr.loadbalancer.server.port: "7878"
+      com.centurylinklabs.watchtower.enable: "true"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7878/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ─────────────────────────────────────────────
+  # Jellyfin — media server
+  # ─────────────────────────────────────────────
+  jellyfin:
+    image: jellyfin/jellyfin:10.9.11
+    container_name: jellyfin
+    restart: unless-stopped
+    networks:
+      - proxy
+      - media_internal
+    environment:
+      TZ: ${TZ:-Asia/Shanghai}
+      JELLYFIN_PublishedServerUrl: "https://jellyfin.${DOMAIN}"
+    volumes:
+      - jellyfin_config:/config
+      - ${MEDIA_ROOT:-/data/media}:/data/media:ro
+    # Uncomment for hardware acceleration (Intel Quick Sync):
+    # devices:
+    #   - /dev/dri:/dev/dri
+    # Uncomment for hardware acceleration (NVIDIA):
+    # runtime: nvidia
+    # environment:
+    #   NVIDIA_VISIBLE_DEVICES: all
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.jellyfin.rule: "Host(`jellyfin.${DOMAIN}`)"
+      traefik.http.routers.jellyfin.entrypoints: "websecure"
+      traefik.http.routers.jellyfin.tls: "true"
+      traefik.http.routers.jellyfin.tls.certresolver: "letsencrypt"
+      traefik.http.services.jellyfin.loadbalancer.server.port: "8096"
+      # Required for Jellyfin media streaming
+      traefik.http.routers.jellyfin.middlewares: "compress@file"
+      com.centurylinklabs.watchtower.enable: "true"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8096/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  # ─────────────────────────────────────────────
+  # Jellyseerr — media request management
+  # ─────────────────────────────────────────────
+  jellyseerr:
+    image: fallenbagel/jellyseerr:2.1.1
+    container_name: jellyseerr
+    restart: unless-stopped
+    depends_on:
+      jellyfin:
+        condition: service_healthy
+      sonarr:
+        condition: service_healthy
+      radarr:
+        condition: service_healthy
+    networks:
+      - proxy
+      - media_internal
+    environment:
+      TZ: ${TZ:-Asia/Shanghai}
+      LOG_LEVEL: info
+    volumes:
+      - jellyseerr_config:/app/config
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.jellyseerr.rule: "Host(`jellyseerr.${DOMAIN}`)"
+      traefik.http.routers.jellyseerr.entrypoints: "websecure"
+      traefik.http.routers.jellyseerr.tls: "true"
+      traefik.http.routers.jellyseerr.tls.certresolver: "letsencrypt"
+      traefik.http.services.jellyseerr.loadbalancer.server.port: "5055"
+      com.centurylinklabs.watchtower.enable: "true"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:5055/api/v1/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s


### PR DESCRIPTION
## Summary

Implements the complete media stack as specified in #2.

## Services Implemented

| Service | Image | URL |
|---------|-------|-----|
| Jellyfin | `jellyfin/jellyfin:10.9.11` | `jellyfin.${DOMAIN}` |
| Sonarr | `lscr.io/linuxserver/sonarr:4.0.11` | `sonarr.${DOMAIN}` |
| Radarr | `lscr.io/linuxserver/radarr:5.8.1` | `radarr.${DOMAIN}` |
| Prowlarr | `lscr.io/linuxserver/prowlarr:1.22.0` | `prowlarr.${DOMAIN}` |
| qBittorrent | `lscr.io/linuxserver/qbittorrent:4.6.7` | `qbittorrent.${DOMAIN}` |
| Jellyseerr | `fallenbagel/jellyseerr:2.1.1` | `jellyseerr.${DOMAIN}` |

## Key Features

### Directory Structure (TRaSH Guides Compliant)
Follows [TRaSH Guides hardlink setup](https://trash-guides.info/Hardlinks/How-to-setup-for/Docker/) — downloads and media on same filesystem enables instant hardlinks, no disk copy overhead.

```
/data/
├── torrents/{movies,tv}    # DOWNLOADS_ROOT — qBittorrent
└── media/{movies,tv}       # MEDIA_ROOT — Jellyfin library
```

### Startup Order (depends_on + healthcheck)
```
qbittorrent [healthy]
    └── prowlarr [healthy]
    └── sonarr [healthy]
    └── radarr [healthy]
            └── jellyseerr (after jellyfin + sonarr + radarr healthy)
jellyfin (independent)
```

### Networking
- All services on `proxy` (external) network → Traefik auto-discovers
- `media_internal` (internal) network for secure inter-service comms
- No direct internet exposure — everything via Traefik HTTPS

### Hardware Acceleration
- Intel Quick Sync: uncomment `devices: /dev/dri`
- NVIDIA GPU: uncomment `runtime: nvidia`

### Watchtower Integration
All containers have `com.centurylinklabs.watchtower.enable: "true"` for auto-updates.

## Verification

```bash
# Create data dirs
sudo mkdir -p /data/{torrents/{movies,tv},media/{movies,tv}}
sudo chown -R $(id -u):$(id -g) /data

# Start stack
cd stacks/media
cp .env.example .env  # configure DOMAIN, PUID, PGID
docker compose up -d
docker compose ps  # all services should show 'healthy'
```

Closes #2