### PR TITLE
feat(media): Add media server stack with Jellyfin, Sonarr, Radarr, etc.

### DIFF
--- a/stacks/media/.env.example
+++ b/stacks/media/.env.example
@@ -1,7 +1,23 @@
+# =============================================================================
+# Media Stack Configuration
+# =============================================================================
+
+# Domain
+DOMAIN=example.com
+
+# Timezone
 TZ=Asia/Shanghai
-DOMAIN=localhost
+
+# User/Group IDs (for permissions)
 PUID=1000
 PGID=1000
-# Local paths for media and downloads
-MEDIA_PATH=/mnt/media
-DOWNLOAD_PATH=/mnt/downloads
+
+# Directory paths (follow TRaSH Guides hardlink structure)
+MEDIA_ROOT=/data/media
+DOWNLOADS_ROOT=/data/torrents
+
+# Torrent port (must be open on firewall/router)
+TORRENT_PORT=6881
+
+# Jellyfin
+JELLYFIN_PUBLISHED_SERVER_URL=https://jellyfin.example.com

--- a/stacks/media/README.md
+++ b/stacks/media/README.md
@@ -1,0 +1,237 @@
+# Media Stack
+
+Complete media server stack with automated content management and downloading.
+
+## Services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| Jellyfin | `jellyfin/jellyfin:10.9.11` | 8096 | Media server |
+| Sonarr | `lscr.io/linuxserver/sonarr:4.0.11` | 8989 | TV series management |
+| Radarr | `lscr.io/linuxserver/radarr:5.8.1` | 7878 | Movie management |
+| Prowlarr | `lscr.io/linuxserver/prowlarr:1.22.0` | 9696 | Indexer manager |
+| qBittorrent | `lscr.io/linuxserver/qbittorrent:4.6.7` | 8080 | Download client |
+| Jellyseerr | `fallenbagel/jellyseerr:2.1.1` | 5055 | Request manager |
+
+## Quick Start
+
+### 1. Create Directory Structure
+
+```bash
+# Following TRaSH Guides hardlink best practices
+sudo mkdir -p /data/{torrents,media}/{movies,tv}
+sudo chown -R 1000:1000 /data
+```
+
+### 2. Configure Environment
+
+```bash
+cp .env.example .env
+nano .env
+```
+
+### 3. Start Services
+
+```bash
+docker compose up -d
+```
+
+### 4. Access Services
+
+| Service | URL |
+|---------|-----|
+| Jellyfin | https://jellyfin.yourdomain.com |
+| Sonarr | https://sonarr.yourdomain.com |
+| Radarr | https://radarr.yourdomain.com |
+| Prowlarr | https://prowlarr.yourdomain.com |
+| qBittorrent | https://qbittorrent.yourdomain.com |
+| Jellyseerr | https://jellyseerr.yourdomain.com |
+
+## Directory Structure
+
+Following [TRaSH Guides](https://trash-guides.info/Hardlinks/How-to-setup-for/Docker/) for hardlink support:
+
+```
+/data/
+├── torrents/              # Downloads (can be deleted after import)
+│   ├── movies/
+│   └── tv/
+└── media/                 # Final media library
+    ├── movies/
+    └── tv/
+```
+
+**Why this structure?**
+- Enables hardlinks (same filesystem)
+- Instant file moves (no copy)
+- Saves disk space and I/O
+
+## Configuration
+
+### Step 1: Prowlarr (Indexers)
+
+1. Access https://prowlarr.yourdomain.com
+2. Add indexers (TorrentLeech, RARBG, etc.)
+3. Settings → Apps → Add:
+   - Sonarr: `http://sonarr:8989`
+   - Radarr: `http://radarr:7878`
+
+### Step 2: qBittorrent (Downloads)
+
+1. Access https://qbittorrent.yourdomain.com
+2. Default: admin / adminadmin
+3. Tools → Options:
+   - Set download path: `/data/torrents`
+   - Enable "Use subcategories"
+
+### Step 3: Sonarr (TV)
+
+1. Access https://sonarr.yourdomain.com
+2. Settings → Media Management:
+   - Root folder: `/data/media/tv`
+3. Settings → Download Clients:
+   - Add qBittorrent
+   - Host: `qbittorrent`
+   - Port: `8080`
+4. Add shows → Search episodes
+
+### Step 4: Radarr (Movies)
+
+1. Access https://radarr.yourdomain.com
+2. Settings → Media Management:
+   - Root folder: `/data/media/movies`
+3. Settings → Download Clients:
+   - Add qBittorrent
+   - Host: `qbittorrent`
+4. Add movies → Search
+
+### Step 5: Jellyfin (Playback)
+
+1. Access https://jellyfin.yourdomain.com
+2. Setup wizard:
+   - Create admin user
+   - Add libraries:
+     - Movies: `/media/movies`
+     - TV Shows: `/media/tv`
+3. Settings → Playback:
+   - Enable hardware transcoding (if supported)
+
+### Step 6: Jellyseerr (Requests)
+
+1. Access https://jellyseerr.yourdomain.com
+2. Sign in with Jellyfin account
+3. Configure:
+   - Jellyfin URL: `http://jellyfin:8096`
+   - Sonarr: `http://sonarr:8989`
+   - Radarr: `http://radarr:7878`
+
+## Network Diagram
+
+```
+                    ┌─────────────────┐
+                    │   Jellyseerr    │
+                    │  (Requests)     │
+                    └────────┬────────┘
+                             │
+         ┌───────────────────┼───────────────────┐
+         │                   │                   │
+         ▼                   ▼                   ▼
+┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐
+│     Sonarr      │ │     Radarr      │ │    Jellyfin     │
+│   (TV Shows)    │ │    (Movies)     │ │ (Media Server)  │
+└────────┬────────┘ └────────┬────────┘ └─────────────────┘
+         │                   │
+         └─────────┬─────────┘
+                   │
+                   ▼
+         ┌─────────────────┐
+         │   Prowlarr      │
+         │  (Indexers)     │
+         └────────┬────────┘
+                  │
+                  ▼
+         ┌─────────────────┐
+         │  qBittorrent    │
+         │  (Downloads)    │
+         └─────────────────┘
+```
+
+## Health Checks
+
+```bash
+# Check all services
+docker compose ps
+
+# Test individual services
+curl -sf http://localhost:8096/health        # Jellyfin
+curl -sf http://localhost:8989/health        # Sonarr
+curl -sf http://localhost:7878/health        # Radarr
+curl -sf http://localhost:9696/health        # Prowlarr
+curl -sf http://localhost:8080/api/v2/app/version  # qBittorrent
+curl -sf http://localhost:5055/api/v1/status # Jellyseerr
+```
+
+## Troubleshooting
+
+### Permission Issues
+
+```bash
+# Fix permissions
+sudo chown -R 1000:1000 /data
+sudo chmod -R 775 /data
+```
+
+### Hardlinks Not Working
+
+```bash
+# Check if same filesystem
+df -h /data/torrents /data/media
+
+# Must show same device (e.g., /dev/sda1)
+# If different, files will be copied instead of hardlinked
+```
+
+### qBittorrent Can't Connect
+
+```bash
+# Check if port is open
+nc -zv your-server 6881
+
+# Open firewall
+sudo ufw allow 6881/tcp
+sudo ufw allow 6881/udp
+```
+
+### Jellyfin Transcoding Issues
+
+```bash
+# Check GPU support
+docker exec jellyfin ls -la /dev/dri
+
+# Enable in docker-compose.yml:
+# devices:
+#   - /dev/dri:/dev/dri
+```
+
+## Resource Requirements
+
+| Service | Min Memory | Recommended |
+|---------|------------|-------------|
+| Jellyfin | 512 MB | 1-2 GB |
+| Sonarr | 128 MB | 256 MB |
+| Radarr | 128 MB | 256 MB |
+| Prowlarr | 64 MB | 128 MB |
+| qBittorrent | 128 MB | 256 MB |
+| Jellyseerr | 64 MB | 128 MB |
+| **Total** | **1 GB** | **2-3 GB** |
+
+## Security Notes
+
+1. **Change default passwords** (especially qBittorrent)
+2. **Use VPN** for torrenting (optional)
+3. **Limit access** via Authentik (optional)
+4. **Keep indexers private** (Prowlarr should not be public)
+
+## License
+
+MIT

--- a/stacks/media/docker-compose.yml
+++ b/stacks/media/docker-compose.yml
@@ -1,158 +1,272 @@
+# =============================================================================
+# Media Stack - Jellyfin + Sonarr + Radarr + Prowlarr + qBittorrent + Jellyseerr
+# Following TRaSH Guides hardlink best practices
+# =============================================================================
+
+services:
+  # ---------------------------------------------------------------------------
+  # Jellyfin - Media Server
+  # https://jellyfin.org/
+  # Image: jellyfin/jellyfin:10.9.11
+  # ---------------------------------------------------------------------------
+  jellyfin:
+    image: jellyfin/jellyfin:10.9.11
+    container_name: jellyfin
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+      - JELLYFIN_PublishedServerUrl=https://jellyfin.${DOMAIN}
+    volumes:
+      - jellyfin-config:/config
+      - jellyfin-cache:/cache
+      - ${MEDIA_ROOT:-/data/media}:/media:ro
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8096/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.${DOMAIN}`)"
+      - traefik.http.routers.jellyfin.entrypoints=websecure
+      - traefik.http.routers.jellyfin.tls=true
+      - traefik.http.routers.jellyfin.tls.certresolver=myresolver
+      - traefik.http.services.jellyfin.loadbalancer.server.port=8096
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+
+  # ---------------------------------------------------------------------------
+  # Sonarr - TV Series Management
+  # https://sonarr.tv/
+  # Image: lscr.io/linuxserver/sonarr:4.0.11
+  # ---------------------------------------------------------------------------
+  sonarr:
+    image: lscr.io/linuxserver/sonarr:4.0.11
+    container_name: sonarr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+    volumes:
+      - sonarr-config:/config
+      - ${MEDIA_ROOT:-/data/media}:/data/media
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/data/torrents
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8989/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)"
+      - traefik.http.routers.sonarr.entrypoints=websecure
+      - traefik.http.routers.sonarr.tls=true
+      - traefik.http.routers.sonarr.tls.certresolver=myresolver
+      - traefik.http.services.sonarr.loadbalancer.server.port=8989
+      - com.centurylinklabs.watchtower.enable=true
+    depends_on:
+      prowlarr:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
+  # ---------------------------------------------------------------------------
+  # Radarr - Movie Management
+  # https://radarr.video/
+  # Image: lscr.io/linuxserver/radarr:5.8.1
+  # ---------------------------------------------------------------------------
+  radarr:
+    image: lscr.io/linuxserver/radarr:5.8.1
+    container_name: radarr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+    volumes:
+      - radarr-config:/config
+      - ${MEDIA_ROOT:-/data/media}:/data/media
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/data/torrents
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:7878/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)"
+      - traefik.http.routers.radarr.entrypoints=websecure
+      - traefik.http.routers.radarr.tls=true
+      - traefik.http.routers.radarr.tls.certresolver=myresolver
+      - traefik.http.services.radarr.loadbalancer.server.port=7878
+      - com.centurylinklabs.watchtower.enable=true
+    depends_on:
+      prowlarr:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
+  # ---------------------------------------------------------------------------
+  # Prowlarr - Indexer Management
+  # https://prowlarr.com/
+  # Image: lscr.io/linuxserver/prowlarr:1.22.0
+  # ---------------------------------------------------------------------------
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:1.22.0
+    container_name: prowlarr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+    volumes:
+      - prowlarr-config:/config
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:9696/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)"
+      - traefik.http.routers.prowlarr.entrypoints=websecure
+      - traefik.http.routers.prowlarr.tls=true
+      - traefik.http.routers.prowlarr.tls.certresolver=myresolver
+      - traefik.http.services.prowlarr.loadbalancer.server.port=9696
+      - com.centurylinklabs.watchtower.enable=true
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 64M
+
+  # ---------------------------------------------------------------------------
+  # qBittorrent - Download Client
+  # https://www.qbittorrent.org/
+  # Image: lscr.io/linuxserver/qbittorrent:4.6.7
+  # ---------------------------------------------------------------------------
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:4.6.7
+    container_name: qbittorrent
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+      - WEBUI_PORT=8080
+      - TORRENTING_PORT=${TORRENT_PORT:-6881}
+    volumes:
+      - qbittorrent-config:/config
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/data/torrents
+    networks:
+      - proxy
+    ports:
+      - "${TORRENT_PORT:-6881}:${TORRENT_PORT:-6881}/tcp"
+      - "${TORRENT_PORT:-6881}:${TORRENT_PORT:-6881}/udp"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/api/v2/app/version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.${DOMAIN}`)"
+      - traefik.http.routers.qbittorrent.entrypoints=websecure
+      - traefik.http.routers.qbittorrent.tls=true
+      - traefik.http.routers.qbittorrent.tls.certresolver=myresolver
+      - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
+      - com.centurylinklabs.watchtower.enable=true
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
+  # ---------------------------------------------------------------------------
+  # Jellyseerr - Request Management
+  # https://github.com/Fallenbagel/jellyseerr
+  # Image: fallenbagel/jellyseerr:2.1.1
+  # ---------------------------------------------------------------------------
+  jellyseerr:
+    image: fallenbagel/jellyseerr:2.1.1
+    container_name: jellyseerr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Asia/Shanghai}
+      - LOG_LEVEL=info
+    volumes:
+      - jellyseerr-config:/app/config
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:5055/api/v1/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.jellyseerr.rule=Host(`jellyseerr.${DOMAIN}`)"
+      - traefik.http.routers.jellyseerr.entrypoints=websecure
+      - traefik.http.routers.jellyseerr.tls=true
+      - traefik.http.routers.jellyseerr.tls.certresolver=myresolver
+      - traefik.http.services.jellyseerr.loadbalancer.server.port=5055
+      - com.centurylinklabs.watchtower.enable=true
+    depends_on:
+      jellyfin:
+        condition: service_healthy
+      sonarr:
+        condition: service_healthy
+      radarr:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 64M
+
 networks:
   proxy:
     external: true
-services:
-  jellyfin:
-    container_name: jellyfin
-    environment:
-    - TZ=${TZ}
-    - JELLYFIN_PublishedServerUrl=https://media.${DOMAIN}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 30s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8096/health
-      timeout: 10s
-    image: jellyfin/jellyfin:10.9.11
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.jellyfin.rule=Host()
-    - traefik.http.routers.jellyfin.entrypoints=websecure
-    - traefik.http.routers.jellyfin.tls=true
-    - traefik.http.services.jellyfin.loadbalancer.server.port=8096
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - jellyfin-config:/config
-    - jellyfin-cache:/cache
-    - ${MEDIA_PATH}:/media:ro
-  prowlarr:
-    container_name: prowlarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:9696/ping
-      timeout: 10s
-    image: linuxserver/prowlarr:1.24.3
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)
-    - traefik.http.routers.prowlarr.entrypoints=websecure
-    - traefik.http.routers.prowlarr.tls=true
-    - traefik.http.services.prowlarr.loadbalancer.server.port=9696
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - prowlarr-config:/config
-  qbittorrent:
-    container_name: qbittorrent
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    - WEBUI_PORT=8080
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8080
-      timeout: 10s
-    image: linuxserver/qbittorrent:4.6.7
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.qbittorrent.rule=Host(`bt.${DOMAIN}`)
-    - traefik.http.routers.qbittorrent.entrypoints=websecure
-    - traefik.http.routers.qbittorrent.tls=true
-    - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - qbittorrent-config:/config
-    - ${DOWNLOAD_PATH}:/downloads
-  radarr:
-    container_name: radarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:7878/ping
-      timeout: 10s
-    image: linuxserver/radarr:5.11.0
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)
-    - traefik.http.routers.radarr.entrypoints=websecure
-    - traefik.http.routers.radarr.tls=true
-    - traefik.http.services.radarr.loadbalancer.server.port=7878
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - radarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
-  sonarr:
-    container_name: sonarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8989/ping
-      timeout: 10s
-    image: linuxserver/sonarr:4.0.9
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)
-    - traefik.http.routers.sonarr.entrypoints=websecure
-    - traefik.http.routers.sonarr.tls=true
-    - traefik.http.services.sonarr.loadbalancer.server.port=8989
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - sonarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+
 volumes:
-  jellyfin-cache: null
-  jellyfin-config: null
-  prowlarr-config: null
-  qbittorrent-config: null
-  radarr-config: null
-  sonarr-config: null
+  jellyfin-config:
+  jellyfin-cache:
+  sonarr-config:
+  radarr-config:
+  prowlarr-config:
+  qbittorrent-config:
+  jellyseerr-config:


### PR DESCRIPTION
Implements Issue #2 - Media Stack.

## Services (6 total)
- Jellyfin 10.9.11 (media server)
- Sonarr 4.0.11 (TV management)
- Radarr 5.8.1 (movie management)
- Prowlarr 1.22.0 (indexer manager)
- qBittorrent 4.6.7 (download client)
- Jellyseerr 2.1.1 (request manager)

## Features
- TRaSH Guides hardlink-friendly directory structure
- Health checks for all services
- Proper startup order
- Traefik reverse proxy
- Watchtower auto-update support

## Validation
- ✅ YAML syntax verified
- ✅ Image versions match Issue requirements
- ✅ 6 health checks configured

Closes #2