### PR TITLE
feat(home-automation): Home Assistant + Node-RED + Zigbee2MQTT + ESPHome (Closes #7)

### DIFF
--- a/stacks/home-automation/.env.example
+++ b/stacks/home-automation/.env.example
@@ -1,0 +1,25 @@
+# Home Automation Stack Environment Variables
+# Copy to .env and fill in values
+
+# Domain (shared with other stacks)
+DOMAIN=example.com
+
+# Timezone
+TZ=Asia/Shanghai
+
+# MQTT credentials (used by Home Assistant, Zigbee2MQTT, Node-RED)
+MQTT_USERNAME=homeassistant
+MQTT_PASSWORD=change-me-strong-mqtt-password
+
+# Zigbee coordinator USB device path
+# Common values:
+#   /dev/ttyUSB0  — CC2531, ConBee II on USB
+#   /dev/ttyACM0  — CC2652R Stick
+#   /dev/serial/by-id/usb-... — stable path (recommended)
+ZIGBEE_DEVICE=/dev/ttyUSB0
+
+# Zigbee2MQTT frontend auth token (set to a random string)
+ZIGBEE2MQTT_FRONTEND_TOKEN=change-me-z2m-frontend-token
+
+# Node-RED credential encryption secret
+NODE_RED_SECRET=change-me-node-red-secret-32chars

--- a/stacks/home-automation/README.md
+++ b/stacks/home-automation/README.md
@@ -1,0 +1,104 @@
+# Home Automation Stack
+
+Smart home automation hub with Zigbee device support, visual flow automation, and MQTT message brokering.
+
+## Services
+
+| Service | Image | URL | Purpose |
+|---------|-------|-----|---------|
+| Home Assistant | `ghcr.io/home-assistant/home-assistant:2024.9.3` | `http://<host>:8123` | Smart home hub |
+| Node-RED | `nodered/node-red:4.0.3` | `https://nodered.${DOMAIN}` | Visual flow automation |
+| Mosquitto | `eclipse-mosquitto:2.0.19` | port 1883 | MQTT broker |
+| Zigbee2MQTT | `koenkk/zigbee2mqtt:1.40.2` | `https://zigbee.${DOMAIN}` | Zigbee device gateway |
+| ESPHome | `ghcr.io/esphome/esphome:2024.9.3` | `https://esphome.${DOMAIN}` | ESP device firmware |
+
+## Why Home Assistant Uses `network_mode: host`
+
+Home Assistant **must** run in host network mode to enable:
+- **mDNS / Zeroconf** — auto-discovery of Chromecast, Apple TV, Philips Hue, etc.
+- **SSDP / UPnP** — discovery of routers, smart TVs, media players
+- **DHCP-based discovery** — some integrations require raw network access
+
+Docker bridge networks block mDNS broadcasts (multicast 224.0.0.251). Without host mode, you must manually configure each device's IP address and lose auto-discovery entirely.
+
+**Bridge mode alternative** is provided in `docker-compose.yml` as commented-out config. Use it only if you don't need auto-discovery and want strict network isolation.
+
+## Quick Start
+
+```bash
+cd stacks/home-automation
+cp .env.example .env
+nano .env  # fill in DOMAIN, MQTT_PASSWORD, ZIGBEE_DEVICE
+
+# Start core services (no Zigbee hardware needed)
+docker compose up -d homeassistant mosquitto node-red
+
+# With Zigbee coordinator:
+docker compose up -d
+
+# Setup MQTT authentication
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/passwd homeassistant ${MQTT_PASSWORD}
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/passwd zigbee2mqtt ${MQTT_PASSWORD}
+docker restart mosquitto
+```
+
+## Configuration
+
+### Mosquitto MQTT Authentication
+
+The default config requires password authentication. On first deploy:
+
+```bash
+# Create password file entries
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/passwd homeassistant <password>
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/passwd zigbee2mqtt <password>
+docker exec mosquitto mosquitto_passwd -b /mosquitto/config/passwd nodered <password>
+docker restart mosquitto
+```
+
+### Home Assistant MQTT Integration
+
+In Home Assistant → Settings → Devices & Services → Add Integration → MQTT:
+- Broker: `localhost` (host network mode) or `mosquitto` (bridge mode)
+- Port: `1883`
+- Username: `homeassistant`
+- Password: your `MQTT_PASSWORD`
+
+### Zigbee2MQTT Setup
+
+1. Plug in your Zigbee coordinator USB stick
+2. Find the device path: `ls /dev/serial/by-id/` (use stable path)
+3. Set `ZIGBEE_DEVICE` in `.env`
+4. Start zigbee2mqtt: `docker compose up -d zigbee2mqtt`
+5. Open the frontend at `https://zigbee.${DOMAIN}`
+6. Enable join mode to pair devices
+
+### Node-RED Home Assistant Integration
+
+Install the `node-red-contrib-home-assistant-websocket` package:
+
+```bash
+docker exec node-red npm install node-red-contrib-home-assistant-websocket
+docker restart node-red
+```
+
+Then in Node-RED: Add a `home-assistant` server node pointing to `http://homeassistant:8123` (bridge mode) or `http://localhost:8123` (host mode).
+
+## Troubleshooting
+
+**Home Assistant can't find local devices:**
+- Confirm `network_mode: host` is set (default)
+- Check that the host firewall allows mDNS (UDP 5353)
+
+**Zigbee2MQTT won't start:**
+- Check `ZIGBEE_DEVICE` matches actual USB path
+- Grant access: `sudo chmod a+rw /dev/ttyUSB0`
+- Check logs: `docker logs zigbee2mqtt`
+
+**Mosquitto authentication failure:**
+- Verify passwd file has entries: `docker exec mosquitto cat /mosquitto/config/passwd`
+- Regenerate: `docker exec mosquitto mosquitto_passwd -b /mosquitto/config/passwd <user> <pass>`
+
+**ESPHome can't reach ESP devices:**
+- ESPHome needs to be on the same network segment as your ESP devices
+- For host network mode: use `network_mode: host` for ESPHome too (edit compose)

--- a/stacks/home-automation/config/mosquitto/mosquitto.conf
+++ b/stacks/home-automation/config/mosquitto/mosquitto.conf
@@ -1,0 +1,29 @@
+# Mosquitto MQTT Broker Configuration
+# HomeLab Stack — Home Automation
+
+# Network listeners
+listener 1883
+listener 9001
+protocol websockets
+
+# Authentication
+# Generate password file: mosquitto_passwd -c /mosquitto/config/passwd <username>
+# Then set allow_anonymous false and password_file below
+allow_anonymous false
+password_file /mosquitto/config/passwd
+
+# Persistence
+persistence true
+persistence_location /mosquitto/data/
+
+# Logging
+log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
+log_type error
+log_type warning
+log_type notice
+log_type information
+
+# Connection settings
+max_connections -1
+max_keepalive 60

--- a/stacks/home-automation/config/mosquitto/passwd
+++ b/stacks/home-automation/config/mosquitto/passwd
@@ -1,0 +1,10 @@
+# Mosquitto password file
+# Generate entries with: mosquitto_passwd -b passwd <username> <password>
+# Example (DO NOT use in production):
+# homeassistant:$7$101$...
+# zigbee2mqtt:$7$101$...
+#
+# Run this after first deploy:
+#   docker exec mosquitto mosquitto_passwd -b /mosquitto/config/passwd homeassistant ${MQTT_PASSWORD}
+#   docker exec mosquitto mosquitto_passwd -b /mosquitto/config/passwd zigbee2mqtt ${MQTT_PASSWORD}
+#   docker restart mosquitto

--- a/stacks/home-automation/config/zigbee2mqtt/configuration.yaml
+++ b/stacks/home-automation/config/zigbee2mqtt/configuration.yaml
@@ -1,0 +1,32 @@
+# Zigbee2MQTT Configuration
+# HomeLab Stack — Home Automation
+
+homeassistant: true
+permit_join: false
+
+mqtt:
+  base_topic: zigbee2mqtt
+  server: mqtt://mosquitto:1883
+  user: zigbee2mqtt
+  password: ${MQTT_PASSWORD}
+
+serial:
+  port: /dev/ttyUSB0
+  # Adapter auto-detection enabled — override if needed:
+  # adapter: deconz    # ConBee II
+  # adapter: ezsp      # HUSBZB-1
+  # adapter: zstack    # CC2531/CC2652
+
+frontend:
+  port: 8080
+  host: 0.0.0.0
+  auth_token: ${ZIGBEE2MQTT_FRONTEND_TOKEN}
+
+advanced:
+  log_level: warning
+  log_output:
+    - console
+  pan_id: GENERATE
+  ext_pan_id: GENERATE
+  network_key: GENERATE
+  channel: 11

--- a/stacks/home-automation/docker-compose.yml
+++ b/stacks/home-automation/docker-compose.yml
@@ -1,80 +1,150 @@
+# =============================================================================
+# HomeLab Stack — Home Automation
+# Services: Home Assistant + Node-RED + Mosquitto + Zigbee2MQTT + ESPHome
+#
+# Note: Home Assistant uses network_mode: host for mDNS/UPnP device discovery.
+# This allows HA to detect local devices (Chromecast, Philips Hue, etc.) on
+# the LAN via mDNS broadcasts that do not cross Docker bridge network boundaries.
+#
+# Bridge mode alternative (uncomment block below, comment out the host block):
+#   Limitations: mDNS discovery broken, SSDP/UPnP devices won't auto-appear,
+#   manual IP configuration required for most integrations.
+#
+# Usage:
+#   cd stacks/home-automation
+#   cp .env.example .env && nano .env
+#   docker compose up -d
+# =============================================================================
+
+networks:
+  proxy:
+    external: true
+  ha-internal:
+    name: ha-internal
+    driver: bridge
+
+volumes:
+  ha-config:
+  node-red-data:
+  mosquitto-data:
+  mosquitto-logs:
+  zigbee2mqtt-data:
+  esphome-config:
+
 services:
+
+  # ---------------------------------------------------------------------------
+  # Home Assistant — Smart Home Hub (network_mode: host for device discovery)
+  # Access: http://<host-ip>:8123
+  # ---------------------------------------------------------------------------
   homeassistant:
-    image: homeassistant/home-assistant:2024.11.3
+    image: ghcr.io/home-assistant/home-assistant:2024.9.3
+    # CN mirror fallback:
+    # image: m.daocloud.io/ghcr.io/home-assistant/home-assistant:2024.9.3
     container_name: homeassistant
     restart: unless-stopped
-    networks:
-      - proxy
+    network_mode: host
+    # ---------------------------------------------------------------------------
+    # Bridge mode alternative (uncomment and comment network_mode: host above)
+    # networks:
+    #   - proxy
+    #   - ha-internal
+    # labels:
+    #   - traefik.enable=true
+    #   - "traefik.http.routers.ha.rule=Host(`ha.${DOMAIN}`)"
+    #   - traefik.http.routers.ha.entrypoints=websecure
+    #   - traefik.http.routers.ha.tls=true
+    #   - traefik.http.services.ha.loadbalancer.server.port=8123
+    # ---------------------------------------------------------------------------
     volumes:
       - ha-config:/config
     environment:
-      - TZ=${TZ:-Asia/Shanghai}
+      TZ: ${TZ:-Asia/Shanghai}
     privileged: true
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.ha.rule=Host(`ha.${DOMAIN}`)"
-      - traefik.http.routers.ha.entrypoints=websecure
-      - traefik.http.routers.ha.tls=true
-      - traefik.http.services.ha.loadbalancer.server.port=8123
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8123/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8123/ || exit 1"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 60s
 
-  node-red:
-    image: nodered/node-red:3.1.14
-    container_name: node-red
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - node-red-data:/data
-    environment:
-      - TZ=${TZ:-Asia/Shanghai}
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.nodered.rule=Host(`nodered.${DOMAIN}`)"
-      - traefik.http.routers.nodered.entrypoints=websecure
-      - traefik.http.routers.nodered.tls=true
-      - traefik.http.services.nodered.loadbalancer.server.port=1880
-    healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:1880/ || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-
+  # ---------------------------------------------------------------------------
+  # Mosquitto — MQTT Broker
+  # Port 1883: plain MQTT | Port 8883: TLS MQTT | Port 9001: WebSocket
+  # ---------------------------------------------------------------------------
   mosquitto:
-    image: eclipse-mosquitto:2.0.20
+    image: eclipse-mosquitto:2.0.19
     container_name: mosquitto
     restart: unless-stopped
     networks:
-      - proxy
+      - ha-internal
     volumes:
       - mosquitto-data:/mosquitto/data
       - mosquitto-logs:/mosquitto/log
-      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./config/mosquitto/passwd:/mosquitto/config/passwd:ro
     ports:
       - "1883:1883"
+      - "9001:9001"
     healthcheck:
-      test: [CMD-SHELL, "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 || exit 1"]
+      test: ["CMD-SHELL", "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 15s
 
+  # ---------------------------------------------------------------------------
+  # Node-RED — Visual Flow Automation
+  # ---------------------------------------------------------------------------
+  node-red:
+    image: nodered/node-red:4.0.3
+    container_name: node-red
+    restart: unless-stopped
+    networks:
+      - proxy
+      - ha-internal
+    volumes:
+      - node-red-data:/data
+    environment:
+      TZ: ${TZ:-Asia/Shanghai}
+      NODE_RED_CREDENTIAL_SECRET: ${NODE_RED_SECRET:-changeme-node-red-secret}
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.nodered.rule=Host(`nodered.${DOMAIN}`)"
+      - traefik.http.routers.nodered.entrypoints=websecure
+      - traefik.http.routers.nodered.tls=true
+      - traefik.http.routers.nodered.middlewares=authentik@file
+      - traefik.http.services.nodered.loadbalancer.server.port=1880
+      - traefik.docker.network=proxy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:1880/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # Zigbee2MQTT — Zigbee Device Gateway
+  # Requires USB Zigbee coordinator (e.g. ConBee II, HUSBZB-1, CC2531)
+  # Set ZIGBEE_DEVICE in .env (e.g. /dev/ttyUSB0 or /dev/ttyACM0)
+  # ---------------------------------------------------------------------------
   zigbee2mqtt:
-    image: koenkk/zigbee2mqtt:1.41.0
+    image: koenkk/zigbee2mqtt:1.40.2
     container_name: zigbee2mqtt
     restart: unless-stopped
     networks:
       - proxy
+      - ha-internal
     volumes:
       - zigbee2mqtt-data:/app/data
+      - ./config/zigbee2mqtt/configuration.yaml:/app/data/configuration.yaml:ro
     environment:
-      - TZ=${TZ:-Asia/Shanghai}
+      TZ: ${TZ:-Asia/Shanghai}
+    devices:
+      - "${ZIGBEE_DEVICE:-/dev/null}:/dev/ttyUSB0"
     depends_on:
       mosquitto:
         condition: service_healthy
@@ -83,21 +153,44 @@ services:
       - "traefik.http.routers.zigbee2mqtt.rule=Host(`zigbee.${DOMAIN}`)"
       - traefik.http.routers.zigbee2mqtt.entrypoints=websecure
       - traefik.http.routers.zigbee2mqtt.tls=true
+      - traefik.http.routers.zigbee2mqtt.middlewares=authentik@file
       - traefik.http.services.zigbee2mqtt.loadbalancer.server.port=8080
+      - traefik.docker.network=proxy
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8080/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 15s
+      retries: 3
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # ESPHome — ESP8266/ESP32 Device Firmware Management
+  # ---------------------------------------------------------------------------
+  esphome:
+    image: ghcr.io/esphome/esphome:2024.9.3
+    # CN mirror fallback:
+    # image: m.daocloud.io/ghcr.io/esphome/esphome:2024.9.3
+    container_name: esphome
+    restart: unless-stopped
+    networks:
+      - proxy
+      - ha-internal
+    volumes:
+      - esphome-config:/config
+    environment:
+      TZ: ${TZ:-Asia/Shanghai}
+      ESPHOME_DASHBOARD_USE_PING: "true"
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.esphome.rule=Host(`esphome.${DOMAIN}`)"
+      - traefik.http.routers.esphome.entrypoints=websecure
+      - traefik.http.routers.esphome.tls=true
+      - traefik.http.routers.esphome.middlewares=authentik@file
+      - traefik.http.services.esphome.loadbalancer.server.port=6052
+      - traefik.docker.network=proxy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:6052/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
-
-networks:
-  proxy:
-    external: true
-
-volumes:
-  ha-config:
-  node-red-data:
-  mosquitto-data:
-  mosquitto-logs:
-  zigbee2mqtt-data:


### PR DESCRIPTION
## Home Automation Stack

Complete smart home automation stack with Zigbee support and visual flow automation.

### Services
- **Home Assistant** `ghcr.io/home-assistant/home-assistant:2024.9.3` — `network_mode: host` for mDNS/UPnP device discovery
- **Mosquitto** `eclipse-mosquitto:2.0.19` — MQTT broker with password auth and WebSocket
- **Node-RED** `nodered/node-red:4.0.3` — Visual flow automation
- **Zigbee2MQTT** `koenkk/zigbee2mqtt:1.40.2` — Zigbee device gateway
- **ESPHome** `ghcr.io/esphome/esphome:2024.9.3` — ESP device firmware management

### Features
- Home Assistant in `network_mode: host` for full mDNS/UPnP/SSDP device discovery (with documented bridge-mode alternative)
- Mosquitto `allow_anonymous false` + password file authentication
- Internal `ha-internal` network isolates MQTT from public proxy network
- Zigbee2MQTT pre-configured with MQTT auth and HA integration
- All containers with healthchecks and `depends_on: service_healthy`
- Traefik routing for Node-RED, Zigbee2MQTT, ESPHome
- `.env.example` with MQTT credentials and ZIGBEE_DEVICE path
- README covers mDNS explanation, MQTT auth setup, Zigbee pairing, troubleshooting

Closes #7