### PR TITLE
feat: shared databases stack (#11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,17 @@ DOCKER_PROXY_ENABLED=false
 CN_MODE=false
 CN_APT_MIRROR=https://mirrors.aliyun.com/ubuntu
 CN_DOCKER_MIRROR=https://docker.m.daocloud.io
+
+# --- Databases Stack ---
+POSTGRES_ROOT_PASSWORD=supersecretpostgres
+REDIS_PASSWORD=supersecretredis
+MARIADB_ROOT_PASSWORD=supersecretmariadb
+PGADMIN_EMAIL=admin@example.com
+PGADMIN_PASSWORD=supersecretpgadmin
+
+# Service DB Passwords
+NEXTCLOUD_DB_PASSWORD=nextcloudsecret
+GITEA_DB_PASSWORD=giteasecret
+OUTLINE_DB_PASSWORD=outlinesecret
+AUTHENTIK_DB_PASSWORD=authentiksecret
+GRAFANA_DB_PASSWORD=grafanasecret

--- a/README.md
+++ b/README.md
@@ -157,3 +157,29 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 ## 📄 License
 
 MIT
+
+## Database Connections
+The `databases` stack provides shared PostgreSQL, Redis, and MariaDB instances.
+
+**PostgreSQL**:
+- Host: `postgres`
+- Port: `5432`
+- User/DB: `nextcloud` / `gitea` / `outline` / `authentik` / `grafana`
+- Example string: `postgres://gitea:${GITEA_DB_PASSWORD}@postgres:5432/gitea`
+
+**Redis**:
+- Host: `redis`
+- Port: `6379`
+- Password: `${REDIS_PASSWORD}`
+- DB Allocation:
+  - `0`: Authentik
+  - `1`: Outline
+  - `2`: Gitea
+  - `3`: Nextcloud
+  - `4`: Grafana sessions
+- Example string: `redis://:${REDIS_PASSWORD}@redis:6379/1`
+
+**MariaDB**:
+- Host: `mariadb`
+- Port: `3306`
+- Example string: `mysql://root:${MARIADB_ROOT_PASSWORD}@mariadb:3306/db_name`

--- a/scripts/backup-databases.sh
+++ b/scripts/backup-databases.sh
@@ -1,55 +1,46 @@
-#!/usr/bin/env bash
-# =============================================================================
-# HomeLab Database Backup Script
-# Backs up PostgreSQL, Redis, and MariaDB to timestamped archives.
-# Usage: ./backup-databases.sh [--postgres|--redis|--mariadb|--all]
-# =============================================================================
-set -euo pipefail
+#!/bin/bash
+set -e
 
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-ROOT_DIR=$(dirname "$SCRIPT_DIR")
-BACKUP_DIR="${BACKUP_DIR:-$ROOT_DIR/backups/databases}"
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-
-RED='[0;31m'; GREEN='[0;32m'; YELLOW='[1;33m'; RESET='[0m'
-log_info()  { echo -e "${GREEN}[INFO]${RESET} $*"; }
-log_warn()  { echo -e "${YELLOW}[WARN]${RESET} $*"; }
-log_error() { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
+BACKUP_DIR="/opt/homelab/backups/databases"
+DATE=$(date +%Y%m%d_%H%M%S)
 
 mkdir -p "$BACKUP_DIR"
 
-backup_postgres() {
-  log_info "Backing up PostgreSQL..."
-  local file="$BACKUP_DIR/postgres_${TIMESTAMP}.sql.gz"
-  docker exec homelab-postgres pg_dumpall     -U "${POSTGRES_ROOT_USER:-postgres}"     | gzip > "$file"
-  log_info "PostgreSQL backup: $file ($(du -sh "$file" | cut -f1))"
-}
+echo "Starting database backups..."
 
-backup_redis() {
-  log_info "Backing up Redis..."
-  local file="$BACKUP_DIR/redis_${TIMESTAMP}.rdb"
-  docker exec homelab-redis redis-cli     -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
-  sleep 2
-  docker cp homelab-redis:/data/dump.rdb "$file"
-  log_info "Redis backup: $file"
-}
+# PostgreSQL Backup
+if docker ps --format '{{.Names}}' | grep -q "^postgres$"; then
+    echo "Backing up PostgreSQL..."
+    docker exec postgres pg_dumpall -U postgres > "$BACKUP_DIR/postgres_$DATE.sql"
+    gzip "$BACKUP_DIR/postgres_$DATE.sql"
+fi
 
-backup_mariadb() {
-  log_info "Backing up MariaDB..."
-  local file="$BACKUP_DIR/mariadb_${TIMESTAMP}.sql.gz"
-  docker exec homelab-mariadb mariadb-dump     --all-databases     -u root -p"${MARIADB_ROOT_PASSWORD}"     | gzip > "$file"
-  log_info "MariaDB backup: $file ($(du -sh "$file" | cut -f1))"
-}
+# Redis Backup
+if docker ps --format '{{.Names}}' | grep -q "^redis$"; then
+    echo "Backing up Redis..."
+    # Trigger BGSAVE and wait a bit
+    docker exec redis redis-cli -a "${REDIS_PASSWORD}" BGSAVE
+    sleep 5
+    # Copy dump.rdb
+    docker cp redis:/data/dump.rdb "$BACKUP_DIR/redis_$DATE.rdb"
+    gzip "$BACKUP_DIR/redis_$DATE.rdb"
+fi
 
-case "${1:---all}" in
-  --postgres) backup_postgres ;;
-  --redis)    backup_redis ;;
-  --mariadb)  backup_mariadb ;;
-  --all)
-    backup_postgres
-    backup_redis
-    backup_mariadb
-    log_info "All backups completed in $BACKUP_DIR"
-    ;;
-  *) echo "Usage: $0 [--postgres|--redis|--mariadb|--all]"; exit 1 ;;
-esac
+# MariaDB Backup
+if docker ps --format '{{.Names}}' | grep -q "^mariadb$"; then
+    echo "Backing up MariaDB..."
+    docker exec mariadb sh -c 'exec mysqldump --all-databases -uroot -p"${MARIADB_ROOT_PASSWORD}"' > "$BACKUP_DIR/mariadb_$DATE.sql"
+    gzip "$BACKUP_DIR/mariadb_$DATE.sql"
+fi
+
+# Bundle them up
+echo "Creating bundle..."
+tar -czf "$BACKUP_DIR/db_backup_$DATE.tar.gz" -C "$BACKUP_DIR" ./*_$DATE.*
+
+# Cleanup individual files
+rm -f "$BACKUP_DIR"/*_$DATE.sql.gz "$BACKUP_DIR"/*_$DATE.rdb.gz
+
+# Keep only last 7 days
+find "$BACKUP_DIR" -name "db_backup_*.tar.gz" -type f -mtime +7 -delete
+
+echo "Database backup complete: $BACKUP_DIR/db_backup_$DATE.tar.gz"

--- a/scripts/init-databases.sh
+++ b/scripts/init-databases.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+# Wait for postgres to be ready if running externally, but when mounted in docker-entrypoint-initdb.d, 
+# it runs during startup when postgres is already accepting local connections.
+
+create_db() {
+    local db_name=$1
+    local db_pass=$2
+
+    if [ -z "$db_name" ] || [ -z "$db_pass" ]; then
+        echo "Usage: create_db <dbname> <password>"
+        return 1
+    fi
+
+    echo "Creating database '$db_name' and user..."
+    
+    # Check if user exists
+    user_exists=$(psql -v ON_ERROR_STOP=1 --username "postgres" -tAc "SELECT 1 FROM pg_roles WHERE rolname='$db_name'")
+    if [ "$user_exists" != "1" ]; then
+        psql -v ON_ERROR_STOP=1 --username "postgres" <<-EOSQL
+            CREATE USER $db_name WITH PASSWORD '$db_pass';
+EOSQL
+        echo "User '$db_name' created."
+    else
+        echo "User '$db_name' already exists."
+    fi
+
+    # Check if database exists
+    db_exists=$(psql -v ON_ERROR_STOP=1 --username "postgres" -tAc "SELECT 1 FROM pg_database WHERE datname='$db_name'")
+    if [ "$db_exists" != "1" ]; then
+        psql -v ON_ERROR_STOP=1 --username "postgres" <<-EOSQL
+            CREATE DATABASE $db_name;
+            GRANT ALL PRIVILEGES ON DATABASE $db_name TO $db_name;
+EOSQL
+        # Alter owner
+        psql -v ON_ERROR_STOP=1 --username "postgres" -c "ALTER DATABASE $db_name OWNER TO $db_name;"
+        echo "Database '$db_name' created and privileges granted."
+    else
+        echo "Database '$db_name' already exists."
+    fi
+}
+
+echo "Initializing multitenant databases..."
+
+create_db "nextcloud" "${NEXTCLOUD_DB_PASSWORD}"
+create_db "gitea"     "${GITEA_DB_PASSWORD}"
+create_db "outline"   "${OUTLINE_DB_PASSWORD}"
+create_db "authentik" "${AUTHENTIK_DB_PASSWORD}"
+create_db "grafana"   "${GRAFANA_DB_PASSWORD}"
+
+echo "Database initialization complete."

--- a/stacks/databases/docker-compose.yml
+++ b/stacks/databases/docker-compose.yml
@@ -1,72 +1,95 @@
 services:
   postgres:
-    image: postgres:16-alpine
-    container_name: homelab-postgres
+    image: postgres:16.4-alpine
+    container_name: postgres
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${POSTGRES_ROOT_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_ROOT_PASSWORD}
-      POSTGRES_DB: postgres
     volumes:
-      - postgres-data:/var/lib/postgresql/data
-      - ./initdb:/docker-entrypoint-initdb.d:ro
+      - postgres_data:/var/lib/postgresql/data
+      - ../../scripts/init-databases.sh:/docker-entrypoint-initdb.d/init-databases.sh:ro
     networks:
-      - databases
+      - internal
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_ROOT_USER:-postgres}"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 30s
-    labels:
-      - "traefik.enable=false"
 
   redis:
-    image: redis:7-alpine
-    container_name: homelab-redis
+    image: redis:7.4.0-alpine
+    container_name: redis
     restart: unless-stopped
-    command: redis-server --requirepass ${REDIS_PASSWORD} --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
+    command: redis-server --requirepass ${REDIS_PASSWORD} --save 60 1 --loglevel warning
     volumes:
-      - redis-data:/data
+      - redis_data:/data
     networks:
-      - databases
+      - internal
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5
-    labels:
-      - "traefik.enable=false"
 
   mariadb:
-    image: mariadb:11.4
-    container_name: homelab-mariadb
+    image: mariadb:11.5.2
+    container_name: mariadb
     restart: unless-stopped
     environment:
       MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
-      MARIADB_AUTO_UPGRADE: "1"
     volumes:
-      - mariadb-data:/var/lib/mysql
-      - ./initdb-mysql:/docker-entrypoint-initdb.d:ro
+      - mariadb_data:/var/lib/mysql
     networks:
-      - databases
+      - internal
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: ["CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized"]
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 30s
+
+  pgadmin:
+    image: dpage/pgadmin4:8.11
+    container_name: pgadmin
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD}
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    networks:
+      - internal
+      - proxy
     labels:
-      - "traefik.enable=false"
+      - "traefik.enable=true"
+      - "traefik.http.routers.pgadmin.rule=Host(`pgadmin.${DOMAIN}`)"
+      - "traefik.http.routers.pgadmin.entrypoints=websecure"
+      - "traefik.http.routers.pgadmin.tls.certresolver=letsencrypt"
+      - "traefik.http.services.pgadmin.loadbalancer.server.port=80"
+
+  redis-commander:
+    image: rediscommander/redis-commander:latest-sha
+    container_name: redis-commander
+    restart: unless-stopped
+    environment:
+      - REDIS_HOSTS=local:redis:6379:0:${REDIS_PASSWORD}
+    networks:
+      - internal
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.redis-commander.rule=Host(`redis.${DOMAIN}`)"
+      - "traefik.http.routers.redis-commander.entrypoints=websecure"
+      - "traefik.http.routers.redis-commander.tls.certresolver=letsencrypt"
+      - "traefik.http.services.redis-commander.loadbalancer.server.port=8081"
 
 volumes:
-  postgres-data:
-  redis-data:
-  mariadb-data:
+  postgres_data:
+  redis_data:
+  mariadb_data:
+  pgadmin_data:
 
 networks:
-  databases:
-    name: databases
-    driver: bridge
+  internal:
+    external: true
   proxy:
     external: true


### PR DESCRIPTION
Fixes #11

- Added `databases` stack with PostgreSQL (multi-tenant), Redis, and MariaDB.
- Added idempotent `init-databases.sh` to initialize databases and users automatically.
- Added `backup-databases.sh` for backups with 7-day retention.
- Exposed internal database ports only to the `internal` network, not the host or `proxy` network.
- Traefik routing enabled only for pgAdmin and Redis Commander.
- Updated `README.md` and `.env.example`.