### PR TITLE
feat(testing): Add integration test framework

### DIFF
--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -1,0 +1,338 @@
+#!/bin/bash
+# =============================================================================
+# assert.sh - Testing assertion library
+# =============================================================================
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+# -----------------------------------------------------------------------------
+# Core assertions
+# -----------------------------------------------------------------------------
+
+assert_eq() {
+    local actual="$1"
+    local expected="$2"
+    local msg="${3:-Values should be equal}"
+    
+    if [[ "$actual" == "$expected" ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Expected: $expected"
+        echo "  Actual:   $actual"
+        return 1
+    fi
+}
+
+assert_not_empty() {
+    local value="$1"
+    local msg="${2:-Value should not be empty}"
+    
+    if [[ -n "$value" ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Value is empty"
+        return 1
+    fi
+}
+
+assert_exit_code() {
+    local code="$1"
+    local msg="${2:-Command should exit with code 0}"
+    
+    if [[ "$code" -eq 0 ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Exit code: $code"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Docker assertions
+# -----------------------------------------------------------------------------
+
+assert_container_running() {
+    local name="$1"
+    local msg="${2:-Container $name should be running}"
+    
+    local status
+    status=$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo "not_found")
+    
+    if [[ "$status" == "running" ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Status: $status"
+        return 1
+    fi
+}
+
+assert_container_healthy() {
+    local name="$1"
+    local timeout="${2:-60}"
+    local msg="${3:-Container $name should be healthy}"
+    
+    local start_time=$(date +%s)
+    local current_time
+    
+    while true; do
+        current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+        
+        if [[ $elapsed -ge $timeout ]]; then
+            echo -e "${RED}ASSERT FAILED${NC}: $msg"
+            echo "  Timeout after ${timeout}s"
+            return 1
+        fi
+        
+        local health
+        health=$(docker inspect -f '{{.State.Health.Status}}' "$name" 2>/dev/null || echo "not_found")
+        
+        if [[ "$health" == "healthy" ]]; then
+            return 0
+        elif [[ "$health" == "unhealthy" ]]; then
+            echo -e "${RED}ASSERT FAILED${NC}: $msg"
+            echo "  Health: unhealthy"
+            return 1
+        fi
+        
+        sleep 2
+    done
+}
+
+assert_container_exists() {
+    local name="$1"
+    local msg="${2:-Container $name should exist}"
+    
+    if docker inspect "$name" &>/dev/null; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# HTTP assertions
+# -----------------------------------------------------------------------------
+
+assert_http_200() {
+    local url="$1"
+    local timeout="${2:-30}"
+    local msg="${3:-HTTP request should return 200}"
+    
+    local code
+    code=$(curl -sf -o /dev/null -w "%{http_code}" --connect-timeout "$timeout" "$url" 2>/dev/null || echo "000")
+    
+    if [[ "$code" == "200" ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  URL: $url"
+        echo "  Expected: 200"
+        echo "  Got: $code"
+        return 1
+    fi
+}
+
+assert_http_response() {
+    local url="$1"
+    local pattern="$2"
+    local msg="${3:-HTTP response should contain pattern}"
+    
+    local response
+    response=$(curl -sf --connect-timeout 30 "$url" 2>/dev/null)
+    
+    if echo "$response" | grep -q "$pattern"; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  URL: $url"
+        echo "  Pattern: $pattern"
+        return 1
+    fi
+}
+
+assert_http_redirect() {
+    local url="$1"
+    local expected_location="${2:-}"
+    local msg="${3:-HTTP should redirect}"
+    
+    local location
+    location=$(curl -sf -o /dev/null -w "%{redirect_url}" "$url" 2>/dev/null)
+    
+    if [[ -n "$location" ]]; then
+        if [[ -n "$expected_location" ]]; then
+            if [[ "$location" == *"$expected_location"* ]]; then
+                return 0
+            else
+                echo -e "${RED}ASSERT FAILED${NC}: $msg"
+                echo "  Expected location: $expected_location"
+                echo "  Got: $location"
+                return 1
+            fi
+        fi
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  No redirect found"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# JSON assertions
+# -----------------------------------------------------------------------------
+
+assert_json_value() {
+    local json="$1"
+    local jq_path="$2"
+    local expected="$3"
+    local msg="${4:-JSON value should match}"
+    
+    local actual
+    actual=$(echo "$json" | jq -r "$jq_path" 2>/dev/null)
+    
+    if [[ "$actual" == "$expected" ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Path: $jq_path"
+        echo "  Expected: $expected"
+        echo "  Got: $actual"
+        return 1
+    fi
+}
+
+assert_json_key_exists() {
+    local json="$1"
+    local jq_path="$2"
+    local msg="${3:-JSON key should exist}"
+    
+    if echo "$json" | jq -e "$jq_path" &>/dev/null; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Path: $jq_path"
+        echo "  Key not found"
+        return 1
+    fi
+}
+
+assert_no_errors() {
+    local json="$1"
+    local msg="${2:-JSON should have no errors}"
+    
+    local errors
+    errors=$(echo "$json" | jq -r '.errors // empty' 2>/dev/null)
+    
+    if [[ -z "$errors" || "$errors" == "null" ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Errors: $errors"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# File assertions
+# -----------------------------------------------------------------------------
+
+assert_file_exists() {
+    local file="$1"
+    local msg="${2:-File should exist}"
+    
+    if [[ -f "$file" ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  File: $file"
+        return 1
+    fi
+}
+
+assert_file_contains() {
+    local file="$1"
+    local pattern="$2"
+    local msg="${3:-File should contain pattern}"
+    
+    if grep -q "$pattern" "$file" 2>/dev/null; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  File: $file"
+        echo "  Pattern: $pattern"
+        return 1
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Compose assertions
+# -----------------------------------------------------------------------------
+
+assert_no_latest_images() {
+    local dir="$1"
+    local msg="${2:-No :latest image tags should be used}"
+    
+    local count
+    count=$(grep -r 'image:.*:latest' "$dir" 2>/dev/null | wc -l || echo "0")
+    
+    if [[ "$count" -eq 0 ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Found $count :latest tags"
+        grep -r 'image:.*:latest' "$dir" 2>/dev/null || true
+        return 1
+    fi
+}
+
+assert_all_services_have_healthcheck() {
+    local compose_file="$1"
+    local msg="${2:-All services should have healthcheck}"
+    
+    local services_without_healthcheck
+    services_without_healthcheck=$(python3 -c "
+import yaml
+import sys
+
+with open('$compose_file') as f:
+    config = yaml.safe_load(f)
+
+services = config.get('services', {})
+missing = []
+
+for name, service in services.items():
+    if 'healthcheck' not in service:
+        missing.append(name)
+
+if missing:
+    print(','.join(missing))
+    sys.exit(1)
+else:
+    sys.exit(0)
+" 2>/dev/null)
+    
+    if [[ $? -eq 0 ]]; then
+        return 0
+    else
+        echo -e "${RED}ASSERT FAILED${NC}: $msg"
+        echo "  Missing healthcheck: $services_without_healthcheck"
+        return 1
+    fi
+}

--- a/tests/lib/docker.sh
+++ b/tests/lib/docker.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# =============================================================================
+# docker.sh - Docker utility functions for testing
+# =============================================================================
+
+set -euo pipefail
+
+# Get container status
+get_container_status() {
+    local name="$1"
+    docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo "not_found"
+}
+
+# Get container health
+get_container_health() {
+    local name="$1"
+    docker inspect -f '{{.State.Health.Status}}' "$name" 2>/dev/null || echo "no_healthcheck"
+}
+
+# Check if container is running
+is_container_running() {
+    local name="$1"
+    [[ $(get_container_status "$name") == "running" ]]
+}
+
+# Check if container is healthy
+is_container_healthy() {
+    local name="$1"
+    [[ $(get_container_health "$name") == "healthy" ]]
+}
+
+# Wait for container to be healthy
+wait_for_healthy() {
+    local name="$1"
+    local timeout="${2:-60}"
+    
+    local start_time=$(date +%s)
+    
+    while true; do
+        local current_time=$(date +%s)
+        local elapsed=$((current_time - start_time))
+        
+        if [[ $elapsed -ge $timeout ]]; then
+            echo "Timeout waiting for $name to be healthy"
+            return 1
+        fi
+        
+        if is_container_healthy "$name"; then
+            return 0
+        fi
+        
+        sleep 2
+    done
+}
+
+# Wait for all containers in compose to be healthy
+wait_for_compose_healthy() {
+    local compose_file="$1"
+    local timeout="${2:-120}"
+    
+    local services
+    services=$(docker compose -f "$compose_file" config --services 2>/dev/null)
+    
+    for service in $services; do
+        wait_for_healthy "$service" "$timeout" || return 1
+    done
+}
+
+# Get container IP
+get_container_ip() {
+    local name="$1"
+    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$name" 2>/dev/null
+}
+
+# Get container logs
+get_container_logs() {
+    local name="$1"
+    local lines="${2:-100}"
+    docker logs --tail "$lines" "$name" 2>&1
+}
+
+# List all running containers
+list_running_containers() {
+    docker ps --format '{{.Names}}'
+}
+
+# Count running containers
+count_running_containers() {
+    docker ps -q | wc -l
+}
+
+# Check if network exists
+network_exists() {
+    local name="$1"
+    docker network inspect "$name" &>/dev/null
+}
+
+# Check if volume exists
+volume_exists() {
+    local name="$1"
+    docker volume inspect "$name" &>/dev/null
+}

--- a/tests/lib/report.sh
+++ b/tests/lib/report.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# =============================================================================
+# report.sh - Test result reporting
+# =============================================================================
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Test counters
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+TESTS_TOTAL=0
+
+# Current stack
+CURRENT_STACK=""
+
+# Results array for JSON
+declare -a TEST_RESULTS=()
+
+# -----------------------------------------------------------------------------
+# Output functions
+# -----------------------------------------------------------------------------
+
+print_header() {
+    echo ""
+    echo -e "${CYAN}╔══════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║   HomeLab Stack — Integration Tests  ║${NC}"
+    echo -e "${CYAN}╚══════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+print_stack_header() {
+    local stack="$1"
+    CURRENT_STACK="$stack"
+    echo ""
+    echo -e "${BOLD}[$stack]${NC}"
+}
+
+print_test_result() {
+    local name="$1"
+    local result="$2"
+    local duration="${3:-0}"
+    local error_msg="${4:-}"
+    
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
+    
+    local status_icon
+    local status_color
+    
+    case "$result" in
+        PASS)
+            status_icon="✅"
+            status_color="$GREEN"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+            ;;
+        FAIL)
+            status_icon="❌"
+            status_color="$RED"
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+            ;;
+        SKIP)
+            status_icon="⏭️"
+            status_color="$YELLOW"
+            TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+            ;;
+    esac
+    
+    echo -e "  ${status_color}▶${NC} $name ${status_icon} ${status_color}${result}${NC} (${duration}s)"
+    
+    if [[ -n "$error_msg" && "$result" == "FAIL" ]]; then
+        echo -e "    ${RED}$error_msg${NC}"
+    fi
+    
+    # Store for JSON
+    TEST_RESULTS+=("{\"stack\":\"$CURRENT_STACK\",\"name\":\"$name\",\"result\":\"$result\",\"duration\":$duration}")
+}
+
+print_summary() {
+    local total_duration="${1:-0}"
+    
+    echo ""
+    echo "──────────────────────────────────────"
+    echo -e "Results: ${GREEN}$TESTS_PASSED passed${NC}, ${RED}$TESTS_FAILED failed${NC}, ${YELLOW}$TESTS_SKIPPED skipped${NC}"
+    echo "Duration: ${total_duration}s"
+    echo "──────────────────────────────────────"
+    
+    if [[ $TESTS_FAILED -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# JSON output
+# -----------------------------------------------------------------------------
+
+generate_json_report() {
+    local output_file="${1:-tests/results/report.json}"
+    local total_duration="${2:-0}"
+    
+    mkdir -p "$(dirname "$output_file")"
+    
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    
+    {
+        echo "{"
+        echo "  \"timestamp\": \"$timestamp\","
+        echo "  \"summary\": {"
+        echo "    \"total\": $TESTS_TOTAL,"
+        echo "    \"passed\": $TESTS_PASSED,"
+        echo "    \"failed\": $TESTS_FAILED,"
+        echo "    \"skipped\": $TESTS_SKIPPED,"
+        echo "    \"duration\": $total_duration"
+        echo "  },"
+        echo "  \"tests\": ["
+        
+        local first=true
+        for result in "${TEST_RESULTS[@]}"; do
+            if $first; then
+                echo "    $result"
+                first=false
+            else
+                echo "    ,$result"
+            fi
+        done
+        
+        echo "  ]"
+        echo "}"
+    } > "$output_file"
+    
+    echo "JSON report: $output_file"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# =============================================================================
+# run-tests.sh - Integration test runner
+# Usage: ./run-tests.sh --stack <name> | --all [--json]
+# =============================================================================
+
+set -euo pipefail
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source libraries
+source "$SCRIPT_DIR/lib/assert.sh"
+source "$SCRIPT_DIR/lib/docker.sh"
+source "$SCRIPT_DIR/lib/report.sh"
+
+# Default values
+STACK=""
+JSON_OUTPUT=false
+VERBOSE=false
+
+# -----------------------------------------------------------------------------
+# Help
+# -----------------------------------------------------------------------------
+
+show_help() {
+    cat << HELPEOF
+HomeLab Stack Integration Tests
+
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --stack <name>    Run tests for specific stack
+  --all             Run tests for all stacks
+  --json            Output JSON report to tests/results/report.json
+  --verbose         Show verbose output
+  --help            Show this help message
+
+Available stacks:
+  base, media, storage, databases, network, productivity,
+  ai, home-automation, notifications, sso
+
+Examples:
+  $(basename "$0") --stack base
+  $(basename "$0") --all --json
+  $(basename "$0") --stack media --verbose
+
+HELPEOF
+}
+
+# -----------------------------------------------------------------------------
+# Parse arguments
+# -----------------------------------------------------------------------------
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --stack)
+            STACK="$2"
+            shift 2
+            ;;
+        --all)
+            STACK="all"
+            shift
+            ;;
+        --json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        --verbose)
+            VERBOSE=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# -----------------------------------------------------------------------------
+# Validation
+# -----------------------------------------------------------------------------
+
+if [[ -z "$STACK" ]]; then
+    echo "Error: --stack or --all required"
+    show_help
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Run tests
+# -----------------------------------------------------------------------------
+
+print_header
+
+START_TIME=$(date +%s)
+
+run_stack_tests() {
+    local stack="$1"
+    local test_file="$SCRIPT_DIR/stacks/${stack}.test.sh"
+    
+    if [[ ! -f "$test_file" ]]; then
+        print_stack_header "$stack"
+        print_test_result "Tests not found" "SKIP" 0 "No test file at $test_file"
+        return 0
+    fi
+    
+    print_stack_header "$stack"
+    source "$test_file"
+}
+
+if [[ "$STACK" == "all" ]]; then
+    for stack in base media storage databases network productivity ai home-automation notifications sso; do
+        run_stack_tests "$stack"
+    done
+else
+    run_stack_tests "$STACK"
+fi
+
+END_TIME=$(date +%s)
+TOTAL_DURATION=$((END_TIME - START_TIME))
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+
+print_summary "$TOTAL_DURATION"
+
+if $JSON_OUTPUT; then
+    generate_json_report "$SCRIPT_DIR/results/report.json" "$TOTAL_DURATION"
+fi
+
+# Exit with error if any tests failed
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+
+exit 0

--- a/tests/stacks/ai.test.sh
+++ b/tests/stacks/ai.test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# =============================================================================
+# ai.test.sh - AI stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    docker compose -f stacks/ai/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_ollama_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "ollama" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Ollama running" "$result" $((end - start))
+}
+
+test_ollama_healthy() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_healthy "ollama" 60 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Ollama healthy" "$result" $((end - start))
+}
+
+test_open_webui_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "open-webui" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Open WebUI running" "$result" $((end - start))
+}
+
+test_stable_diffusion_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "stable-diffusion" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Stable Diffusion running" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_ollama_running
+test_ollama_healthy
+test_open_webui_running
+test_stable_diffusion_running

--- a/tests/stacks/base.test.sh
+++ b/tests/stacks/base.test.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# =============================================================================
+# base.test.sh - Base stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    local error=""
+    
+    if docker compose -f stacks/base/docker-compose.yml config --quiet 2>&1; then
+        :
+    else
+        result="FAIL"
+        error="docker-compose.yml syntax error"
+    fi
+    
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start)) "$error"
+}
+
+test_no_latest_images() {
+    local start=$(date +%s)
+    local result="PASS"
+    local error=""
+    
+    if assert_no_latest_images "stacks/base" 2>&1; then
+        :
+    else
+        result="FAIL"
+        error="Found :latest image tags"
+    fi
+    
+    local end=$(date +%s)
+    print_test_result "No :latest tags" "$result" $((end - start)) "$error"
+}
+
+test_traefik_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    local error=""
+    
+    if assert_container_running "traefik" 2>&1; then
+        :
+    else
+        result="FAIL"
+        error="Traefik not running"
+    fi
+    
+    local end=$(date +%s)
+    print_test_result "Traefik running" "$result" $((end - start)) "$error"
+}
+
+test_traefik_healthy() {
+    local start=$(date +%s)
+    local result="PASS"
+    local error=""
+    
+    if assert_container_healthy "traefik" 60 2>&1; then
+        :
+    else
+        result="FAIL"
+        error="Traefik not healthy"
+    fi
+    
+    local end=$(date +%s)
+    print_test_result "Traefik healthy" "$result" $((end - start)) "$error"
+}
+
+test_portainer_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    local error=""
+    
+    if assert_container_running "portainer" 2>&1; then
+        :
+    else
+        result="FAIL"
+        error="Portainer not running"
+    fi
+    
+    local end=$(date +%s)
+    print_test_result "Portainer running" "$result" $((end - start)) "$error"
+}
+
+test_watchtower_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    local error=""
+    
+    if assert_container_running "watchtower" 2>&1; then
+        :
+    else
+        result="FAIL"
+        error="Watchtower not running"
+    fi
+    
+    local end=$(date +%s)
+    print_test_result "Watchtower running" "$result" $((end - start)) "$error"
+}
+
+# Run all tests
+test_compose_syntax
+test_no_latest_images
+test_traefik_running
+test_traefik_healthy
+test_portainer_running
+test_watchtower_running

--- a/tests/stacks/databases.test.sh
+++ b/tests/stacks/databases.test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# =============================================================================
+# databases.test.sh - Databases stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    docker compose -f stacks/databases/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_postgres_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "homelab-postgres" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "PostgreSQL running" "$result" $((end - start))
+}
+
+test_postgres_healthy() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_healthy "homelab-postgres" 60 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "PostgreSQL healthy" "$result" $((end - start))
+}
+
+test_redis_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "homelab-redis" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Redis running" "$result" $((end - start))
+}
+
+test_redis_healthy() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_healthy "homelab-redis" 60 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Redis healthy" "$result" $((end - start))
+}
+
+test_mariadb_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "homelab-mariadb" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "MariaDB running" "$result" $((end - start))
+}
+
+test_mariadb_healthy() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_healthy "homelab-mariadb" 60 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "MariaDB healthy" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_postgres_running
+test_postgres_healthy
+test_redis_running
+test_redis_healthy
+test_mariadb_running
+test_mariadb_healthy

--- a/tests/stacks/home-automation.test.sh
+++ b/tests/stacks/home-automation.test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# =============================================================================
+# home-automation.test.sh - Home Automation stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    docker compose -f stacks/home-automation/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_home_assistant_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "homeassistant" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Home Assistant running" "$result" $((end - start))
+}
+
+test_nodered_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "nodered" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Node-RED running" "$result" $((end - start))
+}
+
+test_mosquitto_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "mosquitto" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Mosquitto running" "$result" $((end - start))
+}
+
+test_zigbee2mqtt_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "zigbee2mqtt" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Zigbee2MQTT running" "$result" $((end - start))
+}
+
+test_esphome_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "esphome" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "ESPHome running" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_home_assistant_running
+test_nodered_running
+test_mosquitto_running
+test_zigbee2mqtt_running
+test_esphome_running

--- a/tests/stacks/media.test.sh
+++ b/tests/stacks/media.test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# =============================================================================
+# media.test.sh - Media stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    docker compose -f stacks/media/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_jellyfin_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "jellyfin" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Jellyfin running" "$result" $((end - start))
+}
+
+test_sonarr_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "sonarr" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Sonarr running" "$result" $((end - start))
+}
+
+test_radarr_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "radarr" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Radarr running" "$result" $((end - start))
+}
+
+test_qbittorrent_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "qbittorrent" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "qBittorrent running" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_jellyfin_running
+test_sonarr_running
+test_radarr_running
+test_qbittorrent_running

--- a/tests/stacks/network.test.sh
+++ b/tests/stacks/network.test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# =============================================================================
+# network.test.sh - Network stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    docker compose -f stacks/network/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_adguard_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "adguard" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "AdGuard running" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_adguard_running

--- a/tests/stacks/notifications.test.sh
+++ b/tests/stacks/notifications.test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# =============================================================================
+# notifications.test.sh - Notifications stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    docker compose -f stacks/notifications/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_ntfy_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "ntfy" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "ntfy running" "$result" $((end - start))
+}
+
+test_ntfy_healthy() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_healthy "ntfy" 60 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "ntfy healthy" "$result" $((end - start))
+}
+
+test_gotify_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    assert_container_running "gotify" 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "Gotify running" "$result" $((end - start))
+}
+
+test_notify_script_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    
+    bash -n scripts/notify.sh 2>&1 || result="FAIL"
+    
+    local end=$(date +%s)
+    print_test_result "notify.sh syntax" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_ntfy_running
+test_ntfy_healthy
+test_gotify_running
+test_notify_script_syntax

--- a/tests/stacks/productivity.test.sh
+++ b/tests/stacks/productivity.test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# =============================================================================
+# productivity.test.sh - Productivity stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    docker compose -f stacks/productivity/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_gitea_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "gitea" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Gitea running" "$result" $((end - start))
+}
+
+test_vaultwarden_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "vaultwarden" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Vaultwarden running" "$result" $((end - start))
+}
+
+test_outline_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "outline" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Outline running" "$result" $((end - start))
+}
+
+test_stirling_pdf_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "stirling-pdf" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Stirling PDF running" "$result" $((end - start))
+}
+
+test_excalidraw_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "excalidraw" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Excalidraw running" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_gitea_running
+test_vaultwarden_running
+test_outline_running
+test_stirling_pdf_running
+test_excalidraw_running

--- a/tests/stacks/sso.test.sh
+++ b/tests/stacks/sso.test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# =============================================================================
+# sso.test.sh - SSO stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    docker compose -f stacks/sso/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_authentik_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "authentik-server" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Authentik server running" "$result" $((end - start))
+}
+
+test_authentik_worker_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "authentik-worker" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Authentik worker running" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_authentik_running
+test_authentik_worker_running

--- a/tests/stacks/storage.test.sh
+++ b/tests/stacks/storage.test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# =============================================================================
+# storage.test.sh - Storage stack tests
+# =============================================================================
+
+test_compose_syntax() {
+    local start=$(date +%s)
+    local result="PASS"
+    docker compose -f stacks/storage/docker-compose.yml config --quiet 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Compose syntax" "$result" $((end - start))
+}
+
+test_nextcloud_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "nextcloud" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "Nextcloud running" "$result" $((end - start))
+}
+
+test_minio_running() {
+    local start=$(date +%s)
+    local result="PASS"
+    assert_container_running "minio" 2>&1 || result="FAIL"
+    local end=$(date +%s)
+    print_test_result "MinIO running" "$result" $((end - start))
+}
+
+# Run all tests
+test_compose_syntax
+test_nextcloud_running
+test_minio_running


### PR DESCRIPTION
Implements Issue #14 - Integration Testing.

## Test Framework

### Test Runner
- `tests/run-tests.sh --stack <name>` - Run specific stack tests
- `tests/run-tests.sh --all --json` - Run all tests with JSON output

### Assertion Library (tests/lib/assert.sh)
- `assert_eq`, `assert_not_empty`, `assert_exit_code`
- `assert_container_running`, `assert_container_healthy`
- `assert_http_200`, `assert_http_response`, `assert_http_redirect`
- `assert_json_value`, `assert_json_key_exists`, `assert_no_errors`
- `assert_file_exists`, `assert_file_contains`
- `assert_no_latest_images`, `assert_all_services_have_healthcheck`

### Stack Tests (10 stacks)
- base, databases, notifications, ai
- home-automation, productivity, media
- storage, network, sso

## Files
- 14 files, 1,311 lines
- All scripts pass `bash -n` syntax check

Closes #14