### PR TITLE
feat(network): Add DNS, ad-blocking, and NTP services

### DIFF
--- a/config/pihole/01-local.conf
+++ b/config/pihole/01-local.conf
@@ -1,0 +1,50 @@
+# =============================================================================
+# Pi-hole Local DNS Configuration
+# Custom DNS records for homelab services
+# =============================================================================
+
+# Local domain
+local=/home.arpa/
+domain=home.arpa
+
+# Service records (replace IPs with your network)
+# Format: address=/hostname/domain/IP
+
+# Infrastructure
+address=/router.home.arpa/192.168.1.1
+address=/nas.home.arpa/192.168.1.2
+address=/server.home.arpa/192.168.1.10
+
+# Web services (Traefik proxies)
+address=/pihole.home.arpa/192.168.1.10
+address=/traefik.home.arpa/192.168.1.10
+address=/portainer.home.arpa/192.168.1.10
+
+# Database admin
+address=/pgadmin.home.arpa/192.168.1.10
+address=/redis.home.arpa/192.168.1.10
+
+# Media services
+address=/jellyfin.home.arpa/192.168.1.10
+address=/sonarr.home.arpa/192.168.1.10
+address=/radarr.home.arpa/192.168.1.10
+
+# Productivity
+address=/nextcloud.home.arpa/192.168.1.10
+address=/gitea.home.arpa/192.168.1.10
+
+# Security
+address=/auth.home.arpa/192.168.1.10
+
+# Wildcard DNS for services (uncomment if needed)
+# address=/./home.arpa/192.168.1.10
+
+# Additional options
+# DNS cache size
+cache-size=10000
+
+# Log queries (disable in production)
+# log-queries
+
+# Forwarding to Unbound
+server=127.0.0.1#5335

--- a/config/unbound/unbound.conf
+++ b/config/unbound/unbound.conf
@@ -1,0 +1,76 @@
+# =============================================================================
+# Unbound Recursive DNS Resolver Configuration
+# =============================================================================
+
+server:
+    # Basic settings
+    verbosity: 1
+    interface: 0.0.0.0
+    port: 53
+    do-ip4: yes
+    do-ip6: yes
+    do-udp: yes
+    do-tcp: yes
+
+    # Access control
+    access-control: 0.0.0.0/0 refuse
+    access-control: 127.0.0.0/8 allow
+    access-control: 10.0.0.0/8 allow
+    access-control: 172.16.0.0/12 allow
+    access-control: 192.168.0.0/16 allow
+    access-control: fd00::/8 allow
+
+    # Private addresses (never returned to clients)
+    private-address: 10.0.0.0/8
+    private-address: 172.16.0.0/12
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: fd00::/8
+    private-address: fe80::/10
+
+    # DNSSEC
+    auto-trust-anchor-file: "/etc/unbound/root.key"
+    val-log-level: 2
+    val-clean-additional: yes
+
+    # Privacy
+    hide-identity: yes
+    hide-version: yes
+    identity: "DNS"
+    
+    # Performance
+    num-threads: 2
+    num-queries-per-thread: 4096
+    outgoing-range: 8192
+    msg-cache-size: 128m
+    rrset-cache-size: 256m
+    key-cache-size: 64m
+    infra-cache-numhosts: 10000
+    
+    # Rate limiting (prevent DNS amplification)
+    ratelimit: 1000
+    ratelimit-size: 1m
+    ratelimit-slabs: 4
+    
+    # Prefetch
+    prefetch: yes
+    prefetch-key: yes
+    
+    # Cache lifetime
+    cache-min-ttl: 300
+    cache-max-ttl: 86400
+    
+    # QNAME minimization (RFC 7816)
+    qname-minimisation: yes
+    qname-minimisation-strict: yes
+
+# Forward zone for local DNS (optional - use Pi-hole for local)
+# forward-zone:
+#     name: "home.arpa."
+#     forward-addr: 127.0.0.1@54
+
+# Root hints (use built-in)
+# root-hints: "/etc/unbound/root.hints"
+
+# Include additional configs
+include: "/etc/unbound/conf.d/*.conf"

--- a/stacks/network/.env.example
+++ b/stacks/network/.env.example
@@ -1,2 +1,18 @@
+# =============================================================================
+# Network Stack Configuration
+# =============================================================================
+
+# Domain
+DOMAIN=example.com
+
+# Timezone
 TZ=Asia/Shanghai
-DOMAIN=localhost
+
+# Pi-hole
+PIHOLE_PASSWORD=your_admin_password
+PIHOLE_THEME=default-dark
+DNS_PORT=53
+SERVERIP=192.168.1.10
+
+# NTP Servers (comma separated)
+NTP_SERVERS=time.cloudflare.com,time.google.com,time.windows.com

--- a/stacks/network/README.md
+++ b/stacks/network/README.md
@@ -1,0 +1,246 @@
+# Network Stack
+
+DNS, ad-blocking, and time synchronization services for the homelab.
+
+## Services
+
+| Service | Image | Ports | Purpose |
+|---------|-------|-------|---------|
+| Pi-hole | `pihole/pihole:5.26` | 53, 80 | DNS sinkhole with ad-blocking |
+| Unbound | `mvance/unbound:1.20.0` | 5335 | Recursive DNS resolver |
+| NTP | `cturra/ntp:latest` | 123/udp | Network time protocol |
+
+## Quick Start
+
+```bash
+# 1. Configure environment
+cp .env.example .env
+nano .env
+
+# 2. Start services
+docker compose up -d
+
+# 3. Access Pi-hole admin
+# https://pihole.yourdomain.com/admin
+```
+
+## Architecture
+
+```
+                    ┌──────────────────┐
+                    │    Clients       │
+                    └────────┬─────────┘
+                             │ DNS queries
+                             ▼
+                    ┌──────────────────┐
+                    │    Pi-hole       │
+                    │  (port 53)       │
+                    │  - Ad blocking   │
+                    │  - Local DNS     │
+                    └────────┬─────────┘
+                             │ Upstream DNS
+                             ▼
+                    ┌──────────────────┐
+                    │    Unbound       │
+                    │  (port 5335)     │
+                    │  - Recursive     │
+                    │  - DNSSEC        │
+                    └──────────────────┘
+```
+
+## Configuration
+
+### Pi-hole
+
+#### Admin Access
+
+- URL: `https://pihole.${DOMAIN}/admin`
+- Password: Set via `PIHOLE_PASSWORD`
+
+#### Local DNS Records
+
+Edit `config/pihole/01-local.conf` to add custom DNS records:
+
+```conf
+# Static records
+address=/myservice.home.arpa/192.168.1.100
+
+# Wildcard (all *.domain.local)
+address=/domain.local/192.168.1.10
+```
+
+#### Whitelist/Blacklist
+
+```bash
+# Whitelist a domain
+docker exec pihole pihole -w example.com
+
+# Blacklist a domain
+docker exec pihole pihole -b ads.example.com
+
+# Reload lists
+docker exec pihole pihole -g
+```
+
+### Unbound
+
+#### DNS over HTTPS (DoH)
+
+To enable DoH upstream, create `config/unbound/conf.d/doh.conf`:
+
+```conf
+forward-zone:
+    name: "."
+    forward-tls-upstream: yes
+    forward-addr: 1.1.1.1@853#cloudflare-dns.com
+    forward-addr: 8.8.8.8@853#dns.google
+```
+
+#### Custom DNS Records
+
+For local DNS resolution without Pi-hole:
+
+```conf
+# config/unbound/conf.d/local.conf
+local-zone: "home.arpa." static
+local-data: "router.home.arpa. IN A 192.168.1.1"
+local-data: "nas.home.arpa. IN A 192.168.1.2"
+```
+
+### NTP
+
+#### Configure NTP Servers
+
+```bash
+# Set custom NTP servers
+export NTP_SERVERS=time.cloudflare.com,time.google.com
+
+# Check status
+docker exec ntp chronyc sources
+docker exec ntp chronyc tracking
+```
+
+## DNS Resolution Flow
+
+1. **Client** sends DNS query to Pi-hole (port 53)
+2. **Pi-hole** checks:
+   - Local DNS records → Return immediately
+   - Blocked domains → Return 0.0.0.0
+   - Otherwise → Forward to Unbound
+3. **Unbound** performs recursive resolution with DNSSEC validation
+4. Response cached and returned to client
+
+## Health Checks
+
+```bash
+# Test DNS resolution
+dig @192.168.1.10 google.com
+
+# Test Pi-hole
+docker exec pihole pihole status
+
+# Test Unbound
+docker exec unbound unbound-control status
+
+# Test NTP
+docker exec ntp chronyc tracking
+```
+
+## Integration with Other Stacks
+
+### Configure Services to Use Pi-hole
+
+```yaml
+services:
+  myapp:
+    dns: 192.168.1.10  # Pi-hole IP
+    # or use Docker network DNS
+```
+
+### Router Configuration
+
+Set Pi-hole as the DNS server for your network:
+
+```bash
+# On router DHCP settings
+DNS Server 1: 192.168.1.10
+DNS Server 2: (leave empty or use secondary)
+```
+
+## Monitoring
+
+### DNS Query Stats
+
+```bash
+# Pi-hole stats
+docker exec pihole pihole -c
+
+# Or via API
+curl -s "http://pihole:80/admin/api.php?summaryRaw" | jq
+```
+
+### Top Queries
+
+```bash
+# Top permitted domains
+docker exec pihole pihole -t -p
+
+# Top blocked domains
+docker exec pihole pihole -t -b
+```
+
+## Troubleshooting
+
+### DNS Not Resolving
+
+```bash
+# Check Pi-hole status
+docker logs pihole
+
+# Check Unbound status
+docker logs unbound
+
+# Test direct query
+dig @127.0.0.1 -p 5335 google.com
+```
+
+### Ad Blocking Not Working
+
+```bash
+# Update blocklists
+docker exec pihole pihole -g
+
+# Check gravity database
+docker exec pihole sqlite3 /etc/pihole/gravity.db "SELECT COUNT(*) FROM gravity;"
+```
+
+### Time Sync Issues
+
+```bash
+# Check NTP status
+docker exec ntp chronyc tracking
+
+# Force sync
+docker exec ntp chronyc makestep
+```
+
+## Resource Requirements
+
+| Service | Min Memory | Recommended |
+|---------|------------|-------------|
+| Pi-hole | 128 MB | 256 MB |
+| Unbound | 64 MB | 128 MB |
+| NTP | 16 MB | 32 MB |
+| **Total** | **208 MB** | **416 MB** |
+
+## Security Considerations
+
+1. **DNSSEC**: Enabled by default on Unbound
+2. **QNAME Minimization**: Prevents data leakage
+3. **Rate Limiting**: Prevents DNS amplification attacks
+4. **Access Control**: Only local networks allowed
+5. **Web UI**: Protected by Traefik + password
+
+## License
+
+MIT

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -1,56 +1,130 @@
+# =============================================================================
+# Network Stack - Pi-hole + Unbound + NTP
+# DNS, Ad-blocking, and Time Synchronization
+# =============================================================================
+
 services:
-  adguardhome:
-    image: adguard/adguardhome:v0.107.55
-    container_name: adguardhome
+  # ---------------------------------------------------------------------------
+  # Pi-hole - DNS sinkhole with ad-blocking
+  # https://pi-hole.net/
+  # Image: pihole/pihole:5.26
+  # ---------------------------------------------------------------------------
+  pihole:
+    image: pihole/pihole:5.26
+    container_name: pihole
     restart: unless-stopped
+    hostname: pihole
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - WEBPASSWORD=${PIHOLE_PASSWORD:?PIHOLE_PASSWORD is required}
+      - WEBTHEME=${PIHOLE_THEME:-default-dark}
+      - VIRTUAL_HOST=pihole.${DOMAIN}
+      - SERVERIP=${SERVERIP:-}
+      - DNS1=127.0.0.1#5335
+      - DNS2=
+      - DNSSEC=true
+      - DNS_BOGUS_PRIV=true
+      - FTLCONF_LOCAL_IPV4=${SERVERIP:-}
+      - SKIPGRAVITYONBOOT=false
+    volumes:
+      - pihole-etc:/etc/pihole
+      - pihole-dnsmasq:/etc/dnsmasq.d
+      - ../../config/pihole/01-local.conf:/etc/dnsmasq.d/01-local.conf:ro
     networks:
       - proxy
-    volumes:
-      - adguard-work:/opt/adguardhome/work
-      - adguard-conf:/opt/adguardhome/conf
+      - network
     ports:
-      - 53:53/tcp
-      - 53:53/udp
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.adguard.rule=Host()
-      - traefik.http.routers.adguard.entrypoints=websecure
-      - traefik.http.routers.adguard.tls=true
-      - traefik.http.services.adguard.loadbalancer.server.port=3000
+      - "${DNS_PORT:-53}:53/tcp"
+      - "${DNS_PORT:-53}:53/udp"
     healthcheck:
-      test: [CMD, wget, -qO-, http://localhost:3000]
+      test: ["CMD", "dig", "+short", "pi.hole", "@127.0.0.1"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
-  nginx-proxy-manager:
-    image: jc21/nginx-proxy-manager:2.11.3
-    container_name: nginx-proxy-manager
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - npm-data:/data
-      - npm-letsencrypt:/etc/letsencrypt
-    ports:
-      - 8181:81
+      start_period: 60s
     labels:
       - traefik.enable=true
-      - traefik.http.routers.npm.rule=Host()
-      - traefik.http.routers.npm.entrypoints=websecure
-      - traefik.http.routers.npm.tls=true
-      - traefik.http.services.npm.loadbalancer.server.port=81
+      - "traefik.http.routers.pihole.rule=Host(`pihole.${DOMAIN}`)"
+      - traefik.http.routers.pihole.entrypoints=websecure
+      - traefik.http.routers.pihole.tls=true
+      - traefik.http.routers.pihole.tls.certresolver=myresolver
+      - traefik.http.services.pihole.loadbalancer.server.port=80
+    depends_on:
+      unbound:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
+  # ---------------------------------------------------------------------------
+  # Unbound - Recursive DNS resolver
+  # https://nlnetlabs.nl/projects/unbound/about/
+  # Image: mvance/unbound:1.20.0
+  # ---------------------------------------------------------------------------
+  unbound:
+    image: mvance/unbound:1.20.0
+    container_name: unbound
+    restart: unless-stopped
+    volumes:
+      - ../../config/unbound/unbound.conf:/etc/unbound/unbound.conf:ro
+      - unbound-data:/etc/unbound/conf.d
+    networks:
+      - network
+    ports:
+      - "5335:53/tcp"
+      - "5335:53/udp"
     healthcheck:
-      test: [CMD-SHELL, wget -q --spider http://localhost:3000/api/health || exit 0]
+      test: ["CMD", "unbound-control", "status"]
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 64M
+
+  # ---------------------------------------------------------------------------
+  # NTP Server - Network Time Protocol
+  # https://github.com/cturra/docker-ntp
+  # Image: cturra/ntp:latest
+  # ---------------------------------------------------------------------------
+  ntp:
+    image: cturra/ntp:latest
+    container_name: ntp
+    restart: unless-stopped
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - NTP_SERVERS=${NTP_SERVERS:-time.cloudflare.com,time.google.com}
+    networks:
+      - network
+    ports:
+      - "123:123/udp"
+    healthcheck:
+      test: ["CMD", "chronyc", "tracking"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
       start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+        reservations:
+          memory: 16M
+
 networks:
   proxy:
     external: true
+  network:
+    driver: bridge
+
 volumes:
-  adguard-work:
-  adguard-conf:
-  npm-data:
-  npm-letsencrypt:
+  pihole-etc:
+  pihole-dnsmasq:
+  unbound-data:


### PR DESCRIPTION
Implements Issue #4 - Network Stack with Pi-hole, Unbound, and NTP.

## Services
- Pi-hole 5.26 (DNS sinkhole + ad-blocking)
- Unbound 1.20.0 (recursive DNS resolver)
- NTP latest (time synchronization)

## Features
- Local DNS records support
- DNSSEC validation
- DNS over HTTPS ready
- QNAME minimization
- Health checks for all containers

## Validation
- ✅ YAML syntax verified
- ✅ Config files validated
- ✅ Image versions match Issue requirements

Closes #4