### PR TITLE
[BOUNTY ] Backup & DR — 自动备份 + 灾难恢复

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,47 @@ DOCKER_PROXY_ENABLED=false
 CN_MODE=false
 CN_APT_MIRROR=https://mirrors.aliyun.com/ubuntu
 CN_DOCKER_MIRROR=https://docker.m.daocloud.io
+
+# -----------------------------------------------------------------------------
+# BACKUP & DR
+# -----------------------------------------------------------------------------
+# Backup target: local, s3, b2, sftp, r2
+BACKUP_TARGET=local
+
+# Restic repository password (REQUIRED for backups)
+RESTIC_PASSWORD=
+
+# Restic retention policy
+RESTIC_RETENTION_POLICY=--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 1
+
+# Local backup path (when BACKUP_TARGET=local)
+BACKUP_LOCAL_PATH=/opt/homelab-backups
+
+# S3 / MinIO Configuration (BACKUP_TARGET=s3)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=
+S3_ENDPOINT=                    # For MinIO: http://minio.yourdomain.com:9000
+
+# Backblaze B2 Configuration (BACKUP_TARGET=b2)
+B2_ACCOUNT_ID=
+B2_ACCOUNT_KEY=
+B2_BUCKET_NAME=
+
+# SFTP Configuration (BACKUP_TARGET=sftp)
+SFTP_USER=
+SFTP_PASSWORD=
+SFTP_HOST=
+SFTP_PORT=22
+SFTP_PATH=/backups/homelab
+
+# Cloudflare R2 Configuration (BACKUP_TARGET=r2)
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_ENDPOINT=                    # https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+R2_BUCKET_NAME=
+
+# Backup Notifications (ntfy)
+NTFY_SERVER=https://ntfy.sh
+NTFY_TOPIC=homelab-backups

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,343 @@
+# Disaster Recovery Plan
+
+This document provides step-by-step procedures for recovering your HomeLab Stack from a complete system failure.
+
+## Overview
+
+### 3-2-1 Backup Strategy
+
+Our backup implementation follows the 3-2-1 strategy:
+
+| Component | Description |
+|-----------|-------------|
+| **3 Copies** | Live data + Restic repository + Duplicati cloud backup |
+| **2 Media Types** | Local disk + Cloud storage (S3/B2/R2/SFTP) |
+| **1 Offsite** | Cloud backup provides offsite resilience |
+
+### Recovery Time Objectives (RTO)
+
+| Stack | Estimated RTO |
+|-------|---------------|
+| Base (Traefik, Portainer) | 30 minutes |
+| Databases | 1-2 hours |
+| SSO (Authentik) | 1 hour |
+| Storage (Nextcloud, MinIO) | 2-4 hours |
+| Media | 2-4 hours |
+| Productivity | 1-2 hours |
+| Home Automation | 1 hour |
+| Monitoring | 30 minutes |
+| **Full Recovery** | 8-12 hours |
+
+---
+
+## Phase 1: Prepare New Host
+
+### 1.1 Install Base OS
+
+Install a supported Linux distribution (Ubuntu Server 22.04/24.04 LTS recommended).
+
+### 1.2 Install Docker
+
+```bash
+# Update system
+sudo apt update && sudo apt upgrade -y
+
+# Install Docker
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+newgrp docker
+
+# Verify installation
+docker --version
+docker compose version
+```
+
+### 1.3 Clone Repository
+
+```bash
+sudo mkdir -p /opt/homelab-stack
+sudo chown $USER:$USER /opt/homelab-stack
+git clone https://github.com/illbnm/homelab-stack.git /opt/homelab-stack
+cd /opt/homelab-stack
+```
+
+### 1.4 Restore Environment Files
+
+Restore your `.env` files from backup. This is **CRITICAL** as they contain all secrets and configurations.
+
+```bash
+# If you have backed up .env files:
+# cp /path/to/backup/.env /opt/homelab-stack/.env
+# cp /path/to/backup/stacks/*/.env /opt/homelab-stack/stacks/*/
+```
+
+### 1.5 Create Proxy Network
+
+```bash
+docker network create proxy
+```
+
+---
+
+## Phase 2: Restore Backup System
+
+### 2.1 Deploy Backup Stack
+
+```bash
+cd /opt/homelab-stack/stacks/backup
+cp .env.example .env
+# Edit .env with your backup credentials
+nano .env
+
+docker compose up -d
+docker compose ps  # Verify both services are healthy
+```
+
+### 2.2 Verify Backup Access
+
+```bash
+cd /opt/homelab-stack
+./scripts/backup.sh --list
+```
+
+---
+
+## Phase 3: Restore Infrastructure
+
+### 3.1 Restore Base Stack
+
+```bash
+cd /opt/homelab-stack/stacks/base
+
+# Restore Traefik ACME certificates if backed up
+# mkdir -p /opt/homelab-stack/config/traefik
+# touch /opt/homelab-stack/config/traefik/acme.json
+# chmod 600 /opt/homelab-stack/config/traefik/acme.json
+# Restore acme.json from backup
+
+docker compose up -d
+docker compose ps
+```
+
+### 3.2 Verify Base Services
+
+- Traefik Dashboard: `https://traefik.yourdomain.com`
+- Portainer: `https://portainer.yourdomain.com`
+
+---
+
+## Phase 4: Restore Databases
+
+### 4.1 Deploy Database Stack
+
+```bash
+cd /opt/homelab-stack/stacks/databases
+docker compose up -d
+docker compose ps
+```
+
+### 4.2 Restore Database Data
+
+```bash
+# List available backups
+/opt/homelab-stack/scripts/backup.sh --list
+
+# Restore to temporary location
+/opt/homelab-stack/scripts/backup.sh --restore <BACKUP_ID> --target /tmp/db-restore
+
+# Restore PostgreSQL
+docker cp /tmp/db-restore/postgresql_all.sql <postgres_container>:/tmp/
+docker exec <postgres_container> psql -U postgres -f /tmp/postgresql_all.sql
+
+# Restore MySQL/MariaDB
+docker cp /tmp/db-restore/mysql_all.sql <mysql_container>:/tmp/
+docker exec <mysql_container> mysql -u root -p < /tmp/mysql_all.sql
+```
+
+---
+
+## Phase 5: Restore SSO
+
+### 5.1 Deploy Authentik
+
+```bash
+cd /opt/homelab-stack/stacks/sso
+docker compose up -d
+docker compose ps
+```
+
+### 5.2 Restore Authentik Data
+
+```bash
+# Restore Authentik volumes from backup
+/opt/homelab-stack/scripts/backup.sh --restore <BACKUP_ID> --target /tmp/authentik-restore
+
+# Stop Authentik
+docker compose stop
+
+# Restore volumes
+docker run --rm -v authentik-data:/data -v /tmp/authentik-restore:/backup alpine \
+  sh -c "cp -a /backup/. /data/"
+
+# Start Authentik
+docker compose start
+```
+
+---
+
+## Phase 6: Restore Application Stacks
+
+Follow this order for best results:
+
+### 6.1 Network Stack (AdGuard, WireGuard)
+
+```bash
+cd /opt/homelab-stack/stacks/network
+docker compose up -d
+```
+
+### 6.2 Storage Stack (Nextcloud, MinIO)
+
+```bash
+cd /opt/homelab-stack/stacks/storage
+docker compose up -d
+# Restore data volumes from backup
+```
+
+### 6.3 Productivity Stack (Gitea, Vaultwarden, Outline)
+
+```bash
+cd /opt/homelab-stack/stacks/productivity
+docker compose up -d
+# Restore data volumes from backup
+```
+
+### 6.4 Media Stack
+
+```bash
+cd /opt/homelab-stack/stacks/media
+docker compose up -d
+# Restore config volumes (media files usually don't need backup)
+```
+
+### 6.5 Home Automation Stack
+
+```bash
+cd /opt/homelab-stack/stacks/home-automation
+docker compose up -d
+# Restore config volumes
+```
+
+### 6.6 Monitoring Stack
+
+```bash
+cd /opt/homelab-stack/stacks/monitoring
+docker compose up -d
+# Restore Prometheus/Grafana data if needed
+```
+
+---
+
+## Phase 7: Verification Checklist
+
+After completing recovery, verify each service:
+
+### Base Infrastructure
+- [ ] Traefik dashboard accessible at `https://traefik.yourdomain.com`
+- [ ] TLS certificates valid
+- [ ] Portainer accessible at `https://portainer.yourdomain.com`
+- [ ] All containers visible in Portainer
+
+### Databases
+- [ ] PostgreSQL running and accepting connections
+- [ ] Redis running and responsive
+- [ ] MariaDB running and databases restored
+
+### SSO
+- [ ] Authentik accessible at `https://auth.yourdomain.com`
+- [ ] Can log in with admin credentials
+- [ ] OAuth applications configured
+
+### Applications
+- [ ] Nextcloud accessible, files present
+- [ ] Gitea accessible, repositories present
+- [ ] Vaultwarden accessible, vaults intact
+- [ ] Jellyfin accessible, libraries working
+- [ ] Home Assistant accessible, automations working
+
+### Backup System
+- [ ] Restic server healthy
+- [ ] Can list backups: `./scripts/backup.sh --list`
+- [ ] Can verify backups: `./scripts/backup.sh --verify`
+
+---
+
+## Troubleshooting
+
+### Backup Repository Not Accessible
+
+```bash
+# Check restic-server logs
+docker logs restic-server
+
+# Verify network connectivity
+docker run --rm --network proxy alpine ping restic-server
+
+# Check repository
+RESTIC_PASSWORD=your_password docker run --rm --network proxy \
+  -e RESTIC_PASSWORD \
+  -e RESTIC_REPOSITORY=rest:http://restic-server:8000 \
+  restic/restic:0.17.0 snapshots
+```
+
+### Volume Permission Issues
+
+```bash
+# Fix permissions on restored volumes
+docker run --rm -v <volume_name>:/data alpine \
+  sh -c "chown -R 1000:1000 /data"
+```
+
+### Database Restore Failures
+
+```bash
+# PostgreSQL: Check logs
+docker logs <postgres_container>
+
+# Manual restore
+docker exec -it <postgres_container> psql -U postgres
+```
+
+---
+
+## Testing Recovery
+
+Regularly test your backup and recovery procedures:
+
+1. **Monthly**: Run `./scripts/backup.sh --verify`
+2. **Quarterly**: Perform a partial restore test
+3. **Annually**: Full disaster recovery drill
+
+### Quick Recovery Test
+
+```bash
+# Create test restore
+./scripts/backup.sh --restore <BACKUP_ID> --target /tmp/test-restore
+
+# Verify contents
+ls -la /tmp/test-restore
+
+# Clean up
+rm -rf /tmp/test-restore
+```
+
+---
+
+## Contact & Support
+
+- GitHub Issues: https://github.com/illbnm/homelab-stack/issues
+- Documentation: `/opt/homelab-stack/stacks/*/README.md`
+
+---
+
+*Generated/reviewed with: claude-opus-4-6*

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,99 +1,633 @@
 #!/usr/bin/env bash
 # =============================================================================
-# HomeLab Backup — Docker volumes + configs 全量备份
+# HomeLab Backup — 3-2-1 Backup Strategy
+# Usage: backup.sh --target <all|media> [options]
 # =============================================================================
 set -euo pipefail
 
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
-BASE_DIR="$SCRIPT_DIR/.."
-ENV_FILE="$BASE_DIR/config/.env"
+BASE_DIR="$(dirname "$SCRIPT_DIR")"
 
-[[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
 
-BACKUP_DIR="${BACKUP_DIR:-/opt/homelab-backups}"
-RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_PATH="$BACKUP_DIR/$TIMESTAMP"
+# Logging functions
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+log_debug() { [[ "${DEBUG:-0}" == "1" ]] && echo -e "${BLUE}[DEBUG]${NC} $*"; }
 
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
-log_info()  { echo -e "${GREEN}[backup]${NC} $*"; }
-log_warn()  { echo -e "${YELLOW}[backup]${NC} $*"; }
-log_error() { echo -e "${RED}[backup]${NC} $*" >&2; }
-
-mkdir -p "$BACKUP_PATH"
-
-# 备份 Docker volumes
-backup_volumes() {
-  log_info "Backing up Docker volumes..."
-  local volumes
-  volumes=$(docker volume ls --format '{{.Name}}' | grep -v '^[a-f0-9]\{64\}$' || true)
-  while IFS= read -r vol; do
-    [[ -z "$vol" ]] && continue
-    log_info "  Volume: $vol"
-    docker run --rm \
-      -v "${vol}:/data:ro" \
-      -v "$BACKUP_PATH:/backup" \
-      alpine:3.19 \
-      tar czf "/backup/vol_${vol}.tar.gz" -C /data . 2>/dev/null || \
-      log_warn "  Failed to backup volume: $vol"
-  done <<< "$volumes"
+# -----------------------------------------------------------------------------
+# Load Environment
+# -----------------------------------------------------------------------------
+load_env() {
+  local env_files=(
+    "$BASE_DIR/.env"
+    "$BASE_DIR/stacks/backup/.env"
+    "$BASE_DIR/config/.env"
+  )
+  
+  for env_file in "${env_files[@]}"; do
+    if [[ -f "$env_file" ]]; then
+      log_debug "Loading: $env_file"
+      # Export variables, handling quoted values
+      set -a
+      while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+        if [[ "$line" =~ ^([^=]+)=(.*)$ ]]; then
+          local key="${BASH_REMATCH[1]}"
+          local value="${BASH_REMATCH[2]}"
+          # Remove surrounding quotes
+          value="${value#\"}"
+          value="${value%\"}"
+          value="${value#\'}"
+          value="${value%\'}"
+          export "$key=$value"
+        fi
+      done < "$env_file"
+      set +a
+    fi
+  done
 }
 
-# 备份配置文件
+# -----------------------------------------------------------------------------
+# Send ntfy Notification
+# -----------------------------------------------------------------------------
+send_notification() {
+  local message="$1"
+  local title="${2:-HomeLab Backup}"
+  local priority="${3:-default}"
+  
+  if [[ -n "${NTFY_SERVER:-}" ]] && [[ -n "${NTFY_TOPIC:-}" ]]; then
+    curl -s -S \
+      -H "Title: $title" \
+      -H "Priority: $priority" \
+      -H "Tags: backup" \
+      -d "$message" \
+      "${NTFY_SERVER}/${NTFY_TOPIC}" >/dev/null 2>&1 || \
+      log_warn "Failed to send ntfy notification"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Get Restic Repository String
+# -----------------------------------------------------------------------------
+get_restic_repo() {
+  case "${BACKUP_TARGET:-local}" in
+    local)
+      echo "rest:http://${RESTIC_SERVER_HOST:-restic-server}:${RESTIC_SERVER_PORT:-8000}"
+      ;;
+    s3)
+      : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID required for S3}"
+      : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY required for S3}"
+      : "${S3_BUCKET_NAME:?S3_BUCKET_NAME required}"
+      if [[ -n "${S3_ENDPOINT:-}" ]]; then
+        echo "s3:${S3_ENDPOINT}/${S3_BUCKET_NAME}"
+      else
+        : "${AWS_REGION:?AWS_REGION required}"
+        echo "s3:s3.${AWS_REGION}.amazonaws.com/${S3_BUCKET_NAME}"
+      fi
+      ;;
+    b2)
+      : "${B2_ACCOUNT_ID:?B2_ACCOUNT_ID required for B2}"
+      : "${B2_ACCOUNT_KEY:?B2_ACCOUNT_KEY required for B2}"
+      : "${B2_BUCKET_NAME:?B2_BUCKET_NAME required}"
+      echo "b2:${B2_BUCKET_NAME}"
+      ;;
+    sftp)
+      : "${SFTP_USER:?SFTP_USER required}"
+      : "${SFTP_HOST:?SFTP_HOST required}"
+      : "${SFTP_PATH:?SFTP_PATH required}"
+      echo "sftp:${SFTP_USER}@${SFTP_HOST}:${SFTP_PATH}"
+      ;;
+    r2)
+      : "${R2_ACCESS_KEY_ID:?R2_ACCESS_KEY_ID required for R2}"
+      : "${R2_SECRET_ACCESS_KEY:?R2_SECRET_ACCESS_KEY required for R2}"
+      : "${R2_ENDPOINT:?R2_ENDPOINT required}"
+      : "${R2_BUCKET_NAME:?R2_BUCKET_NAME required}"
+      echo "s3:${R2_ENDPOINT}/${R2_BUCKET_NAME}"
+      ;;
+    *)
+      log_error "Unsupported BACKUP_TARGET: ${BACKUP_TARGET}"
+      exit 1
+      ;;
+  esac
+}
+
+# -----------------------------------------------------------------------------
+# Run Restic in Docker Container
+# -----------------------------------------------------------------------------
+run_restic() {
+  local cmd=("$@")
+  local docker_args=("--rm")
+  local volume_args=()
+  
+  # Network for local restic server
+  if [[ "${BACKUP_TARGET:-local}" == "local" ]]; then
+    docker_args+=("--network" "proxy")
+  fi
+  
+  # Process volume mounts
+  for arg in "$@"; do
+    if [[ "$arg" == /* ]] && [[ -e "$arg" ]]; then
+      local basename
+      basename="$(basename "$arg")"
+      volume_args+=("-v" "${arg}:/source/${basename}:ro")
+    fi
+  done
+  
+  # Environment variables for restic
+  local env_args=(
+    "-e" "RESTIC_PASSWORD=${RESTIC_PASSWORD}"
+    "-e" "RESTIC_REPOSITORY=$(get_restic_repo)"
+  )
+  
+  # Add cloud credentials
+  [[ -n "${AWS_ACCESS_KEY_ID:-}" ]] && env_args+=("-e" "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}")
+  [[ -n "${AWS_SECRET_ACCESS_KEY:-}" ]] && env_args+=("-e" "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}")
+  [[ -n "${AWS_REGION:-}" ]] && env_args+=("-e" "AWS_REGION=${AWS_REGION}")
+  [[ -n "${B2_ACCOUNT_ID:-}" ]] && env_args+=("-e" "B2_ACCOUNT_ID=${B2_ACCOUNT_ID}")
+  [[ -n "${B2_ACCOUNT_KEY:-}" ]] && env_args+=("-e" "B2_ACCOUNT_KEY=${B2_ACCOUNT_KEY}")
+  [[ -n "${SFTP_USER:-}" ]] && env_args+=("-e" "SFTP_USER=${SFTP_USER}")
+  [[ -n "${SFTP_PASSWORD:-}" ]] && env_args+=("-e" "SFTP_PASSWORD=${SFTP_PASSWORD}")
+  [[ -n "${R2_ACCESS_KEY_ID:-}" ]] && env_args+=("-e" "AWS_ACCESS_KEY_ID=${R2_ACCESS_KEY_ID}")
+  [[ -n "${R2_SECRET_ACCESS_KEY:-}" ]] && env_args+=("-e" "AWS_SECRET_ACCESS_KEY=${R2_SECRET_ACCESS_KEY}")
+  
+  log_debug "Running: docker run ${docker_args[*]} ${volume_args[*]} ${env_args[*]} restic/restic ${cmd[*]}"
+  
+  if [[ "${DRY_RUN:-0}" == "1" ]] && [[ "${cmd[0]}" != "snapshots" ]] && [[ "${cmd[0]}" != "check" ]]; then
+    log_info "[DRY RUN] Would execute: restic ${cmd[*]}"
+    return 0
+  fi
+  
+  docker run "${docker_args[@]}" "${volume_args[@]}" "${env_args[@]}" \
+    restic/restic:0.17.0 "${cmd[@]}"
+}
+
+# -----------------------------------------------------------------------------
+# Get Volumes to Backup
+# -----------------------------------------------------------------------------
+get_volumes_to_backup() {
+  local target="${1:-all}"
+  local volumes=()
+  
+  # Common infrastructure volumes
+  local infra_volumes=(
+    "traefik-logs"
+    "portainer-data"
+    "authentik-data"
+    "authentik-redis"
+    "postgres-data"
+    "redis-data"
+    "mariadb-data"
+  )
+  
+  # Media stack volumes
+  local media_volumes=(
+    "jellyfin-config"
+    "sonarr-config"
+    "radarr-config"
+    "prowlarr-config"
+    "qbittorrent-config"
+    "jellyseerr-config"
+  )
+  
+  # Productivity volumes
+  local productivity_volumes=(
+    "gitea-data"
+    "vaultwarden-data"
+    "outline-data"
+    "bookstack-data"
+  )
+  
+  # Storage volumes
+  local storage_volumes=(
+    "nextcloud-data"
+    "nextcloud-db"
+    "minio-data"
+    "filebrowser-db"
+  )
+  
+  # Home automation volumes
+  local home_volumes=(
+    "homeassistant-config"
+    "nodered-data"
+    "zigbee2mqtt-data"
+  )
+  
+  # Monitoring volumes
+  local monitoring_volumes=(
+    "prometheus-data"
+    "grafana-data"
+    "loki-data"
+    "alertmanager-data"
+    "uptime-kuma-data"
+  )
+  
+  # Network volumes
+  local network_volumes=(
+    "adguard-config"
+    "wg-easy-config"
+  )
+  
+  case "$target" in
+    all)
+      volumes=(
+        "${infra_volumes[@]}"
+        "${media_volumes[@]}"
+        "${productivity_volumes[@]}"
+        "${storage_volumes[@]}"
+        "${home_volumes[@]}"
+        "${monitoring_volumes[@]}"
+        "${network_volumes[@]}"
+      )
+      ;;
+    media)
+      volumes=("${media_volumes[@]}")
+      ;;
+    infrastructure|base)
+      volumes=("${infra_volumes[@]}")
+      ;;
+    productivity)
+      volumes=("${productivity_volumes[@]}")
+      ;;
+    storage)
+      volumes=("${storage_volumes[@]}")
+      ;;
+    home-automation)
+      volumes=("${home_volumes[@]}")
+      ;;
+    monitoring)
+      volumes=("${monitoring_volumes[@]}")
+      ;;
+    network)
+      volumes=("${network_volumes[@]}")
+      ;;
+    *)
+      log_error "Unknown target: $target"
+      return 1
+      ;;
+  esac
+  
+  # Filter to only existing volumes
+  local existing_volumes=()
+  for vol in "${volumes[@]}"; do
+    if docker volume inspect "$vol" >/dev/null 2>&1; then
+      existing_volumes+=("$vol")
+    else
+      log_debug "Volume not found, skipping: $vol"
+    fi
+  done
+  
+  printf '%s\n' "${existing_volumes[@]}"
+}
+
+# -----------------------------------------------------------------------------
+# Backup Configs
+# -----------------------------------------------------------------------------
 backup_configs() {
-  log_info "Backing up configs..."
-  tar czf "$BACKUP_PATH/configs.tar.gz" \
-    -C "$BASE_DIR" \
-    --exclude='stacks/*/data' \
-    config/ stacks/ scripts/ 2>/dev/null || true
+  local backup_path="${1:-/tmp/homelab-configs}"
+  
+  log_info "Backing up configuration files..."
+  
+  mkdir -p "$backup_path"
+  
+  # Backup key config directories
+  local config_dirs=(
+    "$BASE_DIR/config"
+    "$BASE_DIR/stacks"
+    "$BASE_DIR/scripts"
+    "$BASE_DIR/.env"
+  )
+  
+  for dir in "${config_dirs[@]}"; do
+    if [[ -e "$dir" ]]; then
+      cp -a "$dir" "$backup_path/" 2>/dev/null || true
+    fi
+  done
+  
+  echo "$backup_path"
 }
 
-# 备份数据库
+# -----------------------------------------------------------------------------
+# Backup Databases
+# -----------------------------------------------------------------------------
 backup_databases() {
+  local backup_path="${1:-/tmp/homelab-databases}"
+  
   log_info "Backing up databases..."
-
+  mkdir -p "$backup_path"
+  
   # PostgreSQL
-  if docker ps --format '{{.Names}}' | grep -q 'postgres\|postgresql'; then
-    local pg_container
-    pg_container=$(docker ps --format '{{.Names}}' | grep -E 'postgres|postgresql' | head -1)
+  local pg_container
+  pg_container=$(docker ps --format '{{.Names}}' | grep -E 'postgres|postgresql' | head -1 || true)
+  if [[ -n "$pg_container" ]]; then
+    log_info "  Backing up PostgreSQL..."
     local pg_pass
-    pg_pass=$(docker inspect "$pg_container" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep POSTGRES_PASSWORD | cut -d= -f2 | head -1)
-    docker exec "$pg_container" \
-      sh -c "PGPASSWORD='$pg_pass' pg_dumpall -U postgres" \
-      > "$BACKUP_PATH/postgresql_all.sql" 2>/dev/null || \
-      log_warn "PostgreSQL backup failed"
+    pg_pass=$(docker inspect "$pg_container" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | \
+      grep -E '^POSTGRES_PASSWORD=' | cut -d= -f2 | head -1 || true)
+    docker exec "$pg_container" sh -c "PGPASSWORD='${pg_pass}' pg_dumpall -U postgres" \
+      > "$backup_path/postgresql_all.sql" 2>/dev/null || \
+      log_warn "  PostgreSQL backup failed"
   fi
-
+  
   # MariaDB/MySQL
-  if docker ps --format '{{.Names}}' | grep -q 'mariadb\|mysql'; then
-    local mysql_container
-    mysql_container=$(docker ps --format '{{.Names}}' | grep -E 'mariadb|mysql' | head -1)
+  local mysql_container
+  mysql_container=$(docker ps --format '{{.Names}}' | grep -E 'mariadb|mysql' | head -1 || true)
+  if [[ -n "$mysql_container" ]]; then
+    log_info "  Backing up MariaDB/MySQL..."
     local mysql_pass
-    mysql_pass=$(docker inspect "$mysql_container" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep MYSQL_ROOT_PASSWORD | cut -d= -f2 | head -1)
-    docker exec "$mysql_container" \
-      sh -c "mysqldump -u root -p'$mysql_pass' --all-databases" \
-      > "$BACKUP_PATH/mysql_all.sql" 2>/dev/null || \
-      log_warn "MySQL backup failed"
+    mysql_pass=$(docker inspect "$mysql_container" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | \
+      grep -E '^MYSQL_ROOT_PASSWORD=' | cut -d= -f2 | head -1 || true)
+    docker exec "$mysql_container" sh -c "mysqldump -u root -p'${mysql_pass}' --all-databases" \
+      > "$backup_path/mysql_all.sql" 2>/dev/null || \
+      log_warn "  MariaDB/MySQL backup failed"
   fi
+  
+  # Redis
+  local redis_container
+  redis_container=$(docker ps --format '{{.Names}}' | grep -E 'redis' | head -1 || true)
+  if [[ -n "$redis_container" ]]; then
+    log_info "  Backing up Redis..."
+    docker exec "$redis_container" redis-cli BGSAVE 2>/dev/null || true
+    sleep 2
+    local redis_pass
+    redis_pass=$(docker inspect "$redis_container" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | \
+      grep -E '^REDIS_PASSWORD=' | cut -d= -f2 | head -1 || true)
+    if [[ -n "$redis_pass" ]]; then
+      docker exec "$redis_container" redis-cli -a "${redis_pass}" BGSAVE 2>/dev/null || true
+    fi
+  fi
+  
+  echo "$backup_path"
 }
 
-# 清理旧备份
-cleanup_old() {
-  log_info "Cleaning backups older than ${RETENTION_DAYS} days..."
-  find "$BACKUP_DIR" -maxdepth 1 -type d -mtime +"$RETENTION_DAYS" -exec rm -rf {} + 2>/dev/null || true
+# -----------------------------------------------------------------------------
+# Initialize Repository
+# -----------------------------------------------------------------------------
+init_repo() {
+  log_info "Initializing restic repository..."
+  
+  if run_restic snapshots >/dev/null 2>&1; then
+    log_info "Repository already initialized"
+    return 0
+  fi
+  
+  run_restic init
+  log_info "Repository initialized successfully"
 }
 
-# 生成备份摘要
-generate_summary() {
-  local total_size
-  total_size=$(du -sh "$BACKUP_PATH" 2>/dev/null | cut -f1)
-  log_info "Backup complete: $BACKUP_PATH ($total_size)"
-  ls -lh "$BACKUP_PATH/"
+# -----------------------------------------------------------------------------
+# Backup Command
+# -----------------------------------------------------------------------------
+do_backup() {
+  local target="${1:-all}"
+  local timestamp
+  timestamp=$(date +%Y%m%d_%H%M%S)
+  
+  log_info "Starting backup for target: $target"
+  send_notification "Backup started for target: $target" "HomeLab Backup" "low"
+  
+  # Check required variables
+  : "${RESTIC_PASSWORD:?RESTIC_PASSWORD is required}"
+  
+  # Initialize repository if needed
+  init_repo
+  
+  # Create temp backup directory
+  local temp_dir
+  temp_dir=$(mktemp -d)
+  
+  # Backup configs
+  local config_backup
+  config_backup=$(backup_configs "$temp_dir/configs")
+  
+  # Backup databases
+  local db_backup
+  db_backup=$(backup_databases "$temp_dir/databases")
+  
+  # Get volumes to backup
+  local volumes
+  mapfile -t volumes < <(get_volumes_to_backup "$target")
+  
+  if [[ ${#volumes[@]} -eq 0 ]]; then
+    log_warn "No volumes found to backup"
+  fi
+  
+  # Backup volumes
+  for vol in "${volumes[@]}"; do
+    local mount_point
+    mount_point=$(docker volume inspect "$vol" --format '{{.Mountpoint}}' 2>/dev/null || true)
+    if [[ -n "$mount_point" ]] && [[ -d "$mount_point" ]]; then
+      log_info "  Backing up volume: $vol"
+      run_restic backup "$mount_point" --tag "$target" --tag "$vol" --tag "homelab"
+    fi
+  done
+  
+  # Backup configs and databases
+  if [[ -d "$temp_dir" ]]; then
+    log_info "  Backing up configs and databases"
+    run_restic backup "$temp_dir" --tag "$target" --tag "configs" --tag "homelab"
+    rm -rf "$temp_dir"
+  fi
+  
+  # Prune old backups
+  log_info "Pruning old backups..."
+  run_restic forget ${RESTIC_RETENTION_POLICY:---keep-daily 7 --keep-weekly 4 --keep-monthly 6}
+  run_restic prune
+  
+  log_info "Backup completed successfully"
+  send_notification "Backup completed for target: $target" "HomeLab Backup" "default"
 }
 
-log_info "Starting backup — $TIMESTAMP"
-backup_configs
-backup_volumes
-backup_databases
-cleanup_old
-generate_summary
+# -----------------------------------------------------------------------------
+# Restore Command
+# -----------------------------------------------------------------------------
+do_restore() {
+  local backup_id="${1:?Backup ID required}"
+  local restore_path="${2:?Restore path required}"
+  
+  log_info "Restoring backup $backup_id to $restore_path"
+  
+  mkdir -p "$restore_path"
+  
+  # For restore, we need to mount the restore path
+  local temp_dir
+  temp_dir=$(mktemp -d)
+  
+  # Download to temp dir first
+  docker run --rm \
+    --network proxy \
+    -e "RESTIC_PASSWORD=${RESTIC_PASSWORD}" \
+    -e "RESTIC_REPOSITORY=$(get_restic_repo)" \
+    -v "$temp_dir:/restore" \
+    restic/restic:0.17.0 restore "$backup_id" --target /restore
+  
+  # Copy to final destination
+  cp -a "$temp_dir"/* "$restore_path/" 2>/dev/null || true
+  rm -rf "$temp_dir"
+  
+  log_info "Restore completed to: $restore_path"
+  send_notification "Restore completed to: $restore_path" "HomeLab Backup" "high"
+}
+
+# -----------------------------------------------------------------------------
+# List Command
+# -----------------------------------------------------------------------------
+do_list() {
+  log_info "Listing all backups..."
+  run_restic snapshots
+}
+
+# -----------------------------------------------------------------------------
+# Verify Command
+# -----------------------------------------------------------------------------
+do_verify() {
+  log_info "Verifying backup integrity..."
+  run_restic check --read-data
+  log_info "Verification completed"
+  send_notification "Backup verification completed" "HomeLab Backup" "default"
+}
+
+# -----------------------------------------------------------------------------
+# Help
+# -----------------------------------------------------------------------------
+show_help() {
+  cat << EOF
+HomeLab Backup — 3-2-1 Backup Strategy
+
+Usage:
+  backup.sh --target <all|media|stack> [options]
+  backup.sh --list
+  backup.sh --verify
+  backup.sh --restore <backup_id> --target <path>
+
+Commands:
+  --target <stack>     Backup specified stack (all, media, base, storage, etc.)
+  --dry-run            Show what would be backed up without executing
+  --restore <id>       Restore from specified backup ID
+  --target <path>      Target path for restore operation
+  --list               List all available backups
+  --verify             Verify backup repository integrity
+  --help               Show this help message
+
+Backup Targets:
+  local                Restic REST Server (default)
+  s3                   AWS S3 or MinIO
+  b2                   Backblaze B2
+  sftp                 SFTP server
+  r2                   Cloudflare R2
+
+Environment Variables:
+  BACKUP_TARGET        Backup destination (local, s3, b2, sftp, r2)
+  RESTIC_PASSWORD      Repository encryption password (required)
+  RESTIC_RETENTION_POLICY  Retention policy (default: 7 daily, 4 weekly, 6 monthly)
+
+Examples:
+  # Backup all stacks
+  ./backup.sh --target all
+
+  # Backup only media stack
+  ./backup.sh --target media
+
+  # Dry run
+  ./backup.sh --target all --dry-run
+
+  # List backups
+  ./backup.sh --list
+
+  # Restore
+  ./backup.sh --restore abc123 --target /tmp/restore
+
+Generated/reviewed with: claude-opus-4-6
+EOF
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+main() {
+  local target=""
+  local action="backup"
+  local restore_id=""
+  local restore_path=""
+  
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target)
+        target="$2"
+        shift 2
+        ;;
+      --dry-run)
+        export DRY_RUN=1
+        shift
+        ;;
+      --restore)
+        action="restore"
+        restore_id="$2"
+        shift 2
+        ;;
+      --list)
+        action="list"
+        shift
+        ;;
+      --verify)
+        action="verify"
+        shift
+        ;;
+      --help|-h)
+        show_help
+        exit 0
+        ;;
+      --debug)
+        export DEBUG=1
+        shift
+        ;;
+      *)
+        log_error "Unknown option: $1"
+        show_help
+        exit 1
+        ;;
+    esac
+  done
+  
+  # Load environment
+  load_env
+  
+  # Execute action
+  case "$action" in
+    backup)
+      if [[ -z "$target" ]]; then
+        log_error "--target is required for backup"
+        show_help
+        exit 1
+      fi
+      do_backup "$target"
+      ;;
+    restore)
+      if [[ -z "$restore_id" ]] || [[ -z "$target" ]]; then
+        log_error "--restore <id> and --target <path> are required"
+        show_help
+        exit 1
+      fi
+      do_restore "$restore_id" "$target"
+      ;;
+    list)
+      do_list
+      ;;
+    verify)
+      do_verify
+      ;;
+  esac
+}
+
+main "$@"

--- a/stacks/backup/.env.example
+++ b/stacks/backup/.env.example
@@ -1,0 +1,79 @@
+# =============================================================================
+# Backup Stack — Environment Configuration
+# Copy this file to .env and fill in your values
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# GENERAL
+# -----------------------------------------------------------------------------
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+TZ=${TZ:-Asia/Shanghai}
+
+# -----------------------------------------------------------------------------
+# RESTIC CONFIGURATION
+# -----------------------------------------------------------------------------
+# REQUIRED: Password for Restic repository encryption
+RESTIC_PASSWORD=
+
+# Retention policy (restic prune options)
+RESTIC_RETENTION_POLICY=--keep-daily 7 --keep-weekly 4 --keep-monthly 6 --keep-yearly 1
+
+# Restic server settings (for local backup target)
+RESTIC_SERVER_HOST=restic-server
+RESTIC_SERVER_PORT=8000
+
+# -----------------------------------------------------------------------------
+# BACKUP TARGET CONFIGURATION
+# Choose one: local, s3, b2, sftp, r2
+# -----------------------------------------------------------------------------
+BACKUP_TARGET=local
+
+# Local backup directory (used when BACKUP_TARGET=local)
+BACKUP_LOCAL_PATH=/opt/homelab-backups
+
+# -----------------------------------------------------------------------------
+# S3 / MINIO CONFIGURATION (BACKUP_TARGET=s3)
+# -----------------------------------------------------------------------------
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=
+S3_ENDPOINT=                    # For MinIO: http://minio.yourdomain.com:9000
+
+# -----------------------------------------------------------------------------
+# BACKBLAZE B2 CONFIGURATION (BACKUP_TARGET=b2)
+# -----------------------------------------------------------------------------
+B2_ACCOUNT_ID=
+B2_ACCOUNT_KEY=
+B2_BUCKET_NAME=
+
+# -----------------------------------------------------------------------------
+# SFTP CONFIGURATION (BACKUP_TARGET=sftp)
+# -----------------------------------------------------------------------------
+SFTP_USER=
+SFTP_PASSWORD=
+SFTP_HOST=
+SFTP_PORT=22
+SFTP_PATH=/backups/homelab
+
+# -----------------------------------------------------------------------------
+# CLOUDFLARE R2 CONFIGURATION (BACKUP_TARGET=r2)
+# -----------------------------------------------------------------------------
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_ENDPOINT=                    # https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+R2_BUCKET_NAME=
+
+# -----------------------------------------------------------------------------
+# NTFY NOTIFICATIONS
+# -----------------------------------------------------------------------------
+NTFY_SERVER=https://ntfy.sh
+NTFY_TOPIC=homelab-backups
+
+# -----------------------------------------------------------------------------
+# BACKUP EXCLUSIONS
+# Comma-separated list of paths to exclude from backups
+# Example: BACKUP_EXCLUDE_PATHS=/mnt/media,/mnt/downloads
+# -----------------------------------------------------------------------------
+BACKUP_EXCLUDE_PATHS=

--- a/stacks/backup/README.md
+++ b/stacks/backup/README.md
@@ -1,0 +1,149 @@
+# Backup & Disaster Recovery Stack
+
+This stack provides a complete 3-2-1 backup solution: Duplicati for encrypted cloud backups and Restic REST Server for local backups.
+
+## Services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| Restic REST Server | `restic/rest-server:0.13.0` | 8000 (internal) | Local backup repository |
+| Duplicati | `lscr.io/linuxserver/duplicati:2.0.8` | 8200 | Encrypted cloud backup GUI |
+
+## Quick Start
+
+### 1. Configure Environment
+
+```bash
+cd stacks/backup
+cp .env.example .env
+nano .env
+```
+
+Required settings:
+- `RESTIC_PASSWORD` — Strong password for repository encryption
+- `BACKUP_TARGET` — Choose: `local`, `s3`, `b2`, `sftp`, `r2`
+- Cloud credentials (if using cloud target)
+
+### 2. Deploy Stack
+
+```bash
+docker compose up -d
+```
+
+### 3. Verify Services
+
+```bash
+docker compose ps
+# Both services should show "healthy"
+```
+
+## Backup Script Usage
+
+The main backup script is located at `scripts/backup.sh`:
+
+```bash
+# Backup all stacks
+./scripts/backup.sh --target all
+
+# Backup only media stack
+./scripts/backup.sh --target media
+
+# Dry run (show what would be backed up)
+./scripts/backup.sh --target all --dry-run
+
+# List all backups
+./scripts/backup.sh --list
+
+# Verify backup integrity
+./scripts/backup.sh --verify
+
+# Restore from backup
+./scripts/backup.sh --restore <backup_id> --target /path/to/restore
+```
+
+## Scheduled Backups
+
+Install systemd timer for daily backups at 2:00 AM:
+
+```bash
+sudo cp stacks/backup/systemd/backup.* /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable backup.timer
+sudo systemctl start backup.timer
+```
+
+## Backup Targets
+
+### Local (default)
+- Stores backups in Restic REST Server
+- Path: `/opt/homelab-backups`
+
+### S3 / MinIO
+Set in `.env`:
+```bash
+BACKUP_TARGET=s3
+AWS_ACCESS_KEY_ID=your_key
+AWS_SECRET_ACCESS_KEY=your_secret
+S3_BUCKET_NAME=your_bucket
+S3_ENDPOINT=http://minio.example.com:9000  # For MinIO
+```
+
+### Backblaze B2
+```bash
+BACKUP_TARGET=b2
+B2_ACCOUNT_ID=your_id
+B2_ACCOUNT_KEY=your_key
+B2_BUCKET_NAME=your_bucket
+```
+
+### Cloudflare R2
+```bash
+BACKUP_TARGET=r2
+R2_ACCESS_KEY_ID=your_key
+R2_SECRET_ACCESS_KEY=your_secret
+R2_ENDPOINT=https://your-account.r2.cloudflarestorage.com
+R2_BUCKET_NAME=your_bucket
+```
+
+### SFTP
+```bash
+BACKUP_TARGET=sftp
+SFTP_USER=user
+SFTP_PASSWORD=password
+SFTP_HOST=backup.server.com
+SFTP_PATH=/backups/homelab
+```
+
+## Notifications
+
+Backup notifications are sent via ntfy:
+
+```bash
+NTFY_SERVER=https://ntfy.sh
+NTFY_TOPIC=homelab-backups
+```
+
+Subscribe to notifications:
+```bash
+# Web: https://ntfy.sh/homelab-backups
+# CLI: ntfy subscribe homelab-backups
+```
+
+## Duplicati Web UI
+
+Access Duplicati for manual cloud backup configuration:
+- URL: `https://duplicati.yourdomain.com`
+- Port: 8200
+
+Use Duplicati to configure additional cloud backup jobs with encryption.
+
+## Disaster Recovery
+
+See [docs/disaster-recovery.md](../../docs/disaster-recovery.md) for complete recovery procedures.
+
+## 3-2-1 Strategy
+
+This stack implements the 3-2-1 backup strategy:
+- **3 copies**: Live data + Restic repo + Duplicati cloud
+- **2 media types**: Local disk + Cloud storage
+- **1 offsite**: Cloud backup (S3/B2/R2/SFTP)

--- a/stacks/backup/docker-compose.yml
+++ b/stacks/backup/docker-compose.yml
@@ -1,0 +1,98 @@
+# =============================================================================
+# HomeLab Stack — Backup & Disaster Recovery
+# Services: Duplicati (encrypted cloud backup) + Restic REST Server (local repo)
+#
+# Prerequisites:
+#   1. cp .env.example .env && fill in required values
+#   2. Ensure 'proxy' network exists: docker network create proxy
+#   3. docker compose up -d
+#
+# Usage:
+#   - Duplicati Web UI: https://duplicati.${DOMAIN}
+#   - Restic REST Server: Internal only (accessed via backup.sh script)
+#   - Automated backups: systemd timer (daily at 2:00 AM)
+# =============================================================================
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # Restic REST Server — Local Backup Repository
+  # Provides a REST backend for restic backups
+  # Accessible only within Docker network (via backup.sh)
+  # ---------------------------------------------------------------------------
+  restic-server:
+    image: restic/rest-server:0.13.0
+    container_name: restic-server
+    hostname: restic-server
+    restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      - RESTIC_PASSWORD=${RESTIC_PASSWORD:?RESTIC_PASSWORD is required}
+    volumes:
+      - restic-data:/data
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    labels:
+      - "traefik.enable=false"
+
+  # ---------------------------------------------------------------------------
+  # Duplicati — Encrypted Cloud Backup GUI
+  # Web UI: https://duplicati.${DOMAIN}
+  # Use for manual cloud backup configuration (B2, S3, R2, SFTP)
+  # ---------------------------------------------------------------------------
+  duplicati:
+    image: lscr.io/linuxserver/duplicati:2.0.8
+    container_name: duplicati
+    hostname: duplicati
+    restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+      - CLI_ARGS=--webservice-interface=any
+    volumes:
+      - duplicati-config:/config
+      - duplicati-backups:/backups
+      # Mount source paths for backup (read-only)
+      - /var/lib/docker/volumes:/docker-volumes:ro
+    ports:
+      - "8200:8200"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8200/api/v1/serverstate"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.duplicati.rule=Host(`duplicati.${DOMAIN}`)"
+      - "traefik.http.routers.duplicati.entrypoints=websecure"
+      - "traefik.http.routers.duplicati.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.duplicati.service=duplicati"
+      - "traefik.http.services.duplicati.loadbalancer.server.port=8200"
+      - "traefik.http.routers.duplicati.middlewares=security-headers@file"
+
+# =============================================================================
+# Networks
+# =============================================================================
+networks:
+  proxy:
+    external: true
+
+# =============================================================================
+# Volumes
+# =============================================================================
+volumes:
+  restic-data:
+    driver: local
+  duplicati-config:
+    driver: local
+  duplicati-backups:
+    driver: local

--- a/stacks/backup/systemd/backup.service
+++ b/stacks/backup/systemd/backup.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=HomeLab Stack Daily Backup
+Documentation=https://github.com/illbnm/homelab-stack
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/homelab-stack
+ExecStart=/opt/homelab-stack/scripts/backup.sh --target all
+EnvironmentFile=/opt/homelab-stack/.env
+EnvironmentFile=/opt/homelab-stack/stacks/backup/.env
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/opt/homelab-backups
+
+[Install]
+WantedBy=multi-user.target

--- a/stacks/backup/systemd/backup.timer
+++ b/stacks/backup/systemd/backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run HomeLab Stack Daily Backup at 2:00 AM
+Documentation=https://github.com/illbnm/homelab-stack
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## 实现内容

### 服务
- **Duplicati** (2.0.8) — 加密云备份 GUI
- **Restic REST Server** (0.13.0) — 本地备份仓库

### 功能特性
- ✅ 完整的 3-2-1 备份策略
- ✅ 支持 5 种备份目标: local, S3, B2, SFTP, R2
- ✅ systemd timer 每日 2:00 AM 自动备份
- ✅ ntfy 通知集成
- ✅ 完整的灾难恢复文档

### 备份脚本命令
\\\ash
# 备份所有 stack
./scripts/backup.sh --target all

# 仅备份媒体 stack
./scripts/backup.sh --target media

# 预览模式（不实际执行）
./scripts/backup.sh --target all --dry-run

# 列出所有备份
./scripts/backup.sh --list

# 验证备份完整性
./scripts/backup.sh --verify

# 从备份恢复
./scripts/backup.sh --restore <backup_id> --target /path/to/restore
\\\

### 文件清单
| 文件 | 说明 |
|------|------|
| \stacks/backup/docker-compose.yml\ | Duplicati + Restic 服务定义 |
| \stacks/backup/.env.example\ | 环境变量示例 |
| \stacks/backup/README.md\ | 使用文档 |
| \stacks/backup/systemd/backup.service\ | systemd 服务单元 |
| \stacks/backup/systemd/backup.timer\ | systemd 定时器 |
| \scripts/backup.sh\ | 备份脚本（重写） |
| \docs/disaster-recovery.md\ | 灾难恢复文档 |
| \.env.example\ | 添加备份相关变量 |

### 验收标准
- [x] Duplicati + Restic REST Server 服务配置
- [x] backup.sh 支持 --target, --dry-run, --restore, --list, --verify
- [x] 支持 local/S3/B2/SFTP/R2 备份目标
- [x] systemd timer 每日 2:00 AM 自动备份
- [x] ntfy 通知集成
- [x] 灾难恢复文档 (RTO, 恢复顺序, 验证清单)
- [x] 所有镜像使用具体版本号（无 latest）

### 钱包地址
FNDRY: \