### PR TITLE
feat(sso): Authentik Unified Identity — OIDC/SSO for all services (Closes #9)

### DIFF
--- a/config/traefik/dynamic/middlewares.yml
+++ b/config/traefik/dynamic/middlewares.yml
@@ -1,0 +1,71 @@
+http:
+  middlewares:
+    # -------------------------------------------------------------------------
+    # Authentik ForwardAuth
+    # Protects any service routed through Traefik — redirects unauthenticated
+    # requests to https://auth.${DOMAIN} for login.
+    #
+    # Usage: add label to any service:
+    #   traefik.http.routers.<name>.middlewares=authentik@file
+    #
+    # Docs: https://docs.goauthentik.io/docs/providers/proxy/traefik
+    # -------------------------------------------------------------------------
+    authentik:
+      forwardAuth:
+        address: "http://authentik-server:9000/outpost.goauthentik.io/auth/traefik"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - X-authentik-username
+          - X-authentik-groups
+          - X-authentik-email
+          - X-authentik-name
+          - X-authentik-uid
+          - X-authentik-jwt
+          - X-authentik-meta-jwks
+          - X-authentik-meta-outpost
+          - X-authentik-meta-provider
+          - X-authentik-meta-app
+          - X-authentik-meta-version
+
+    # -------------------------------------------------------------------------
+    # HTTPS redirect
+    # -------------------------------------------------------------------------
+    https-redirect:
+      redirectScheme:
+        scheme: https
+        permanent: true
+
+    # -------------------------------------------------------------------------
+    # Secured chain — HTTPS redirect + Authentik auth (convenience alias)
+    # Usage: traefik.http.routers.<name>.middlewares=secured@file
+    # -------------------------------------------------------------------------
+    secured:
+      chain:
+        middlewares:
+          - https-redirect
+          - authentik
+
+    # -------------------------------------------------------------------------
+    # Rate limiting (general)
+    # -------------------------------------------------------------------------
+    rate-limit:
+      rateLimit:
+        average: 100
+        burst: 50
+
+    # -------------------------------------------------------------------------
+    # Security headers
+    # -------------------------------------------------------------------------
+    security-headers:
+      headers:
+        customResponseHeaders:
+          X-Robots-Tag: "noindex,nofollow,nosnippet,noarchive,notranslate,noimageindex"
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        stsPreload: true
+        forceSTSHeader: true
+        contentTypeNosniff: true
+        browserXssFilter: true
+        referrerPolicy: "same-origin"
+        frameDeny: false
+        customFrameOptionsValue: "SAMEORIGIN"

--- a/scripts/authentik-setup.sh
+++ b/scripts/authentik-setup.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# =============================================================================
+# authentik-setup.sh — Automated Authentik OIDC/OAuth2 Provider Setup
+# =============================================================================
+# Creates all OAuth2/OIDC providers, applications, and the ForwardAuth outpost.
+# Outputs Client ID + Client Secret for each service so you can paste into .env
+#
+# Usage:
+#   ./scripts/authentik-setup.sh              # Full setup
+#   ./scripts/authentik-setup.sh --dry-run    # Preview only (no changes)
+#   ./scripts/authentik-setup.sh --service grafana  # Setup single service
+#
+# Requirements:
+#   - Authentik running and accessible at https://auth.${DOMAIN}
+#   - AUTHENTIK_ADMIN_EMAIL and AUTHENTIK_ADMIN_PASSWORD set in .env
+#   - curl and jq installed
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Load environment
+if [[ -f "${ROOT_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/.env"
+  set +a
+else
+  echo "ERROR: .env not found at ${ROOT_DIR}/.env" >&2
+  exit 1
+fi
+
+# =============================================================================
+# Config
+# =============================================================================
+DRY_RUN=false
+TARGET_SERVICE=""
+AUTHENTIK_URL="https://auth.${DOMAIN}"
+API="${AUTHENTIK_URL}/api/v3"
+TOKEN=""
+FLOW_UUID=""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# =============================================================================
+# Arg parsing
+# =============================================================================
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true ;;
+    --service) TARGET_SERVICE="${2:-}"; shift ;;
+    --help|-h)
+      echo "Usage: $0 [--dry-run] [--service <name>]"
+      echo "Services: grafana gitea nextcloud outline openwebui portainer"
+      exit 0 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo -e "${YELLOW}[DRY RUN] No changes will be made.${NC}"
+fi
+
+# =============================================================================
+# Functions
+# =============================================================================
+
+log_ok()   { echo -e "${GREEN}[OK]${NC} $*"; }
+log_info() { echo -e "${BLUE}[--]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[!!]${NC} $*"; }
+log_err()  { echo -e "${RED}[ERR]${NC} $*" >&2; }
+
+check_deps() {
+  for cmd in curl jq; do
+    if ! command -v "${cmd}" &>/dev/null; then
+      log_err "Missing dependency: ${cmd}"
+      exit 1
+    fi
+  done
+}
+
+wait_for_authentik() {
+  log_info "Waiting for Authentik at ${AUTHENTIK_URL} ..."
+  local retries=30
+  while [[ ${retries} -gt 0 ]]; do
+    if curl -sf "${AUTHENTIK_URL}/-/health/ready/" &>/dev/null; then
+      log_ok "Authentik is ready"
+      return 0
+    fi
+    retries=$(( retries - 1 ))
+    sleep 5
+  done
+  log_err "Authentik did not become ready in time"
+  exit 1
+}
+
+authenticate() {
+  log_info "Authenticating as ${AUTHENTIK_ADMIN_EMAIL} ..."
+  local response
+  response=$(curl -sf -X POST "${API}/core/tokens/" \
+    -H "Content-Type: application/json" \
+    -u "${AUTHENTIK_ADMIN_EMAIL}:${AUTHENTIK_ADMIN_PASSWORD}" \
+    -d '{"identifier": "setup-script-token", "intent": "api", "description": "Created by authentik-setup.sh", "expiring": false}' 2>/dev/null || true)
+
+  if [[ -z "${response}" ]]; then
+    # Try direct API token approach using session cookie
+    response=$(curl -sf -X POST "${AUTHENTIK_URL}/api/v3/core/tokens/" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${AUTHENTIK_SECRET_KEY}" \
+      -d '{"identifier": "setup-script-token", "intent": "api"}' 2>/dev/null || true)
+  fi
+
+  # Fallback: use admin API key from env if set
+  if [[ -n "${AUTHENTIK_API_TOKEN:-}" ]]; then
+    TOKEN="${AUTHENTIK_API_TOKEN}"
+    log_ok "Using API token from env"
+    return 0
+  fi
+
+  # Prompt for API token if needed
+  log_warn "Could not auto-generate API token."
+  log_info "Create an API token in Authentik Admin UI:"
+  log_info "  ${AUTHENTIK_URL}/if/admin/#/admin/token"
+  echo -n "Paste API Token: "
+  read -r TOKEN
+  if [[ -z "${TOKEN}" ]]; then
+    log_err "No API token provided"
+    exit 1
+  fi
+  log_ok "API token set"
+}
+
+api_get() {
+  local path="$1"
+  curl -sf -H "Authorization: Bearer ${TOKEN}" "${API}${path}"
+}
+
+api_post() {
+  local path="$1"
+  local data="$2"
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo -e "${YELLOW}[DRY RUN] POST ${path}${NC}"
+    echo "${data}" | jq '.' 2>/dev/null || echo "${data}"
+    return 0
+  fi
+  curl -sf -X POST \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    "${API}${path}" \
+    -d "${data}"
+}
+
+get_or_create_flow() {
+  # Get the default authorization flow UUID
+  local flows
+  flows=$(api_get "/flows/instances/?designation=authorization" 2>/dev/null || echo '{"results":[]}')
+  FLOW_UUID=$(echo "${flows}" | jq -r '.results[0].pk // empty')
+  if [[ -z "${FLOW_UUID}" ]]; then
+    log_warn "Could not determine authorization flow UUID — using default"
+    FLOW_UUID="default"
+  fi
+  log_info "Authorization flow: ${FLOW_UUID}"
+}
+
+create_provider() {
+  local name="$1"
+  local slug="$2"
+  local redirect_uri="$3"
+
+  log_info "Creating OAuth2 provider: ${name}"
+
+  local payload
+  payload=$(jq -n \
+    --arg name "${name}" \
+    --arg slug "${slug}" \
+    --arg redirect_uri "${redirect_uri}" \
+    --arg flow "${FLOW_UUID}" \
+    '{
+      name: $name,
+      authorization_flow: $flow,
+      client_type: "confidential",
+      redirect_uris: $redirect_uri,
+      sub_mode: "hashed_user_id",
+      include_claims_in_id_token: true,
+      signing_key: null,
+      property_mappings: []
+    }')
+
+  local result
+  result=$(api_post "/providers/oauth2/" "${payload}" 2>/dev/null || echo '{}')
+
+  local client_id client_secret pk
+  client_id=$(echo "${result}" | jq -r '.client_id // empty')
+  client_secret=$(echo "${result}" | jq -r '.client_secret // empty')
+  pk=$(echo "${result}" | jq -r '.pk // empty')
+
+  if [[ -z "${client_id}" ]]; then
+    log_warn "Provider ${name} may already exist or creation failed"
+    # Try to find existing
+    local existing
+    existing=$(api_get "/providers/oauth2/?name=${name}" 2>/dev/null || echo '{"results":[]}')
+    client_id=$(echo "${existing}" | jq -r '.results[0].client_id // "N/A"')
+    client_secret=$(echo "${existing}" | jq -r '.results[0].client_secret // "N/A"')
+    pk=$(echo "${existing}" | jq -r '.results[0].pk // empty')
+  fi
+
+  echo "${pk}:${client_id}:${client_secret}"
+}
+
+create_application() {
+  local name="$1"
+  local slug="$2"
+  local provider_pk="$3"
+  local description="$4"
+
+  log_info "Creating application: ${name}"
+
+  local payload
+  payload=$(jq -n \
+    --arg name "${name}" \
+    --arg slug "${slug}" \
+    --argjson provider_pk "${provider_pk}" \
+    --arg description "${description}" \
+    '{
+      name: $name,
+      slug: $slug,
+      provider: $provider_pk,
+      meta_description: $description,
+      meta_launch_url: "",
+      open_in_new_tab: false
+    }')
+
+  api_post "/core/applications/" "${payload}" >/dev/null 2>&1 || \
+    log_warn "Application ${name} may already exist"
+}
+
+setup_service() {
+  local service_name="$1"
+  local app_name="$2"
+  local slug="$3"
+  local redirect_uri="$4"
+  local env_prefix="$5"
+  local description="$6"
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  log_info "Setting up: ${app_name}"
+
+  local result provider_pk client_id client_secret
+  result=$(create_provider "${app_name}" "${slug}" "${redirect_uri}")
+  provider_pk=$(echo "${result}" | cut -d: -f1)
+  client_id=$(echo "${result}" | cut -d: -f2)
+  client_secret=$(echo "${result}" | cut -d: -f3)
+
+  if [[ -n "${provider_pk}" && "${provider_pk}" != "null" ]]; then
+    create_application "${app_name}" "${slug}" "${provider_pk}" "${description}"
+  fi
+
+  log_ok "Created provider: ${app_name}"
+  echo "     Client ID:     ${client_id}"
+  echo "     Client Secret: ${client_secret}"
+  echo "     Redirect URI:  ${redirect_uri}"
+  echo ""
+  echo "     Add to .env:"
+  echo "       ${env_prefix}_OAUTH_CLIENT_ID=${client_id}"
+  echo "       ${env_prefix}_OAUTH_CLIENT_SECRET=${client_secret}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+create_groups() {
+  log_info "Creating user groups..."
+
+  for group in "homelab-admins" "homelab-users" "media-users"; do
+    local payload
+    payload=$(jq -n --arg name "${group}" '{"name": $name, "is_superuser": false}')
+    api_post "/core/groups/" "${payload}" >/dev/null 2>&1 || \
+      log_warn "Group ${group} may already exist"
+    log_ok "Group: ${group}"
+  done
+}
+
+create_forwardauth_outpost() {
+  log_info "Creating Traefik ForwardAuth outpost..."
+
+  local providers_list
+  providers_list="[]"
+
+  local payload
+  payload=$(jq -n \
+    --arg name "homelab-proxy" \
+    '{
+      name: $name,
+      type: "proxy",
+      providers: [],
+      config: {
+        authentik_host: ("https://auth." + (env.DOMAIN // "example.com")),
+        authentik_host_insecure: false,
+        log_level: "info",
+        error_reporting: false
+      }
+    }')
+
+  api_post "/outposts/instances/" "${payload}" >/dev/null 2>&1 || \
+    log_warn "Outpost may already exist"
+
+  log_ok "ForwardAuth outpost created: homelab-proxy"
+  log_info "Add applications to the outpost in Authentik Admin UI:"
+  log_info "  ${AUTHENTIK_URL}/if/admin/#/outpost/list"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+echo "============================================================"
+echo "  Authentik Setup Script"
+echo "  Target: ${AUTHENTIK_URL}"
+echo "  Mode: $(if [[ "${DRY_RUN}" == "true" ]]; then echo "DRY RUN"; else echo "LIVE"; fi)"
+echo "============================================================"
+echo ""
+
+check_deps
+wait_for_authentik
+authenticate
+get_or_create_flow
+
+# Create groups first
+if [[ -z "${TARGET_SERVICE}" ]]; then
+  create_groups
+fi
+
+# Define all services
+declare -A SERVICES
+SERVICES=(
+  ["grafana"]="Grafana|grafana|https://grafana.${DOMAIN}/login/generic_oauth|GRAFANA|Grafana monitoring dashboard"
+  ["gitea"]="Gitea|gitea|https://gitea.${DOMAIN}/user/oauth2/authentik/callback|GITEA|Gitea Git hosting"
+  ["nextcloud"]="Nextcloud|nextcloud|https://nextcloud.${DOMAIN}/apps/sociallogin/custom_oidc/authentik|NEXTCLOUD|Nextcloud file storage"
+  ["outline"]="Outline|outline|https://outline.${DOMAIN}/auth/oidc.callback|OUTLINE|Outline wiki"
+  ["openwebui"]="Open WebUI|openwebui|https://chat.${DOMAIN}/oauth/oidc/callback|OPENWEBUI|Open WebUI AI chat"
+  ["portainer"]="Portainer|portainer|https://portainer.${DOMAIN}|PORTAINER|Portainer Docker management"
+)
+
+# Process services
+for service in "${!SERVICES[@]}"; do
+  if [[ -n "${TARGET_SERVICE}" && "${service}" != "${TARGET_SERVICE}" ]]; then
+    continue
+  fi
+
+  IFS='|' read -r app_name slug redirect_uri env_prefix description <<< "${SERVICES[${service}]}"
+  setup_service "${service}" "${app_name}" "${slug}" "${redirect_uri}" "${env_prefix}" "${description}"
+done
+
+# Create ForwardAuth outpost
+if [[ -z "${TARGET_SERVICE}" ]]; then
+  echo ""
+  create_forwardauth_outpost
+fi
+
+echo ""
+echo "============================================================"
+log_ok "Setup complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Copy the Client ID/Secret values above into .env"
+echo "  2. Restart affected stacks:"
+echo "       docker compose -f stacks/monitoring/docker-compose.yml restart"
+echo "       docker compose -f stacks/productivity/docker-compose.yml restart"
+echo "  3. Visit ${AUTHENTIK_URL}/if/admin/ to verify providers"
+echo "  4. Test login on each service"
+echo "============================================================"

--- a/scripts/nextcloud-oidc-setup.sh
+++ b/scripts/nextcloud-oidc-setup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+# nextcloud-oidc-setup.sh — Configure Nextcloud OIDC via Social Login App
+# =============================================================================
+# Run after authentik-setup.sh has generated NEXTCLOUD_OAUTH_CLIENT_ID/SECRET
+#
+# Usage:
+#   ./scripts/nextcloud-oidc-setup.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -f "${ROOT_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/.env"
+  set +a
+else
+  echo "ERROR: .env not found" >&2
+  exit 1
+fi
+
+CONTAINER="${NEXTCLOUD_CONTAINER:-nextcloud}"
+NEXTCLOUD_URL="https://nextcloud.${DOMAIN}"
+AUTHENTIK_URL="https://auth.${DOMAIN}"
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_ok()   { echo -e "${GREEN}[OK]${NC} $*"; }
+log_info() { echo -e "${BLUE}[--]${NC} $*"; }
+
+log_info "Installing Social Login app in Nextcloud..."
+docker exec -u www-data "${CONTAINER}" php occ app:install sociallogin 2>/dev/null \
+  && log_ok "Installed sociallogin" \
+  || log_info "sociallogin already installed"
+
+docker exec -u www-data "${CONTAINER}" php occ app:enable sociallogin
+log_ok "Social Login app enabled"
+
+log_info "Configuring Authentik OIDC provider..."
+
+PROVIDER_CONFIG=$(cat <<EOF
+[{
+  "name": "authentik",
+  "title": "Authentik SSO",
+  "clientId": "${NEXTCLOUD_OAUTH_CLIENT_ID}",
+  "clientSecret": "${NEXTCLOUD_OAUTH_CLIENT_SECRET}",
+  "discoveryUrl": "${AUTHENTIK_URL}/application/o/nextcloud/.well-known/openid-configuration",
+  "scope": "openid email profile",
+  "groupsClaim": "groups",
+  "style": "openid",
+  "defaultGroup": ""
+}]
+EOF
+)
+
+docker exec -u www-data "${CONTAINER}" php occ config:app:set sociallogin custom_providers \
+  --value="${PROVIDER_CONFIG}"
+
+log_ok "OIDC provider configured"
+
+log_info "Enabling auto-create users on OAuth login..."
+docker exec -u www-data "${CONTAINER}" php occ config:app:set sociallogin auto_create_groups --value="1"
+docker exec -u www-data "${CONTAINER}" php occ config:app:set sociallogin disable_registration --value="0"
+
+log_ok "Done!"
+echo ""
+echo "Test: ${NEXTCLOUD_URL}/login → 'Login with Authentik SSO'"

--- a/stacks/sso/.env.example
+++ b/stacks/sso/.env.example
@@ -1,0 +1,97 @@
+# =============================================================================
+# SSO Stack — Authentik Environment Variables
+# Copy to ../../.env (or merge into root .env.example)
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# AUTHENTIK CORE (all required)
+# -----------------------------------------------------------------------------
+
+# Secret key — MUST be at least 50 characters, random
+# Generate: openssl rand -base64 60 | tr -d '\n'
+AUTHENTIK_SECRET_KEY=
+
+# Initial admin credentials (used on first-run bootstrap only)
+# After first login, change the password via the Web UI
+AUTHENTIK_ADMIN_EMAIL=admin@yourdomain.com
+AUTHENTIK_ADMIN_PASSWORD=
+
+# Domain — Authentik will be accessible at https://auth.${DOMAIN}
+DOMAIN=yourdomain.com
+
+# Log level: debug | info | warning | error
+AUTHENTIK_LOG_LEVEL=info
+
+# -----------------------------------------------------------------------------
+# DATABASE CREDENTIALS
+# -----------------------------------------------------------------------------
+
+# Authentik-dedicated PostgreSQL password
+# Generate: openssl rand -base64 24 | tr -d '\n'
+AUTHENTIK_POSTGRES_PASSWORD=
+
+# Authentik-dedicated Redis password
+# Generate: openssl rand -base64 24 | tr -d '\n'
+AUTHENTIK_REDIS_PASSWORD=
+
+# -----------------------------------------------------------------------------
+# EMAIL CONFIGURATION (optional — enables password reset & alerts)
+# -----------------------------------------------------------------------------
+# Leave blank to disable email entirely
+
+AUTHENTIK_EMAIL_HOST=smtp.example.com
+AUTHENTIK_EMAIL_PORT=587
+AUTHENTIK_EMAIL_USERNAME=
+AUTHENTIK_EMAIL_PASSWORD=
+AUTHENTIK_EMAIL_USE_TLS=true
+AUTHENTIK_EMAIL_USE_SSL=false
+AUTHENTIK_EMAIL_FROM=authentik@yourdomain.com
+
+# -----------------------------------------------------------------------------
+# OAUTH2 CLIENT CREDENTIALS
+# Auto-populated by: ./scripts/authentik-setup.sh
+# Manually fill after running the setup script
+# -----------------------------------------------------------------------------
+
+# Grafana OIDC
+GRAFANA_OAUTH_CLIENT_ID=
+GRAFANA_OAUTH_CLIENT_SECRET=
+
+# Gitea OIDC
+GITEA_OAUTH_CLIENT_ID=
+GITEA_OAUTH_CLIENT_SECRET=
+
+# Nextcloud OIDC (social login app)
+NEXTCLOUD_OAUTH_CLIENT_ID=
+NEXTCLOUD_OAUTH_CLIENT_SECRET=
+
+# Outline OIDC
+OUTLINE_OAUTH_CLIENT_ID=
+OUTLINE_OAUTH_CLIENT_SECRET=
+
+# Open WebUI OIDC
+OPENWEBUI_OAUTH_CLIENT_ID=
+OPENWEBUI_OAUTH_CLIENT_SECRET=
+
+# Portainer OAuth
+PORTAINER_OAUTH_CLIENT_ID=
+PORTAINER_OAUTH_CLIENT_SECRET=
+
+# =============================================================================
+# QUICK SETUP CHEATSHEET
+# =============================================================================
+#
+# 1. Generate all secrets at once:
+#
+#    export AUTHENTIK_SECRET_KEY=$(openssl rand -base64 60 | tr -d '\n')
+#    export AUTHENTIK_POSTGRES_PASSWORD=$(openssl rand -base64 24 | tr -d '\n')
+#    export AUTHENTIK_REDIS_PASSWORD=$(openssl rand -base64 24 | tr -d '\n')
+#
+# 2. Or use the interactive setup script:
+#    ./install.sh  (auto-generates all required secrets)
+#
+# 3. After docker compose up -d, run:
+#    ./scripts/authentik-setup.sh
+#    This creates all OIDC providers and outputs client credentials.
+#
+# =============================================================================

--- a/stacks/sso/README.md
+++ b/stacks/sso/README.md
@@ -1,0 +1,304 @@
+# 🔐 SSO Stack — Authentik Unified Identity
+
+> Single sign-on for your entire homelab. One login, all services.
+
+Authentik (`auth.${DOMAIN}`) is the OIDC/SAML identity provider for all services in this stack. It provides:
+
+- **OIDC/OAuth2** for Grafana, Gitea, Nextcloud, Outline, Open WebUI, Portainer
+- **SAML** for enterprise-compatible integrations  
+- **Traefik ForwardAuth** for services without native SSO support
+- **User group isolation** (admins / users / media-users)
+
+---
+
+## 📋 Requirements
+
+- Docker Engine 24+ and Docker Compose v2
+- The **base stack** running (Traefik + `proxy` network)
+- A valid domain and Let's Encrypt HTTPS
+
+---
+
+## 🚀 First-Time Setup
+
+### Step 1 — Configure environment
+
+```bash
+# From the repo root
+cp .env.example .env
+```
+
+Edit `.env` and fill the SSO section:
+
+```bash
+# Generate all secrets in one shot
+export AUTHENTIK_SECRET_KEY=$(openssl rand -base64 60 | tr -d '\n')
+export AUTHENTIK_POSTGRES_PASSWORD=$(openssl rand -base64 24 | tr -d '\n')
+export AUTHENTIK_REDIS_PASSWORD=$(openssl rand -base64 24 | tr -d '\n')
+
+# Paste into .env
+echo "AUTHENTIK_SECRET_KEY=${AUTHENTIK_SECRET_KEY}"
+echo "AUTHENTIK_POSTGRES_PASSWORD=${AUTHENTIK_POSTGRES_PASSWORD}"
+echo "AUTHENTIK_REDIS_PASSWORD=${AUTHENTIK_REDIS_PASSWORD}"
+```
+
+Also set:
+```env
+DOMAIN=yourdomain.com
+AUTHENTIK_ADMIN_EMAIL=admin@yourdomain.com
+AUTHENTIK_ADMIN_PASSWORD=YourStrongPassword123!
+```
+
+### Step 2 — Start the stack
+
+```bash
+cd stacks/sso
+docker compose up -d
+
+# Verify all 4 containers are healthy
+docker compose ps
+```
+
+Expected output (all `healthy`):
+```
+NAME                   STATUS
+authentik-server       running (healthy)
+authentik-worker       running (healthy)
+authentik-postgres     running (healthy)
+authentik-redis        running (healthy)
+```
+
+### Step 3 — Complete initial setup
+
+Visit `https://auth.yourdomain.com/if/flow/initial-setup/`
+
+The bootstrap admin account (set via `AUTHENTIK_ADMIN_EMAIL` / `AUTHENTIK_ADMIN_PASSWORD`) is created automatically on first startup.
+
+### Step 4 — Create user groups
+
+In the Authentik Admin UI (`https://auth.yourdomain.com/if/admin/`):
+
+Navigate to **Directory → Groups** and create:
+
+| Group | Purpose |
+|-------|---------|
+| `homelab-admins` | Full access to all service admin interfaces |
+| `homelab-users` | Access to standard services (Grafana, Gitea, Nextcloud, etc.) |
+| `media-users` | Access to Jellyfin and Jellyseerr only |
+
+### Step 5 — Run the setup script
+
+```bash
+# From the repo root
+./scripts/authentik-setup.sh
+```
+
+This script:
+1. Creates OIDC/OAuth2 providers for all supported services
+2. Creates the corresponding Applications
+3. Outputs `Client ID` and `Client Secret` for each service
+4. Installs the Traefik ForwardAuth outpost
+
+Paste the output credentials into `.env` for the respective stacks.
+
+### Step 6 — Enable Traefik ForwardAuth middleware
+
+The middleware is pre-defined in `config/traefik/dynamic/middlewares.yml`.
+Add it to any service's Traefik labels:
+
+```yaml
+labels:
+  - "traefik.http.routers.myapp.middlewares=authentik@file"
+```
+
+---
+
+## 🏗️ Architecture
+
+```
+Browser
+  │
+  ▼
+[Traefik]
+  │  ← checks ForwardAuth for protected routes
+  ▼
+[Authentik Server :9000]    ← OIDC/SAML/ForwardAuth
+  │
+  ├── [PostgreSQL :5432]    ← persistent identity store
+  └── [Redis :6379]         ← session cache + task queue
+```
+
+### Networks
+
+| Network | Purpose |
+|---------|---------|
+| `proxy` | Shared with Traefik (external, created by base stack) |
+| `sso` | Internal — Authentik ↔ PostgreSQL ↔ Redis |
+
+---
+
+## ⚙️ OIDC Integration Guide
+
+### How Authentik OIDC works
+
+1. User visits a service (e.g. Grafana)
+2. Service redirects to `https://auth.${DOMAIN}/application/o/<slug>/authorize/`
+3. User logs in with Authentik credentials
+4. Authentik redirects back with an auth code
+5. Service exchanges code for tokens
+6. User is logged in
+
+### Adding a new service via OIDC
+
+**In Authentik Admin UI:**
+
+1. Go to **Applications → Providers → Create**
+2. Choose **OAuth2/OpenID Provider**
+3. Set name, client type (`Confidential`), redirect URIs
+4. Copy the generated `Client ID` and `Client Secret`
+5. Go to **Applications → Applications → Create**
+6. Link the new provider
+
+**Standard OIDC endpoints** (replace `<slug>` with your app name):
+```
+Authorization: https://auth.yourdomain.com/application/o/<slug>/authorize/
+Token:         https://auth.yourdomain.com/application/o/<slug>/token/
+Userinfo:      https://auth.yourdomain.com/application/o/<slug>/userinfo/
+JWKS:          https://auth.yourdomain.com/application/o/<slug>/jwks/
+```
+
+---
+
+## 🖥️ Service Integration Examples
+
+### Grafana (OIDC)
+
+Add to `config/grafana/grafana.ini`:
+
+```ini
+[auth.generic_oauth]
+enabled = true
+name = Authentik
+icon = signin
+client_id = ${GRAFANA_OAUTH_CLIENT_ID}
+client_secret = ${GRAFANA_OAUTH_CLIENT_SECRET}
+scopes = openid email profile
+empty_scopes = false
+auth_url = https://auth.${DOMAIN}/application/o/grafana/authorize/
+token_url = https://auth.${DOMAIN}/application/o/grafana/token/
+api_url = https://auth.${DOMAIN}/application/o/userinfo/
+login_attribute_path = preferred_username
+groups_attribute_path = groups
+name_attribute_path = name
+use_auto_assign_org = true
+auto_assign_org_id = 1
+auto_assign_org_role = Viewer
+role_attribute_path = contains(groups[*], 'homelab-admins') && 'Admin' || 'Viewer'
+allow_sign_up = true
+```
+
+### Portainer (OAuth2)
+
+In Portainer Settings → Authentication:
+1. Select **OAuth**
+2. Fill:
+   - Client ID: `${PORTAINER_OAUTH_CLIENT_ID}`
+   - Client Secret: `${PORTAINER_OAUTH_CLIENT_SECRET}`
+   - Authorization URL: `https://auth.${DOMAIN}/application/o/portainer/authorize/`
+   - Access Token URL: `https://auth.${DOMAIN}/application/o/portainer/token/`
+   - Resource URL: `https://auth.${DOMAIN}/application/o/userinfo/`
+   - Redirect URL: `https://portainer.${DOMAIN}`
+   - User identifier: `preferred_username`
+   - Scopes: `openid email profile`
+
+See [docs/integration-examples.md](docs/integration-examples.md) for full examples for all services.
+
+---
+
+## 🛡️ Traefik ForwardAuth
+
+For services without native OIDC support, use Authentik's ForwardAuth outpost:
+
+```yaml
+# config/traefik/dynamic/middlewares.yml
+middlewares:
+  authentik:
+    forwardAuth:
+      address: "http://authentik-server:9000/outpost.goauthentik.io/auth/traefik"
+      trustForwardHeader: true
+      authResponseHeaders:
+        - X-authentik-username
+        - X-authentik-groups
+        - X-authentik-email
+        - X-authentik-name
+        - X-authentik-uid
+        - X-authentik-jwt
+        - X-authentik-meta-jwks
+        - X-authentik-meta-outpost
+        - X-authentik-meta-provider
+        - X-authentik-meta-app
+        - X-authentik-meta-version
+```
+
+Apply to any service:
+```yaml
+labels:
+  - "traefik.http.routers.myapp.middlewares=authentik@file"
+```
+
+---
+
+## 👥 User Group Permissions
+
+| Group | Grafana | Gitea | Nextcloud | Jellyfin | Admin UIs |
+|-------|---------|-------|-----------|----------|-----------|
+| `homelab-admins` | Admin | Owner | Admin | Admin | ✅ |
+| `homelab-users` | Viewer | User | User | User | ❌ |
+| `media-users` | ❌ | ❌ | ❌ | User | ❌ |
+
+Configure group-based access in **Authentik Admin → Applications → [App] → Policy Bindings**.
+
+---
+
+## 🔄 Maintenance
+
+```bash
+# Update Authentik (change version tag first)
+docker compose pull && docker compose up -d
+
+# View logs
+docker compose logs -f authentik-server
+
+# Backup database
+docker exec authentik-postgres pg_dump -U authentik authentik > backup-$(date +%Y%m%d).sql
+
+# Run a management command
+docker exec authentik-worker ak repair_migrations
+```
+
+---
+
+## ❓ Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `authentik-server` won't start | Check `AUTHENTIK_SECRET_KEY` is set (min 50 chars) |
+| "Invalid redirect URI" | Add the exact callback URL in Authentik provider settings |
+| ForwardAuth 401 on all requests | Ensure outpost is deployed and `proxy` network is shared |
+| Worker not processing tasks | Check Redis password matches in both Authentik and Redis config |
+| Can't log in after password reset | Clear browser cookies for `auth.${DOMAIN}` |
+
+```bash
+# Full diagnostic
+docker compose logs authentik-server authentik-worker 2>&1 | grep -E 'ERROR|WARN|exception'
+```
+
+---
+
+## 📚 References
+
+- [Authentik Documentation](https://docs.goauthentik.io/)
+- [Authentik Docker Compose Guide](https://docs.goauthentik.io/docs/installation/docker-compose)
+- [OIDC Provider Setup](https://docs.goauthentik.io/docs/providers/oauth2/)
+- [Traefik ForwardAuth Integration](https://docs.goauthentik.io/docs/providers/proxy/traefik)
+- [Blueprint Reference](https://docs.goauthentik.io/docs/blueprints/)

--- a/stacks/sso/docker-compose.yml
+++ b/stacks/sso/docker-compose.yml
@@ -1,0 +1,178 @@
+# =============================================================================
+# SSO Stack — Authentik Unified Identity Provider
+# Docs: https://docs.goauthentik.io/docs/installation/docker-compose
+# Access: https://auth.${DOMAIN}
+# =============================================================================
+#
+# First-time setup:
+#   1. Copy .env.example → .env and fill all required values
+#   2. Generate secret key: openssl rand -base64 32
+#   3. docker compose up -d
+#   4. Run: ./scripts/authentik-setup.sh
+#   5. Visit https://auth.${DOMAIN}/if/flow/initial-setup/
+#
+# CN Mirror fallback images:
+#   ghcr.io/goauthentik/server:2024.8.3
+#   → m.daocloud.io/ghcr.io/goauthentik/server:2024.8.3
+# =============================================================================
+
+name: sso
+
+x-authentik-common: &authentik-common
+  image: ghcr.io/goauthentik/server:2024.8.3
+  restart: unless-stopped
+  environment:
+    AUTHENTIK_REDIS__HOST: authentik-redis
+    AUTHENTIK_REDIS__PASSWORD: ${AUTHENTIK_REDIS_PASSWORD}
+    AUTHENTIK_POSTGRESQL__HOST: authentik-postgres
+    AUTHENTIK_POSTGRESQL__USER: authentik
+    AUTHENTIK_POSTGRESQL__NAME: authentik
+    AUTHENTIK_POSTGRESQL__PASSWORD: ${AUTHENTIK_POSTGRES_PASSWORD}
+    AUTHENTIK_SECRET_KEY: ${AUTHENTIK_SECRET_KEY}
+    AUTHENTIK_ERROR_REPORTING__ENABLED: "false"
+    AUTHENTIK_LOG_LEVEL: ${AUTHENTIK_LOG_LEVEL:-info}
+    # Email settings (optional — for password reset, alerts)
+    AUTHENTIK_EMAIL__HOST: ${AUTHENTIK_EMAIL_HOST:-localhost}
+    AUTHENTIK_EMAIL__PORT: ${AUTHENTIK_EMAIL_PORT:-25}
+    AUTHENTIK_EMAIL__USERNAME: ${AUTHENTIK_EMAIL_USERNAME:-}
+    AUTHENTIK_EMAIL__PASSWORD: ${AUTHENTIK_EMAIL_PASSWORD:-}
+    AUTHENTIK_EMAIL__USE_TLS: ${AUTHENTIK_EMAIL_USE_TLS:-false}
+    AUTHENTIK_EMAIL__USE_SSL: ${AUTHENTIK_EMAIL_USE_SSL:-false}
+    AUTHENTIK_EMAIL__FROM: ${AUTHENTIK_EMAIL_FROM:-authentik@${DOMAIN}}
+    # Bootstrap admin credentials (used on first startup only)
+    AUTHENTIK_BOOTSTRAP_EMAIL: ${AUTHENTIK_ADMIN_EMAIL}
+    AUTHENTIK_BOOTSTRAP_PASSWORD: ${AUTHENTIK_ADMIN_PASSWORD}
+  env_file:
+    - ../../.env
+  depends_on:
+    authentik-postgres:
+      condition: service_healthy
+    authentik-redis:
+      condition: service_healthy
+  networks:
+    - sso
+    - proxy
+
+services:
+  # ---------------------------------------------------------------------------
+  # Authentik Server — web UI + API + OIDC/SAML endpoints
+  # ---------------------------------------------------------------------------
+  authentik-server:
+    <<: *authentik-common
+    container_name: authentik-server
+    command: server
+    volumes:
+      - authentik-media:/media
+      - authentik-templates:/templates
+      - ../../config/authentik:/blueprints/custom
+    ports:
+      - "127.0.0.1:9000:9000"   # HTTP (internal)
+      - "127.0.0.1:9443:9443"   # HTTPS (internal)
+    healthcheck:
+      test: ["CMD", "ak", "healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.authentik.rule=Host(`auth.${DOMAIN}`)"
+      - "traefik.http.routers.authentik.entrypoints=websecure"
+      - "traefik.http.routers.authentik.tls=true"
+      - "traefik.http.routers.authentik.tls.certresolver=letsencrypt"
+      - "traefik.http.services.authentik.loadbalancer.server.port=9000"
+      # ForwardAuth outpost — handles /outpost.goauthentik.io/* paths
+      - "traefik.http.routers.authentik-outpost.rule=HostRegexp(`{subdomain:[a-z0-9-]+}.${DOMAIN}`) && PathPrefix(`/outpost.goauthentik.io/`)"
+      - "traefik.http.routers.authentik-outpost.entrypoints=websecure"
+      - "traefik.http.routers.authentik-outpost.tls=true"
+      - "traefik.http.routers.authentik-outpost.tls.certresolver=letsencrypt"
+      - "traefik.http.services.authentik-outpost.loadbalancer.server.port=9000"
+
+  # ---------------------------------------------------------------------------
+  # Authentik Worker — background task processor
+  # ---------------------------------------------------------------------------
+  authentik-worker:
+    <<: *authentik-common
+    container_name: authentik-worker
+    command: worker
+    volumes:
+      - authentik-media:/media
+      - authentik-templates:/templates
+      - ../../config/authentik:/blueprints/custom
+      - /var/run/docker.sock:/var/run/docker.sock:ro  # For managed outposts
+    user: root  # Required for docker socket access
+    healthcheck:
+      test: ["CMD", "ak", "healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # ---------------------------------------------------------------------------
+  # PostgreSQL — Authentik-dedicated database
+  # ---------------------------------------------------------------------------
+  authentik-postgres:
+    image: postgres:16.4-alpine
+    container_name: authentik-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: authentik
+      POSTGRES_DB: authentik
+      POSTGRES_PASSWORD: ${AUTHENTIK_POSTGRES_PASSWORD}
+    volumes:
+      - authentik-postgres-data:/var/lib/postgresql/data
+    networks:
+      - sso
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U authentik -d authentik"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    security_opt:
+      - no-new-privileges:true
+
+  # ---------------------------------------------------------------------------
+  # Redis — Authentik cache and task queue
+  # ---------------------------------------------------------------------------
+  authentik-redis:
+    image: redis:7.4.0-alpine
+    container_name: authentik-redis
+    restart: unless-stopped
+    command: >
+      redis-server
+      --requirepass ${AUTHENTIK_REDIS_PASSWORD}
+      --save 60 1
+      --loglevel warning
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+    volumes:
+      - authentik-redis-data:/data
+    networks:
+      - sso
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${AUTHENTIK_REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    security_opt:
+      - no-new-privileges:true
+
+networks:
+  sso:
+    name: sso
+    driver: bridge
+  proxy:
+    name: proxy
+    external: true   # Shared Traefik network — created by base stack
+
+volumes:
+  authentik-postgres-data:
+    driver: local
+  authentik-redis-data:
+    driver: local
+  authentik-media:
+    driver: local
+  authentik-templates:
+    driver: local

--- a/stacks/sso/docs/integration-examples.md
+++ b/stacks/sso/docs/integration-examples.md
@@ -1,0 +1,382 @@
+# 🔗 Authentik SSO Integration Examples
+
+Complete integration guides for every service in the homelab stack.
+
+> **Prerequisites:** Authentik is running at `https://auth.${DOMAIN}` and you have run `./scripts/authentik-setup.sh` to obtain client credentials.
+
+---
+
+## Table of Contents
+
+1. [Grafana — OIDC](#1-grafana--oidc)
+2. [Gitea — OIDC](#2-gitea--oidc)
+3. [Nextcloud — OIDC (Social Login)](#3-nextcloud--oidc-social-login)
+4. [Outline — OIDC](#4-outline--oidc)
+5. [Open WebUI — OIDC](#5-open-webui--oidc)
+6. [Portainer — OAuth2](#6-portainer--oauth2)
+7. [Traefik ForwardAuth — Any Service](#7-traefik-forwardauth--any-service)
+8. [Adding a New Service](#8-adding-a-new-service)
+
+---
+
+## 1. Grafana — OIDC
+
+**Create provider in Authentik:**
+1. Admin UI → Providers → Create → OAuth2/OpenID Provider
+2. Name: `Grafana`, Client type: `Confidential`
+3. Redirect URIs: `https://grafana.${DOMAIN}/login/generic_oauth`
+4. Scopes: `openid`, `email`, `profile`
+5. Note the Client ID and Client Secret
+
+**Configure `config/grafana/grafana.ini`:**
+
+```ini
+[server]
+root_url = https://grafana.${DOMAIN}
+
+[auth]
+disable_login_form = false       # Keep enabled as fallback
+oauth_auto_login = false
+
+[auth.generic_oauth]
+enabled = true
+name = Authentik
+icon = signin
+client_id = ${GRAFANA_OAUTH_CLIENT_ID}
+client_secret = ${GRAFANA_OAUTH_CLIENT_SECRET}
+scopes = openid email profile
+empty_scopes = false
+auth_url = https://auth.${DOMAIN}/application/o/grafana/authorize/
+token_url = https://auth.${DOMAIN}/application/o/grafana/token/
+api_url = https://auth.${DOMAIN}/application/o/userinfo/
+login_attribute_path = preferred_username
+groups_attribute_path = groups
+name_attribute_path = name
+use_auto_assign_org = true
+auto_assign_org_id = 1
+auto_assign_org_role = Viewer
+role_attribute_path = contains(groups[*], 'homelab-admins') && 'Admin' || 'Viewer'
+allow_sign_up = true
+tls_skip_verify_insecure = false
+```
+
+**Environment variables (added to `stacks/monitoring/.env` or root `.env`):**
+
+```env
+GRAFANA_OAUTH_CLIENT_ID=<from authentik-setup.sh>
+GRAFANA_OAUTH_CLIENT_SECRET=<from authentik-setup.sh>
+```
+
+**Test:** Visit `https://grafana.${DOMAIN}` → click "Sign in with Authentik" → redirects to Authentik login → returns to Grafana dashboard.
+
+---
+
+## 2. Gitea — OIDC
+
+**Create provider in Authentik:**
+1. Provider name: `Gitea`, Client type: `Confidential`
+2. Redirect URIs: `https://gitea.${DOMAIN}/user/oauth2/authentik/callback`
+3. Scopes: `openid`, `email`, `profile`
+
+**Option A — Via Gitea Web UI (Admin):**
+
+Navigate to Site Administration → Authentication Sources → Add Authentication Source:
+- Type: `OAuth2`
+- Authentication Name: `authentik`
+- OAuth2 Provider: `OpenID Connect`
+- Client ID: `${GITEA_OAUTH_CLIENT_ID}`
+- Client Secret: `${GITEA_OAUTH_CLIENT_SECRET}`
+- OpenID Connect Auto Discovery URL: `https://auth.${DOMAIN}/application/o/gitea/.well-known/openid-configuration`
+
+**Option B — Via `stacks/productivity/.env`:**
+
+```env
+GITEA_OAUTH_CLIENT_ID=<from authentik-setup.sh>
+GITEA_OAUTH_CLIENT_SECRET=<from authentik-setup.sh>
+GITEA_OAUTH_DISCOVERY_URL=https://auth.${DOMAIN}/application/o/gitea/.well-known/openid-configuration
+```
+
+Then bootstrap via CLI (add to Gitea startup):
+```bash
+gitea admin auth add-oauth \
+  --name authentik \
+  --provider openidConnect \
+  --key "${GITEA_OAUTH_CLIENT_ID}" \
+  --secret "${GITEA_OAUTH_CLIENT_SECRET}" \
+  --auto-discover-url "https://auth.${DOMAIN}/application/o/gitea/.well-known/openid-configuration" \
+  --scopes "openid email profile"
+```
+
+**Test:** Visit `https://gitea.${DOMAIN}` → Sign In → "Sign in with authentik".
+
+---
+
+## 3. Nextcloud — OIDC (Social Login)
+
+**Create provider in Authentik:**
+1. Provider name: `Nextcloud`, Client type: `Confidential`
+2. Redirect URIs: `https://nextcloud.${DOMAIN}/apps/sociallogin/custom_oidc/authentik`
+3. Scopes: `openid`, `email`, `profile`
+
+**`scripts/nextcloud-oidc-setup.sh`:**
+
+```bash
+#!/usr/bin/env bash
+# Configure Nextcloud OIDC via Social Login app
+# Run: ./scripts/nextcloud-oidc-setup.sh
+
+set -euo pipefail
+source .env
+
+NEXTCLOUD_URL="https://nextcloud.${DOMAIN}"
+CONTAINER="nextcloud"
+
+echo "Installing Social Login app..."
+docker exec -u www-data "${CONTAINER}" php occ app:install sociallogin 2>/dev/null || true
+docker exec -u www-data "${CONTAINER}" php occ app:enable sociallogin
+
+echo "Configuring Authentik OIDC..."
+docker exec -u www-data "${CONTAINER}" php occ config:app:set sociallogin custom_providers \
+  --value='[{
+    "name": "authentik",
+    "title": "Authentik SSO",
+    "clientId": "'"${NEXTCLOUD_OAUTH_CLIENT_ID}"'",
+    "clientSecret": "'"${NEXTCLOUD_OAUTH_CLIENT_SECRET}"'",
+    "discoveryUrl": "https://auth.'"${DOMAIN}"'/application/o/nextcloud/.well-known/openid-configuration",
+    "scope": "openid email profile",
+    "groupsClaim": "groups",
+    "style": "openid"
+  }]'
+
+echo "[OK] Nextcloud OIDC configured. Visit ${NEXTCLOUD_URL}/login to test."
+```
+
+Make executable and run:
+```bash
+chmod +x scripts/nextcloud-oidc-setup.sh
+./scripts/nextcloud-oidc-setup.sh
+```
+
+---
+
+## 4. Outline — OIDC
+
+**Create provider in Authentik:**
+1. Provider name: `Outline`, Client type: `Confidential`
+2. Redirect URIs: `https://outline.${DOMAIN}/auth/oidc.callback`
+3. Scopes: `openid`, `email`, `profile`
+
+**`stacks/productivity/.env` additions:**
+
+```env
+# Outline OIDC
+OIDC_CLIENT_ID=${OUTLINE_OAUTH_CLIENT_ID}
+OIDC_CLIENT_SECRET=${OUTLINE_OAUTH_CLIENT_SECRET}
+OIDC_AUTH_URI=https://auth.${DOMAIN}/application/o/outline/authorize/
+OIDC_TOKEN_URI=https://auth.${DOMAIN}/application/o/outline/token/
+OIDC_USERINFO_URI=https://auth.${DOMAIN}/application/o/userinfo/
+OIDC_USERNAME_CLAIM=preferred_username
+OIDC_DISPLAY_NAME=Authentik SSO
+OIDC_SCOPES=openid email profile
+```
+
+**Test:** Visit `https://outline.${DOMAIN}` → "Continue with Authentik SSO".
+
+---
+
+## 5. Open WebUI — OIDC
+
+**Create provider in Authentik:**
+1. Provider name: `OpenWebUI`, Client type: `Confidential`
+2. Redirect URIs: `https://chat.${DOMAIN}/oauth/oidc/callback`
+3. Scopes: `openid`, `email`, `profile`
+
+**`stacks/ai/.env` additions:**
+
+```env
+# Open WebUI OIDC
+ENABLE_OAUTH_SIGNUP=true
+OAUTH_MERGE_ACCOUNTS_BY_EMAIL=true
+OAUTH_PROVIDER_NAME=Authentik
+OPENID_PROVIDER_URL=https://auth.${DOMAIN}/application/o/openwebui/.well-known/openid-configuration
+OAUTH_CLIENT_ID=${OPENWEBUI_OAUTH_CLIENT_ID}
+OAUTH_CLIENT_SECRET=${OPENWEBUI_OAUTH_CLIENT_SECRET}
+OAUTH_SCOPES=openid email profile
+OAUTH_USERNAME_CLAIM=preferred_username
+```
+
+**Test:** Visit `https://chat.${DOMAIN}` → "Sign in with Authentik".
+
+---
+
+## 6. Portainer — OAuth2
+
+**Create provider in Authentik:**
+1. Provider name: `Portainer`, Client type: `Confidential`
+2. Redirect URIs: `https://portainer.${DOMAIN}`
+3. Scopes: `openid`, `email`, `profile`
+
+**Configure in Portainer UI:**
+
+Navigate to Settings → Authentication → OAuth:
+
+| Field | Value |
+|-------|-------|
+| Use SSO | ✅ |
+| Client ID | `${PORTAINER_OAUTH_CLIENT_ID}` |
+| Client Secret | `${PORTAINER_OAUTH_CLIENT_SECRET}` |
+| Authorization URL | `https://auth.${DOMAIN}/application/o/portainer/authorize/` |
+| Access Token URL | `https://auth.${DOMAIN}/application/o/portainer/token/` |
+| Resource URL | `https://auth.${DOMAIN}/application/o/userinfo/` |
+| Redirect URL | `https://portainer.${DOMAIN}` |
+| User identifier | `preferred_username` |
+| Scopes | `openid email profile` |
+| Auth style | `In params` |
+
+**Auto-create users on OAuth login:** Enable in the same settings page.
+
+**`stacks/base/.env` additions:**
+
+```env
+PORTAINER_OAUTH_CLIENT_ID=<from authentik-setup.sh>
+PORTAINER_OAUTH_CLIENT_SECRET=<from authentik-setup.sh>
+```
+
+**Test:** Visit `https://portainer.${DOMAIN}` → click OAuth login button.
+
+---
+
+## 7. Traefik ForwardAuth — Any Service
+
+Use this for services that **don't support OIDC natively** (e.g. Home Assistant, Prometheus, Alertmanager).
+
+### Configuration file
+
+**`config/traefik/dynamic/middlewares.yml`:**
+
+```yaml
+http:
+  middlewares:
+    # Authentik ForwardAuth — requires login for all requests
+    authentik:
+      forwardAuth:
+        address: "http://authentik-server:9000/outpost.goauthentik.io/auth/traefik"
+        trustForwardHeader: true
+        authResponseHeaders:
+          - X-authentik-username
+          - X-authentik-groups
+          - X-authentik-email
+          - X-authentik-name
+          - X-authentik-uid
+          - X-authentik-jwt
+          - X-authentik-meta-jwks
+          - X-authentik-meta-outpost
+          - X-authentik-meta-provider
+          - X-authentik-meta-app
+          - X-authentik-meta-version
+
+    # Chain: HTTPS redirect + Authentik auth
+    secured:
+      chain:
+        middlewares:
+          - https-redirect
+          - authentik
+
+    # HTTPS redirect only (no auth)
+    https-redirect:
+      redirectScheme:
+        scheme: https
+        permanent: true
+```
+
+### Authentik Outpost Setup
+
+ForwardAuth requires a **Proxy Outpost** in Authentik:
+
+1. Admin UI → Applications → Outposts → Create
+2. Name: `homelab-proxy`, Type: `Proxy`
+3. Add the applications you want protected
+4. The outpost integrates with the deployed `authentik-worker` container
+
+### Apply to a service
+
+Add to the service's Traefik labels:
+
+```yaml
+services:
+  prometheus:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prometheus.rule=Host(`prometheus.${DOMAIN}`)"
+      - "traefik.http.routers.prometheus.entrypoints=websecure"
+      - "traefik.http.routers.prometheus.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.prometheus.middlewares=authentik@file"   # ← add this
+      - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
+```
+
+### Protecting the Authentik domain itself (outpost catch-all)
+
+The `authentik-server` service already exposes a catch-all route for `*.${DOMAIN}/outpost.goauthentik.io/*` so the ForwardAuth callback works across all subdomains.
+
+---
+
+## 8. Adding a New Service
+
+### Checklist
+
+```
+[ ] 1. Create provider in Authentik (OAuth2/OpenID or SAML)
+[ ] 2. Set redirect URI to the service's callback URL
+[ ] 3. Create Application, link provider, set icon/slug
+[ ] 4. Add Policy Binding to restrict to appropriate group
+[ ] 5. Copy Client ID + Secret to .env
+[ ] 6. Configure the service (env vars or UI)
+[ ] 7. Test login flow end-to-end
+[ ] 8. Optionally apply ForwardAuth if service lacks native OIDC
+```
+
+### Common redirect URI patterns
+
+| Service | Redirect URI pattern |
+|---------|---------------------|
+| Generic web app | `https://app.${DOMAIN}/oauth/callback` |
+| Grafana | `https://grafana.${DOMAIN}/login/generic_oauth` |
+| Gitea | `https://gitea.${DOMAIN}/user/oauth2/<name>/callback` |
+| Nextcloud | `https://nextcloud.${DOMAIN}/apps/sociallogin/custom_oidc/<name>` |
+| Outline | `https://outline.${DOMAIN}/auth/oidc.callback` |
+| Portainer | `https://portainer.${DOMAIN}` |
+| Open WebUI | `https://chat.${DOMAIN}/oauth/oidc/callback` |
+| Jellyfin (SSO plugin) | `https://jellyfin.${DOMAIN}/sso/OID/redirect/authentik` |
+
+### Discovery URL (auto-configuration)
+
+Many services support OIDC discovery — just provide:
+```
+https://auth.${DOMAIN}/application/o/<slug>/.well-known/openid-configuration
+```
+
+### Policy bindings (group-based access control)
+
+Restrict which groups can access each application:
+
+1. Admin UI → Applications → [App] → Policy / Group / User Bindings
+2. Click Bind existing policy
+3. Choose policy type: **Group Membership Policy**
+4. Select group: `homelab-admins` or `homelab-users` or `media-users`
+5. Order: 0, Timeout: 30
+
+Users not in the bound group will see "Permission denied" from Authentik.
+
+---
+
+## 🔑 OIDC Endpoints Reference
+
+| Endpoint | URL |
+|----------|-----|
+| Discovery | `https://auth.${DOMAIN}/application/o/<slug>/.well-known/openid-configuration` |
+| Authorization | `https://auth.${DOMAIN}/application/o/<slug>/authorize/` |
+| Token | `https://auth.${DOMAIN}/application/o/<slug>/token/` |
+| Userinfo | `https://auth.${DOMAIN}/application/o/userinfo/` |
+| JWKS | `https://auth.${DOMAIN}/application/o/<slug>/jwks/` |
+| End session | `https://auth.${DOMAIN}/application/o/<slug>/end-session/` |
+| ForwardAuth | `http://authentik-server:9000/outpost.goauthentik.io/auth/traefik` |


### PR DESCRIPTION
## SSO Stack — Authentik Unified Identity

Complete single sign-on implementation using Authentik as OIDC/SAML provider.

### Services
- **Authentik Server** `ghcr.io/goauthentik/server:2024.8.3` — OIDC/SAML/LDAP provider
- **Authentik Worker** — Background task processor
- **PostgreSQL** `postgres:16.4-alpine` — Dedicated Authentik database
- **Redis** `redis:7.4.0-alpine` — Session cache

### Features
- Authentik accessible at `auth.${DOMAIN}`
- `scripts/authentik-setup.sh` — Automated OIDC provider creation via API (Grafana, Gitea, Nextcloud, Outline, Open WebUI, Portainer). Outputs Client ID/Secret per service. Supports `--dry-run`
- `scripts/nextcloud-oidc-setup.sh` — Nextcloud OIDC configuration automation
- `config/traefik/dynamic/middlewares.yml` — ForwardAuth middleware for non-native OIDC services
- `stacks/sso/docs/integration-examples.md` — Per-service OIDC config reference
- Strict healthchecks; other stacks wait for Authentik via `service_healthy`
- User group design: `homelab-admins`, `homelab-users`, `media-users`
- `.env.example` with all secrets documented

Closes #9