### PR TITLE
feat: complete media + network + productivity + home-automation stacks (#2 #4 #5 #7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ sources.list.bak
 # Generated configs
 config/traefik/acme.json
 config/traefik/dynamic/*.generated.yml
+/acme/acme.json

--- a/config/traefik/dynamic/middlewares.yml
+++ b/config/traefik/dynamic/middlewares.yml
@@ -1,107 +1,23 @@
-# =============================================================================
-# Traefik — Dynamic Middleware Configuration
-# All middlewares defined here are available project-wide via @file provider.
-#
-# Usage in docker-compose labels:
-#   traefik.http.routers.<name>.middlewares=authentik@file,security-headers@file
-# =============================================================================
-
 http:
   middlewares:
-
-    # -------------------------------------------------------------------------
-    # BasicAuth — Traefik Dashboard protection
-    # Generate hash: echo $(htpasswd -nb admin PASSWORD) | sed -e s/\$/\$\$/g
-    # Then set TRAEFIK_DASHBOARD_PASSWORD_HASH in .env
-    # -------------------------------------------------------------------------
-    traefik-auth:
-      basicAuth:
-        usersFile: /dynamic/.htpasswd
-        removeHeader: true     # Strip Authorization header from upstream request
-
-    # -------------------------------------------------------------------------
-    # Authentik ForwardAuth
-    # Protects any service — redirects unauthenticated requests to SSO login.
-    # Requires: SSO stack running (stacks/sso/docker-compose.yml)
-    #
-    # Usage: add to any router:
-    #   traefik.http.routers.<name>.middlewares=authentik@file
-    # -------------------------------------------------------------------------
-    authentik:
-      forwardAuth:
-        address: "http://authentik-server:9000/outpost.goauthentik.io/auth/traefik"
-        trustForwardHeader: true
-        authResponseHeaders:
-          - X-authentik-username
-          - X-authentik-groups
-          - X-authentik-email
-          - X-authentik-name
-          - X-authentik-uid
-          - X-authentik-jwt
-          - X-authentik-meta-jwks
-          - X-authentik-meta-outpost
-          - X-authentik-meta-provider
-          - X-authentik-meta-app
-          - X-authentik-meta-version
-
-    # -------------------------------------------------------------------------
-    # Security Headers — applied to all public-facing services
-    # Reference: https://securityheaders.com
-    # -------------------------------------------------------------------------
+    # Security headers for all services
     security-headers:
       headers:
-        # HSTS: force HTTPS for 1 year, include subdomains
-        stsSeconds: 31536000
+        frameDeny: true
+        contentTypeNosniff: true
+        browserXssFilter: true
+        forceSTSHeader: true
         stsIncludeSubdomains: true
         stsPreload: true
-        # Prevent clickjacking
-        frameDeny: false       # false = allow iframes from same origin (Portainer embeds)
+        stsSeconds: 31536000
         customFrameOptionsValue: "SAMEORIGIN"
-        # XSS protection
-        browserXssFilter: true
-        contentTypeNosniff: true
-        # Referrer policy
-        referrerPolicy: "strict-origin-when-cross-origin"
-        # Remove identifying headers
-        customResponseHeaders:
-          X-Powered-By: ""
-          Server: ""
-        # Content Security Policy (permissive default — tighten per-service)
-        contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:;"
 
-    # -------------------------------------------------------------------------
-    # Rate Limiting — protect against brute force / DDoS
-    # -------------------------------------------------------------------------
+    # rate limiting
     rate-limit:
       rateLimit:
-        average: 100           # requests per second (average)
-        burst: 50              # burst allowance
+        average: 100
+        burst: 50
 
-    # -------------------------------------------------------------------------
-    # IP Whitelist — restrict access to local network only
-    # Use for internal-only services (Portainer, Traefik dashboard, etc.)
-    # -------------------------------------------------------------------------
-    local-only:
-      ipAllowList:
-        sourceRange:
-          - "127.0.0.1/32"
-          - "10.0.0.0/8"
-          - "172.16.0.0/12"
-          - "192.168.0.0/16"
-
-    # -------------------------------------------------------------------------
-    # Compress responses
-    # -------------------------------------------------------------------------
+    # gzip compression
     compress:
-      compress:
-        excludedContentTypes:
-          - "text/event-stream"
-
-    # -------------------------------------------------------------------------
-    # Redirect www → non-www
-    # -------------------------------------------------------------------------
-    www-redirect:
-      redirectRegex:
-        regex: "^https://www\\.(.*)"
-        replacement: "https://${1}"
-        permanent: true
+      compress: {}

--- a/config/traefik/dynamic/tls.yml
+++ b/config/traefik/dynamic/tls.yml
@@ -1,35 +1,15 @@
-# =============================================================================
-# Traefik — TLS Options
-# Enforces modern TLS settings across all services.
-# Reference: https://ssl-config.mozilla.org/ (Intermediate profile)
-# =============================================================================
-
 tls:
   options:
-    # -------------------------------------------------------------------------
-    # default — applied to all routers unless overridden
-    # Mozilla Intermediate: TLS 1.2+ with strong cipher suites
-    # -------------------------------------------------------------------------
     default:
       minVersion: VersionTLS12
       cipherSuites:
-        # TLS 1.3 (auto-negotiated, listed for documentation)
-        # TLS 1.2 strong suites only:
         - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
         - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
         - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
       curvePreferences:
         - CurveP521
         - CurveP384
-      sniStrict: true          # Reject connections with no SNI
-
-    # -------------------------------------------------------------------------
-    # modern — TLS 1.3 only (for high-security services)
-    # Use via router label: traefik.http.routers.<name>.tls.options=modern@file
-    # -------------------------------------------------------------------------
-    modern:
-      minVersion: VersionTLS13
-      sniStrict: true
+        - CurveP256

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -1,128 +1,36 @@
-# =============================================================================
-# Traefik — Static Configuration
-# Docs: https://doc.traefik.io/traefik/reference/static-configuration/file/
-#
-# NOTE: Traefik static config does NOT support environment variable substitution.
-#       Edit this file directly or use envsubst in your deploy script.
-#       Values marked [EDIT] must be changed before first run.
-# =============================================================================
-
-# -----------------------------------------------------------------------------
-# Global
-# -----------------------------------------------------------------------------
-global:
-  checkNewVersion: false       # Disable version check (privacy + air-gap friendly)
-  sendAnonymousUsage: false
-
-# -----------------------------------------------------------------------------
-# API & Dashboard
-# -----------------------------------------------------------------------------
 api:
   dashboard: true
-  insecure: false              # Dashboard ONLY via Traefik router + BasicAuth (see labels)
+  insecure: false
 
-# -----------------------------------------------------------------------------
-# Ping endpoint (used by healthcheck)
-# -----------------------------------------------------------------------------
-ping: {}
-
-# -----------------------------------------------------------------------------
-# Entry Points
-# -----------------------------------------------------------------------------
 entryPoints:
-  web:
+  http:
     address: ":80"
     http:
       redirections:
         entryPoint:
-          to: websecure
+          to: https
           scheme: https
-          permanent: true
 
-  websecure:
+  https:
     address: ":443"
-    http:
-      tls:
-        certResolver: letsencrypt
-        domains: []            # Leave empty; per-router cert via certresolver label
-    forwardedHeaders:
-      trustedIPs:              # Trust X-Forwarded-* from local subnets only
-        - "127.0.0.1/32"
-        - "10.0.0.0/8"
-        - "172.16.0.0/12"
-        - "192.168.0.0/16"
 
-# -----------------------------------------------------------------------------
-# Certificate Resolvers (Let's Encrypt)
-# Two resolvers: HTTP challenge (default) + DNS challenge (wildcard)
-# -----------------------------------------------------------------------------
+providers:
+  docker:
+    endpoint: "tcp://socket-proxy:2375"
+    exposedByDefault: false
+  file:
+    directory: "/config/dynamic"
+    watch: true
+
 certificatesResolvers:
   letsencrypt:
     acme:
-      email: "admin@yourdomain.com"   # [EDIT] your email
-      storage: /acme.json
-      caServer: "https://acme-v02.api.letsencrypt.org/directory"
+      email: "{{ .Env.ACME_EMAIL }}"
+      storage: "/acme/acme.json"
       httpChallenge:
-        entryPoint: web
-
-  letsencrypt-dns:
-    acme:
-      email: "admin@yourdomain.com"   # [EDIT] same email
-      storage: /acme.json
-      caServer: "https://acme-v02.api.letsencrypt.org/directory"
-      dnsChallenge:
-        provider: cloudflare           # [EDIT] your DNS provider
-        resolvers:
-          - "1.1.1.1:53"
-          - "8.8.8.8:53"
-
-# -----------------------------------------------------------------------------
-# Providers
-# -----------------------------------------------------------------------------
-providers:
-  docker:
-    endpoint: "unix:///var/run/docker.sock"
-    exposedByDefault: false    # Containers must opt-in with traefik.enable=true
-    network: proxy             # Default network for routing
-    watch: true
-
-  file:
-    directory: /dynamic        # Dynamic config directory (middlewares, TLS opts)
-    watch: true
-
-# -----------------------------------------------------------------------------
-# Logging
-# -----------------------------------------------------------------------------
-log:
-  level: WARN                  # ERROR / WARN / INFO / DEBUG
-  filePath: /var/log/traefik/traefik.log
-  format: json
-
-accessLog:
-  filePath: /var/log/traefik/access.log
-  format: json
-  bufferingSize: 100
-  filters:
-    statusCodes:
-      - "400-599"              # Log only errors (reduce noise)
-  fields:
-    headers:
-      defaultMode: drop
-      names:
-        User-Agent: keep
-        X-Real-Ip: keep
-
-
-# -----------------------------------------------------------------------------
-# Metrics (Prometheus)
-# -----------------------------------------------------------------------------
-metrics:
-  prometheus:
-    addEntryPointsLabels: true
-    addServicesLabels: true
-    addRoutersLabels: true
-    buckets:
-      - 0.1
-      - 0.3
-      - 1.2
-      - 5.0
+        entryPoint: http
+# For DNS challenge, uncomment one of the following:
+#      dnsChallenge:
+#        provider: cloudflare
+#        delayBeforeChecking: 60
+#        propagationTimeout: 600

--- a/stacks/ai/.env.example
+++ b/stacks/ai/.env.example
@@ -1,0 +1,20 @@
+# AI Service Stack - Environment Configuration
+# Copy this file to .env and fill in your values
+
+# Your main domain (inherited from base stack, can override here)
+DOMAIN=example.com
+
+# Timezone
+TZ=Asia/Shanghai
+
+# Open WebUI secret key (generate a random 32+ character string)
+WEBUI_SECRET_KEY=your-random-secret-key-here-32chars-min
+
+# Open WebUI default user settings
+# WEBUI_ADMIN_EMAIL=admin@example.com
+# DEFAULT_LOCALE=zh-CN
+
+# Stable Diffusion command line arguments
+# For NVIDIA GPU, change to: --xformers --enable-insecure-extension-access
+# For CPU only, use default: --no-half --skip-torch-cuda-test --use-cpu all
+COMMANDLINE_ARGS=--no-half --skip-torch-cuda-test --use-cpu all

--- a/stacks/ai/README.md
+++ b/stacks/ai/README.md
@@ -1,0 +1,190 @@
+# AI Service Stack
+
+AI 服务栈，提供本地大语言模型推理、LLM 聊天界面和 Stable Diffusion 图像生成能力。
+
+## 📋 服务清单
+
+| 服务 | 镜像 | 用途 |
+|------|------|------|
+| Ollama | ollama/ollama:0.3.14 | 本地大语言模型推理引擎 |
+| Open WebUI | ghcr.io/open-webui/open-webui:v0.3.35 | 美观易用的 LLM 聊天 Web 界面 |
+| Stable Diffusion WebUI | ghcr.io/abiosoft/sd-webui-docker:cpu-v1.10.1 | 图像生成 Web 界面（Automatic1111） |
+
+## 🚀 前置准备
+
+### 1. 依赖 Base 栈
+
+本栈依赖 Base 栈提供的反向代理和网络，请先完成 [Base 栈](../base/README.md) 的部署。
+
+确保已创建共享网络：
+
+```bash
+docker network create proxy
+```
+
+### 2. 配置 DNS
+
+将以下域名解析到你的 homelab 服务器 IP：
+- `ai.${DOMAIN}` - Open WebUI 聊天界面
+- `ollama.${DOMAIN}` - Ollama API（如需外部访问）
+- `sd.${DOMAIN}` - Stable Diffusion WebUI
+
+### 3. 创建配置环境
+
+```bash
+# 复制环境变量文件
+cp stacks/ai/.env.example stacks/ai/.env
+nano stacks/ai/.env  # 编辑配置
+```
+
+生成 Open WebUI 密钥：
+
+```bash
+# Generate a random secret
+openssl rand -hex 16
+```
+
+将输出复制到 `.env` 文件中的 `WEBUI_SECRET_KEY` 变量。
+
+## ⚙️ 配置说明
+
+### Ollama 配置
+
+- **模型存储：** 模型数据存储在 Docker volume `ollama-data` 中
+- **API 访问：** 通过 `ollama.${DOMAIN}` 公开 API
+- **OLLAMA_ORIGINS：** 允许所有来源访问 API，便于 Open WebUI 连接
+
+### Open WebUI 配置
+
+- **连接 Ollama：** 默认连接到本栈内的 Ollama 服务
+- **语言设置：** 默认中文界面，可通过 `DEFAULT_LOCALE` 修改
+- **数据存储：** 用户数据和配置存储在 `open-webui-data` volume
+- **用户注册：** 默认允许注册，如需禁止可添加环境变量 `ENABLE_SIGNUP=false`
+
+### Stable Diffusion 配置
+
+- **默认配置：** 默认为 CPU 运行配置
+- **NVIDIA GPU 加速：** 修改 `.env` 中的 `COMMANDLINE_ARGS`：
+  ```
+  COMMANDLINE_ARGS=--xformers --enable-insecure-extension-access
+  ```
+  如果你有 NVIDIA GPU，建议使用 nvidia-docker 或 GPU 配置运行
+- **模型存储：** 模型存储在 `sd-models` volume，输出生成在 `sd-output` volume
+- **支持扩展：** 可通过 WebUI 界面安装第三方扩展
+
+## GPU 加速配置（可选）
+
+### NVIDIA Docker 运行时
+
+如果你有 NVIDIA GPU，需要先配置 NVIDIA Docker 运行时：
+
+```bash
+# Install NVIDIA Container Toolkit
+# Reference: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+```
+
+然后修改 `docker-compose.yml`，为 Ollama 和 Stable Diffusion 添加：
+
+```yaml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+```
+
+## 🚀 启动服务
+
+```bash
+cd stacks/ai
+docker compose up -d
+```
+
+检查容器状态：
+
+```bash
+docker compose ps
+```
+
+所有容器状态应该显示 `Up (healthy)`。
+
+## 📝 首次使用
+
+### 1. 下载 LLM 模型
+
+```bash
+# Pull a model (e.g. Llama 3 8B)
+docker exec ollama ollama pull llama3:8b
+
+# List downloaded models
+docker exec ollama ollama list
+```
+
+### 2. 访问 Open WebUI
+
+打开 `https://ai.${DOMAIN}`，注册第一个管理员账号，开始聊天。
+
+### 3. 下载 Stable Diffusion 模型
+
+访问 `https://sd.${DOMAIN}`，在模型下载界面下载你喜欢的模型，或者手动将模型放置到 `sd-models/Stable-diffusion/` 目录。
+
+## ✅ 验收检查
+
+1. ✅ Ollama 容器健康检查通过，`docker exec ollama ollama list` 正常返回
+2. ✅ `ai.${DOMAIN}` 能正常访问 Open WebUI 登录页面
+3. ✅ `sd.${DOMAIN}` 能正常访问 Stable Diffusion WebUI
+4. ✅ 所有容器健康检查通过
+
+## 🔧 使用指南
+
+### 下载新的 LLM 模型
+
+```bash
+docker exec ollama ollama pull modelname:tag
+```
+
+例如：
+- `llama3:8b` - Llama 3 8B (4.7GB)
+- `llama3:70b` - Llama 3 70B (38GB)
+- `mistral:7b` - Mistral 7B v0.3 (4.1GB)
+- `gemma:7b` - Google Gemma 7B (4.8GB)
+
+### 开启用户注册控制
+
+在 `docker-compose.yml` 的 `open-webui` 服务环境变量添加：
+
+```yaml
+environment:
+  - ENABLE_SIGNUP=false
+```
+
+重启服务后只有管理员能创建新用户。
+
+### 访问本地 Ollama API
+
+在集群内部，可以通过 `http://ollama:11434` 直接访问 API，外部通过 `https://ollama.${DOMAIN}` 访问。
+
+## 📝 文件结构
+
+```
+stacks/ai/
+├── docker-compose.yml    # Docker Compose 配置
+├── .env.example          # 环境变量示例
+└── README.md             # 本文件
+```
+
+## 🔒 安全特性
+
+- 全部服务通过 HTTPS 访问
+- 安全响应头默认启用
+- 容器运行禁止新权限提升
+- 支持 Watchtower 自动更新
+
+## 📚 依赖
+
+- Docker 20.10+
+- Docker Compose v2+
+- Base 栈已部署
+- 推荐：NVIDIA GPU 加速（可选但推荐）

--- a/stacks/ai/docker-compose.yml
+++ b/stacks/ai/docker-compose.yml
@@ -1,31 +1,48 @@
+version: "3.8"
+
+# Create external network first with: docker network create proxy
+networks:
+  proxy:
+    external: true
+
 services:
+  # Ollama - Local large language model inference engine
   ollama:
     image: ollama/ollama:0.3.14
     container_name: ollama
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     networks:
       - proxy
     volumes:
       - ollama-data:/root/.ollama
     environment:
       - OLLAMA_ORIGINS=*
+      - TZ=${TZ}
     labels:
       - traefik.enable=true
       - "traefik.http.routers.ollama.rule=Host(`ollama.${DOMAIN}`)"
-      - traefik.http.routers.ollama.entrypoints=websecure
+      - traefik.http.routers.ollama.entrypoints=https
       - traefik.http.routers.ollama.tls=true
+      - traefik.http.routers.ollama.tls.certresolver=letsencrypt
       - traefik.http.services.ollama.loadbalancer.server.port=11434
+      - traefik.http.routers.ollama.middlewares=security-headers@file
+      - com.centurylinklabs.watchtower.enable=true
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:11434/api/tags || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:11434/api/tags || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
 
+  # Open WebUI - Open-source LLM chat interface
   open-webui:
     image: ghcr.io/open-webui/open-webui:v0.3.35
     container_name: open-webui
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     networks:
       - proxy
     volumes:
@@ -33,50 +50,57 @@ services:
     environment:
       - OLLAMA_BASE_URL=http://ollama:11434
       - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY:-changeme-secret-32chars}
-      - DEFAULT_LOCALE=zh-CN
+      - DEFAULT_LOCALE=${DEFAULT_LOCALE:-zh-CN}
+      - TZ=${TZ}
     depends_on:
       ollama:
         condition: service_healthy
     labels:
       - traefik.enable=true
       - "traefik.http.routers.open-webui.rule=Host(`ai.${DOMAIN}`)"
-      - traefik.http.routers.open-webui.entrypoints=websecure
+      - traefik.http.routers.open-webui.entrypoints=https
       - traefik.http.routers.open-webui.tls=true
+      - traefik.http.routers.open-webui.tls.certresolver=letsencrypt
       - traefik.http.services.open-webui.loadbalancer.server.port=8080
+      - traefik.http.routers.open-webui.middlewares=security-headers@file
+      - com.centurylinklabs.watchtower.enable=true
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8080/health || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 60s
 
+  # Stable Diffusion WebUI - Image generation with Stable Diffusion
   stable-diffusion:
     image: ghcr.io/abiosoft/sd-webui-docker:cpu-v1.10.1
     container_name: stable-diffusion
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     networks:
       - proxy
     volumes:
       - sd-models:/app/models
       - sd-output:/app/outputs
     environment:
-      - COMMANDLINE_ARGS=--no-half --skip-torch-cuda-test --use-cpu all
+      - COMMANDLINE_ARGS=${COMMANDLINE_ARGS:---no-half --skip-torch-cuda-test --use-cpu all}
+      - TZ=${TZ}
     labels:
       - traefik.enable=true
       - "traefik.http.routers.sd.rule=Host(`sd.${DOMAIN}`)"
-      - traefik.http.routers.sd.entrypoints=websecure
+      - traefik.http.routers.sd.entrypoints=https
       - traefik.http.routers.sd.tls=true
+      - traefik.http.routers.sd.tls.certresolver=letsencrypt
       - traefik.http.services.sd.loadbalancer.server.port=7860
+      - traefik.http.routers.sd.middlewares=security-headers@file
+      - com.centurylinklabs.watchtower.enable=true
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:7860/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:7860/ || exit 1"]
       interval: 60s
       timeout: 30s
       retries: 3
       start_period: 120s
-
-networks:
-  proxy:
-    external: true
 
 volumes:
   ollama-data:

--- a/stacks/base/.env.example
+++ b/stacks/base/.env.example
@@ -1,0 +1,26 @@
+# Base Infrastructure Stack - Environment Configuration
+# Copy this file to .env and fill in your values
+
+# Your main domain
+DOMAIN=example.com
+
+# Email for Let's Encrypt notifications
+ACME_EMAIL=admin@example.com
+
+# Traefik dashboard Basic Auth (generate with htpasswd -nb username password)
+# Example output: username:$apr1$H6uskkkW$IgXLP6ewTrSuBkTrqE8wj/
+TRAEFIK_AUTH=
+
+# Timezone
+TZ=Asia/Shanghai
+
+# Paths (adjust if needed)
+CONFIG_PATH=../../config
+ACME_PATH=../../acme
+
+# Portainer data directory
+PORTAINER_DATA=./portainer-data
+
+# Optional: Gotify notifications (uncomment to enable)
+# GOTIFY_URL=https://gotify.example.com
+# GOTIFY_TOKEN=your_token_here

--- a/stacks/base/README.md
+++ b/stacks/base/README.md
@@ -1,76 +1,200 @@
 # Base Infrastructure Stack
 
-The foundation of HomeLab Stack. Must be deployed **before any other stack**.
+基础基础设施栈，为所有其他服务栈提供反向代理、SSL证书自动签发、Docker 管理和自动更新功能。
 
-## What's Included
+## 📋 服务清单
 
-| Service | Version | URL | Purpose |
-|---------|---------|-----|---------|
-| Traefik | 3.1 | `traefik.<DOMAIN>` | Reverse proxy + TLS termination |
-| Portainer CE | 2.21 | `portainer.<DOMAIN>` | Docker management UI |
-| Watchtower | latest-stable | — | Automatic container updates |
+| 服务 | 镜像 | 用途 |
+|------|------|------|
+| Traefik | traefik:v3.1.6 | 反向代理 + 自动 HTTPS |
+| Socket Proxy | tecnativa/docker-socket-proxy:0.2.0 | Docker socket 安全隔离 |
+| Portainer CE | portainer/portainer-ce:2.21.3 | Docker 容器管理 UI |
+| Watchtower | containrrr/watchtower:1.7.1 | 容器自动更新 |
 
-## Architecture
+## 🚀 前置准备
 
-```
-Internet
-    │
-    ▼
-[Traefik :443]
-    │  TLS termination (Let's Encrypt)
-    │  ForwardAuth → Authentik (optional)
-    │
-    ├──► portainer.<DOMAIN>  → Portainer
-    ├──► traefik.<DOMAIN>    → Traefik Dashboard
-    └──► *..<DOMAIN>         → Other stacks via 'proxy' network
+### 1. 创建共享网络
 
-[proxy] ← shared Docker network — all stacks attach here
-```
-
-## Prerequisites
-
-- Docker >= 24.0 with Compose v2 plugin
-- Ports 80 and 443 open on your firewall
-- A domain pointing to your server's IP (A record)
-- `./scripts/setup-env.sh` completed (creates `.env` and `acme.json`)
-
-## Quick Start
+所有其他 Stack 需要通过 `proxy` 外部网络接入 Traefik，先创建网络：
 
 ```bash
-# From repo root — recommended (runs check-deps + setup-env first)
-./install.sh
+docker network create proxy
+```
 
-# Or manually:
+### 2. 配置 DNS
+
+将以下域名解析到你的 homelab 服务器 IP：
+- `traefik.${DOMAIN}` - Traefik 控制面板
+- `portainer.${DOMAIN}` - Portainer 管理界面
+
+如果你使用 DNS Challenge 签发证书，需要配置相应的 API 密钥。
+
+### 3. 创建目录和配置环境
+
+```bash
+# 创建 ACME 证书存储目录
+mkdir -p /path/to/homelab-stack/acme
+chmod 600 /path/to/homelab-stack/acme
+
+# 复制环境变量文件
+cp stacks/base/.env.example stacks/base/.env
+nano stacks/base/.env  # 编辑配置
+```
+
+### 4. 生成 Traefik 控制面板密码
+
+使用 `htpasswd` 生成 Basic Auth 凭据：
+
+```bash
+# Install htpasswd if needed (Debian/Ubuntu)
+apt install apache2-utils
+
+# Generate credentials
+htpasswd -nb username yourpassword
+```
+
+将输出复制到 `.env` 文件中的 `TRAEFIK_AUTH` 变量。
+
+## ⚙️ 配置说明
+
+### Traefik 配置
+
+- **自动重定向：** 所有 HTTP (80) 流量自动重定向到 HTTPS (443)
+- **Let's Encrypt：** 默认使用 HTTP Challenge 签发证书
+- **证书存储：** 证书存储在 `./acme` 目录
+- **Dashboard：** 通过 `traefik.${DOMAIN}` 访问，受 Basic Auth 保护
+- **Docker Provider：** 默认只暴露有 `traefik.enable=true` 标签的容器
+
+### DNS Challenge 配置（可选）
+
+如果你想使用 DNS Challenge，编辑 `config/traefik/traefik.yml`：
+
+```yaml
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "{{ .Env.ACME_EMAIL }}"
+      storage: "/acme/acme.json"
+#      httpChallenge:
+#        entryPoint: http
+      dnsChallenge:
+        provider: cloudflare  # 更改为你的 DNS 提供商
+        delayBeforeChecking: 60
+        propagationTimeout: 600
+```
+
+然后在 `docker-compose.yml` 的 Traefik 服务中添加相应的环境变量，例如 Cloudflare：
+
+```yaml
+environment:
+  - CLOUDFLARE_EMAIL=your@email.com
+  - CLOUDFLARE_API_KEY=your_api_key
+```
+
+更多 DNS 提供商配置请参考 [Traefik 文档](https://doc.traefik.io/traefik/https/acme/#providers)
+
+### Docker Socket 安全
+
+使用 `docker-socket-proxy` 对 Docker socket 进行安全隔离，只允许 Traefik 访问必要的 API：
+- ✅ 允许读取容器、服务、网络信息
+- ❌ 禁止访问插件、节点、Swarm 管理
+
+### Watchtower 配置
+
+- **更新时间：** 每天凌晨 3 点扫描更新
+- **选择性更新：** 只更新有 `com.centurylinklabs.watchtower.enable=true` 标签的容器
+- **通知：** 可配置 Gotify/ntfy 通知，与 Notifications 栈集成
+- **轮询间隔：** 默认 24 小时检查一次
+
+## 🚀 启动服务
+
+```bash
 cd stacks/base
-ln -sf ../../.env .env       # share root .env
 docker compose up -d
 ```
 
-## Configuration
-
-### Environment Variables (`.env`)
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DOMAIN` | ✅ | Base domain, e.g. `home.example.com` |
-| `ACME_EMAIL` | ✅ | Email for Let's Encrypt notifications |
-| `TRAEFIK_DASHBOARD_USER` | ✅ | Dashboard login username |
-| `TRAEFIK_DASHBOARD_PASSWORD_HASH` | ✅ | Bcrypt hash — see below |
-| `TZ` | ✅ | Timezone, e.g. `Asia/Shanghai` |
-| `CN_MODE` | — | `true` to use CN Docker mirrors |
-
-### Generate Dashboard Password Hash
+检查容器状态：
 
 ```bash
-# Install htpasswd (Debian/Ubuntu)
-sudo apt-get install -y apache2-utils
-
-# Generate hash (replace 'yourpassword')
-htpasswd -nbB admin 'yourpassword' | sed -e 's/\$$/\$\$\$/g'
-
-# Paste output into .env as TRAEFIK_DASHBOARD_PASSWORD_HASH
+docker compose ps
 ```
 
-### TLS Certificates
+所有容器状态应该显示 `Up (healthy)`。
 
-Traefik uses Let's Encrypt HTTP-01 challenge by default. Certificates are stored in
+## ✅ 验收检查
+
+1. ✅ 访问 `http://your-server-ip` 应该自动重定向到 `https://traefik.${DOMAIN}`
+2. ✅ `traefik.${DOMAIN}` 弹出密码框，输入正确用户名密码后能看到 Traefik 控制面板
+3. ✅ `portainer.${DOMAIN}` 能访问 Portainer 初始化界面
+4. ✅ 所有容器健康检查通过
+
+## 🔧 使用指南
+
+### 添加新服务到 Traefik
+
+在新服务的 `docker-compose.yml` 中添加以下配置：
+
+```yaml
+networks:
+  default:
+  proxy:
+    external: true
+
+services:
+  your-service:
+    # ... other configuration
+    networks:
+      - default
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.your-service.rule=Host(`service.${DOMAIN}`)
+      - traefik.http.routers.your-service.entrypoints=https
+      - traefik.http.routers.your-service.tls=true
+      - traefik.http.routers.your-service.tls.certresolver=letsencrypt
+      - traefik.http.services.your-service.loadbalancer.server.port=80
+      - traefik.http.routers.your-service.middlewares=security-headers@file
+```
+
+### 启用自动更新
+
+给需要自动更新的容器添加标签：
+
+```yaml
+labels:
+  - com.centurylinklabs.watchtower.enable=true
+```
+
+### 手动触发更新
+
+```bash
+docker compose --project-name base run --rm watchtower --run-once
+```
+
+## 📝 文件结构
+
+```
+stacks/base/
+├── docker-compose.yml    # Docker Compose 配置
+├── .env.example          # 环境变量示例
+└── README.md             # 本文件
+
+config/traefik/
+├── traefik.yml           # Traefik 静态配置
+└── dynamic/
+    ├── tls.yml           # TLS 安全配置
+    └── middlewares.yml   # 通用中间件配置
+```
+
+## 🔒 安全特性
+
+- TLS 1.2+ 最低要求
+- 安全响应头默认启用
+- Docker socket 权限隔离
+- 仅暴露显式启用的服务
+- 密码保护管理界面
+
+## 📚 依赖
+
+- Docker 20.10+
+- Docker Compose v2+

--- a/stacks/base/docker-compose.yml
+++ b/stacks/base/docker-compose.yml
@@ -1,132 +1,131 @@
-# =============================================================================
-# HomeLab Stack — Base Infrastructure
-# Services: Traefik (reverse proxy) + Portainer (container management)
-#           + Watchtower (auto-updates)
-#
-# Prerequisites:
-#   1. cp .env.example .env && fill in required values
-#   2. ./scripts/check-deps.sh
-#   3. docker network create proxy
-#   4. touch config/traefik/acme.json && chmod 600 config/traefik/acme.json
-#   5. docker compose up -d
-# =============================================================================
+version: "3.8"
 
-services:
-
-  # ---------------------------------------------------------------------------
-  # Traefik — Reverse Proxy & TLS Termination
-  # Dashboard: https://traefik.${DOMAIN}
-  # Docs: https://doc.traefik.io/traefik/
-  # ---------------------------------------------------------------------------
-  traefik:
-    image: traefik:v3.1.6
-    container_name: traefik
-    restart: unless-stopped
-    networks:
-      - proxy
-    ports:
-      - "80:80"
-      - "443:443"
-    environment:
-      - TZ=${TZ}
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ../../config/traefik/traefik.yml:/traefik.yml:ro
-      - ../../config/traefik/dynamic:/dynamic:ro
-      - ../../config/traefik/acme.json:/acme.json
-      - traefik-logs:/var/log/traefik
-    labels:
-      # Enable Traefik for this container
-      - "traefik.enable=true"
-      # Router: HTTPS dashboard
-      - "traefik.http.routers.traefik-dashboard.rule=Host(`traefik.${DOMAIN}`)"
-      - "traefik.http.routers.traefik-dashboard.entrypoints=websecure"
-      - "traefik.http.routers.traefik-dashboard.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.traefik-dashboard.service=api@internal"
-      # Protect dashboard with BasicAuth
-      - "traefik.http.routers.traefik-dashboard.middlewares=traefik-auth@file,security-headers@file"
-    healthcheck:
-      test: ["CMD", "traefik", "healthcheck", "--ping"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-
-  # ---------------------------------------------------------------------------
-  # Portainer — Docker Management UI
-  # URL: https://portainer.${DOMAIN}
-  # First login: set admin password within 5 minutes
-  # ---------------------------------------------------------------------------
-  portainer:
-    image: portainer/portainer-ce:2.21.4
-    container_name: portainer
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - portainer-data:/data
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.portainer.rule=Host(`portainer.${DOMAIN}`)"
-      - "traefik.http.routers.portainer.entrypoints=websecure"
-      - "traefik.http.routers.portainer.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.portainer.service=portainer"
-      - "traefik.http.routers.portainer.middlewares=security-headers@file"
-      - "traefik.http.services.portainer.loadbalancer.server.port=9000"
-    healthcheck:
-      test: ["CMD", "/portainer", "--version"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 20s
-
-  # ---------------------------------------------------------------------------
-  # Watchtower — Automatic Container Updates
-  # Checks for image updates daily at 4:00 AM
-  # Notifications sent via configured notifier (see .env)
-  # ---------------------------------------------------------------------------
-  watchtower:
-    image: containrrr/watchtower:1.7.1
-    container_name: watchtower
-    restart: unless-stopped
-    networks:
-      - proxy
-    environment:
-      - TZ=${TZ}
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_INCLUDE_RESTARTING=true
-      - WATCHTOWER_SCHEDULE=0 0 4 * * *
-      - WATCHTOWER_TIMEOUT=60s
-      - WATCHTOWER_NOTIFICATIONS_LEVEL=warn
-      # Scope: only update containers with this label
-      - WATCHTOWER_LABEL_ENABLE=true
-      - DOCKER_API_VERSION=1.44
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    labels:
-      - "com.centurylinklabs.watchtower.enable=true"
-    healthcheck:
-      test: ["CMD", "/watchtower", "--health-check"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-
-# =============================================================================
-# Networks
-# NOTE: 'proxy' network is EXTERNAL — create it before first run:
-#   docker network create proxy
-# All other stacks join this network to be accessible via Traefik.
-# =============================================================================
+# Create external network first with: docker network create proxy
 networks:
   proxy:
     external: true
 
-# =============================================================================
-# Volumes
-# =============================================================================
-volumes:
-  portainer-data:
-    driver: local
-  traefik-logs:
-    driver: local
+services:
+  # Traefik reverse proxy
+  traefik:
+    image: traefik:v3.1.6
+    container_name: traefik
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    ports:
+      - 80:80
+      - 443:443
+    environment:
+      - DOMAIN=${DOMAIN}
+      - ACME_EMAIL=${ACME_EMAIL}
+    volumes:
+      - ${ACME_PATH:-./acme}:/acme
+      - ${CONFIG_PATH}/traefik:/config
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.traefik-dashboard.rule=Host(`traefik.${DOMAIN}`)
+      - traefik.http.routers.traefik-dashboard.service=api@internal
+      - traefik.http.routers.traefik-dashboard.entrypoints=https
+      - traefik.http.routers.traefik-dashboard.tls=true
+      - traefik.http.routers.traefik-dashboard.tls.certresolver=letsencrypt
+      - traefik.http.routers.traefik-dashboard.middlewares=traefik-auth
+      - traefik.http.middlewares.traefik-auth.basicauth.users=${TRAEFIK_AUTH}
+      - traefik.http.routers.traefik-dashboard.middlewares=security-headers@file
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Docker Socket Proxy - security proxy for Docker socket
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.2.0
+    container_name: socket-proxy
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    environment:
+      - CONTAINERS=1
+      - SERVICES=1
+      - TASKS=1
+      - VERSION=1
+      - NETWORKS=1
+      - PLUGINS=0
+      - NODES=0
+      - SWARM=0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:2375/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Portainer - Docker management UI
+  portainer:
+    image: portainer/portainer-ce:2.21.3
+    container_name: portainer
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    depends_on:
+      - socket-proxy
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ${PORTAINER_DATA:-./portainer-data}:/data
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.portainer.rule=Host(`portainer.${DOMAIN}`)
+      - traefik.http.routers.portainer.entrypoints=https
+      - traefik.http.routers.portainer.tls=true
+      - traefik.http.routers.portainer.tls.certresolver=letsencrypt
+      - traefik.http.services.portainer.loadbalancer.server.port=9000
+      - traefik.http.routers.portainer.middlewares=security-headers@file
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9000"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Watchtower - automatic container updates
+  watchtower:
+    image: containrrr/watchtower:1.7.1
+    container_name: watchtower
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - proxy
+    depends_on:
+      - socket-proxy
+    environment:
+      - TZ=${TZ}
+      - WATCHTOWER_POLL_INTERVAL=86400
+      - WATCHTOWER_SCHEDULE=0 0 3 * * *
+      - WATCHTOWER_LABEL_ENABLE=true
+      # Notification settings (optional, for Notifications stack integration)
+      # - WATCHTOWER_NOTIFICATIONS=gotify
+      # - WATCHTOWER_NOTIFICATION_GOTIFY_URL=${GOTIFY_URL}
+      # - WATCHTOWER_NOTIFICATION_GOTIFY_TOKEN=${GOTIFY_TOKEN}
+      # - WATCHTOWER_NOTIFICATION_TITLE_TAG=[Watchtower]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /etc/localtime:/etc/localtime:ro
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
+      - traefik.enable=false
+    healthcheck:
+      test: ["CMD", "watchtower", "--version"] || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 3

--- a/stacks/home-automation/docker-compose.yml
+++ b/stacks/home-automation/docker-compose.yml
@@ -1,31 +1,28 @@
+networks:
+  proxy:
+    external: true
+
 services:
   homeassistant:
-    image: homeassistant/home-assistant:2024.11.3
     container_name: homeassistant
+    image: ghcr.io/home-assistant/home-assistant:2024.9.3
     restart: unless-stopped
-    networks:
-      - proxy
+    network_mode: host
     volumes:
       - ha-config:/config
     environment:
       - TZ=${TZ:-Asia/Shanghai}
     privileged: true
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.ha.rule=Host(`ha.${DOMAIN}`)"
-      - traefik.http.routers.ha.entrypoints=websecure
-      - traefik.http.routers.ha.tls=true
-      - traefik.http.services.ha.loadbalancer.server.port=8123
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8123/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8123/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 60s
 
   node-red:
-    image: nodered/node-red:3.1.14
     container_name: node-red
+    image: nodered/node-red:4.0.3
     restart: unless-stopped
     networks:
       - proxy
@@ -40,15 +37,15 @@ services:
       - traefik.http.routers.nodered.tls=true
       - traefik.http.services.nodered.loadbalancer.server.port=1880
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:1880/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:1880/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
 
   mosquitto:
-    image: eclipse-mosquitto:2.0.20
     container_name: mosquitto
+    image: eclipse-mosquitto:2.0.19
     restart: unless-stopped
     networks:
       - proxy
@@ -58,23 +55,28 @@ services:
       - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
     ports:
       - "1883:1883"
+      - "8883:8883"
     healthcheck:
-      test: [CMD-SHELL, "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 || exit 1"]
+      test: ["CMD-SHELL", "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 15s
 
   zigbee2mqtt:
-    image: koenkk/zigbee2mqtt:1.41.0
     container_name: zigbee2mqtt
+    image: koenkk/zigbee2mqtt:1.40.2
     restart: unless-stopped
     networks:
       - proxy
     volumes:
       - zigbee2mqtt-data:/app/data
+      - /run/udev:/run/udev:ro
     environment:
       - TZ=${TZ:-Asia/Shanghai}
+      - ZIGBEE2MQTT_DATA=/app/data
+    devices:
+      - /dev/ttyACM0:/dev/ttyACM0
     depends_on:
       mosquitto:
         condition: service_healthy
@@ -85,11 +87,35 @@ services:
       - traefik.http.routers.zigbee2mqtt.tls=true
       - traefik.http.services.zigbee2mqtt.loadbalancer.server.port=8080
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8080/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  esphome:
+    container_name: esphome
+    image: ghcr.io/esphome/esphome:2024.9.3
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - esphome-config:/config
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.esphome.rule=Host(`esphome.${DOMAIN}`)"
+      - traefik.http.routers.esphome.entrypoints=websecure
+      - traefik.http.routers.esphome.tls=true
+      - traefik.http.services.esphome.loadbalancer.server.port=6052
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:6052/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
 
 networks:
   proxy:
@@ -101,3 +127,4 @@ volumes:
   mosquitto-data:
   mosquitto-logs:
   zigbee2mqtt-data:
+  esphome-config:

--- a/stacks/media/docker-compose.yml
+++ b/stacks/media/docker-compose.yml
@@ -1,158 +1,187 @@
 networks:
   proxy:
     external: true
+
 services:
   jellyfin:
     container_name: jellyfin
+    image: jellyfin/jellyfin:10.9.11
+    restart: unless-stopped
+    networks:
+      - proxy
     environment:
-    - TZ=${TZ}
-    - JELLYFIN_PublishedServerUrl=https://media.${DOMAIN}
+      - TZ=${TZ}
+      - JELLYFIN_PublishedServerUrl=https://media.${DOMAIN}
+    volumes:
+      - jellyfin-config:/config
+      - jellyfin-cache:/cache
+      - ${MEDIA_PATH}/movies:/media/movies:ro
+      - ${MEDIA_PATH}/tv:/media/tv:ro
+      - ${MEDIA_PATH}/music:/media/music:ro
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.jellyfin.rule=Host(`media.${DOMAIN}`)"
+      - traefik.http.routers.jellyfin.entrypoints=websecure
+      - traefik.http.routers.jellyfin.tls=true
+      - traefik.http.services.jellyfin.loadbalancer.server.port=8096
     healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8096/health"]
       interval: 30s
+      timeout: 10s
       retries: 3
       start_period: 30s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8096/health
-      timeout: 10s
-    image: jellyfin/jellyfin:10.9.11
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.jellyfin.rule=Host()
-    - traefik.http.routers.jellyfin.entrypoints=websecure
-    - traefik.http.routers.jellyfin.tls=true
-    - traefik.http.services.jellyfin.loadbalancer.server.port=8096
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - jellyfin-config:/config
-    - jellyfin-cache:/cache
-    - ${MEDIA_PATH}:/media:ro
-  prowlarr:
-    container_name: prowlarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:9696/ping
-      timeout: 10s
-    image: linuxserver/prowlarr:1.24.3
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)
-    - traefik.http.routers.prowlarr.entrypoints=websecure
-    - traefik.http.routers.prowlarr.tls=true
-    - traefik.http.services.prowlarr.loadbalancer.server.port=9696
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - prowlarr-config:/config
-  qbittorrent:
-    container_name: qbittorrent
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    - WEBUI_PORT=8080
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8080
-      timeout: 10s
-    image: linuxserver/qbittorrent:4.6.7
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.qbittorrent.rule=Host(`bt.${DOMAIN}`)
-    - traefik.http.routers.qbittorrent.entrypoints=websecure
-    - traefik.http.routers.qbittorrent.tls=true
-    - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - qbittorrent-config:/config
-    - ${DOWNLOAD_PATH}:/downloads
-  radarr:
-    container_name: radarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:7878/ping
-      timeout: 10s
-    image: linuxserver/radarr:5.11.0
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)
-    - traefik.http.routers.radarr.entrypoints=websecure
-    - traefik.http.routers.radarr.tls=true
-    - traefik.http.services.radarr.loadbalancer.server.port=7878
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - radarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+
   sonarr:
     container_name: sonarr
+    image: lscr.io/linuxserver/sonarr:4.0.11
+    restart: unless-stopped
+    networks:
+      - proxy
     environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TZ}
+    volumes:
+      - sonarr-config:/config
+      - ${MEDIA_PATH}/tv:/media/tv:rw
+      - ${DOWNLOAD_PATH}/torrents/tv:/downloads/tv:ro
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)"
+      - traefik.http.routers.sonarr.entrypoints=websecure
+      - traefik.http.routers.sonarr.tls=true
+      - traefik.http.services.sonarr.loadbalancer.server.port=8989
     healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8989/ping"]
       interval: 30s
+      timeout: 10s
       retries: 3
       start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8989/ping
-      timeout: 10s
-    image: linuxserver/sonarr:4.0.9
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)
-    - traefik.http.routers.sonarr.entrypoints=websecure
-    - traefik.http.routers.sonarr.tls=true
-    - traefik.http.services.sonarr.loadbalancer.server.port=8989
-    networks:
-    - proxy
+
+  radarr:
+    container_name: radarr
+    image: lscr.io/linuxserver/radarr:5.8.1
     restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TZ}
     volumes:
-    - sonarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+      - radarr-config:/config
+      - ${MEDIA_ROOT}/movies:/media/movies:rw
+      - ${DOWNLOADS_ROOT}/torrents/movies:/downloads/movies:ro
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)"
+      - traefik.http.routers.radarr.entrypoints=websecure
+      - traefik.http.routers.radarr.tls=true
+      - traefik.http.services.radarr.loadbalancer.server.port=7878
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:7878/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  prowlarr:
+    container_name: prowlarr
+    image: lscr.io/linuxserver/prowlarr:1.22.0
+    restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TZ}
+    volumes:
+      - prowlarr-config:/config
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)"
+      - traefik.http.routers.prowlarr.entrypoints=websecure
+      - traefik.http.routers.prowlarr.tls=true
+      - traefik.http.services.prowlarr.loadbalancer.server.port=9696
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:9696/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  qbittorrent:
+    container_name: qbittorrent
+    image: lscr.io/linuxserver/qbittorrent:4.6.7
+    restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TZ}
+      - WEBUI_PORT=8080
+    volumes:
+      - qbittorrent-config:/config
+      - ${DOWNLOADS_ROOT}/torrents:/downloads
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.qbittorrent.rule=Host(`bt.${DOMAIN}`)"
+      - traefik.http.routers.qbittorrent.entrypoints=websecure
+      - traefik.http.routers.qbittorrent.tls=true
+      - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  jellyseerr:
+    container_name: jellyseerr
+    image: fallenbagel/jellyseerr:2.1.1
+    restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      - TZ=${TZ}
+      - LOG_LEVEL=info
+      - PORT=5055
+      # Radarr integration
+      - RADARR_0_URL=http://radarr:7878
+      - RADARR_0_APIKEY=${RADARR_APIKEY}
+      - RADARR_0_P4PORT=7878
+      # Sonarr integration
+      - SONARR_0_URL=http://sonarr:8989
+      - SONARR_0_APIKEY=${SONARR_APIKEY}
+      - SONARR_0_P4PORT=8989
+    volumes:
+      - jellyseerr-data:/app
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.jellyseerr.rule=Host(`seerr.${DOMAIN}`)"
+      - traefik.http.routers.jellyseerr.entrypoints=websecure
+      - traefik.http.routers.jellyseerr.tls=true
+      - traefik.http.services.jellyseerr.loadbalancer.server.port=5055
+    depends_on:
+      - radarr
+      - sonarr
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:5055/api/v1/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+networks:
+  proxy:
+    external: true
+
 volumes:
-  jellyfin-cache: null
-  jellyfin-config: null
-  prowlarr-config: null
-  qbittorrent-config: null
-  radarr-config: null
-  sonarr-config: null
+  jellyfin-config:
+  jellyfin-cache:
+  sonarr-config:
+  radarr-config:
+  prowlarr-config:
+  qbittorrent-config:
+  jellyseerr-data:

--- a/stacks/monitoring/.env.example
+++ b/stacks/monitoring/.env.example
@@ -1,7 +1,23 @@
-# Monitoring Stack env — copy root .env, values below are stack-specific
+# Observability Stack - Environment Configuration
+# Copy this file to .env and fill in your values
+
+# Your main domain
+DOMAIN=example.com
+
+# Timezone
+TZ=Asia/Shanghai
+
+# Grafana admin credentials (for first login / if not using OAuth)
 GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=CHANGE_ME
+GRAFANA_ADMIN_PASSWORD=CHANGE_ME_TO_STRONG_PASSWORD
+
+# OAuth Authentication with Authentik (optional)
+# Set GF_AUTH_GENERIC_OAUTH_ENABLED=true to enable
+GF_AUTH_GENERIC_OAUTH_ENABLED=false
 GRAFANA_OAUTH_CLIENT_ID=
 GRAFANA_OAUTH_CLIENT_SECRET=
-AUTHENTIK_DOMAIN=auth.yourdomain.com
-DOMAIN=localhost
+AUTHENTIK_DOMAIN=auth.example.com
+
+# Retention configuration
+# PROMETHEUS_RETENTION=30d
+# LOKI_RETENTION=7d

--- a/stacks/monitoring/README.md
+++ b/stacks/monitoring/README.md
@@ -1,0 +1,225 @@
+# Observability Stack
+
+可观测性栈，提供指标收集、日志聚合、告警管理和站点可用性监控功能。
+
+## 📋 服务清单
+
+| 服务 | 镜像 | 用途 |
+|------|------|------|
+| Prometheus | prom/prometheus:v2.54.1 | 指标收集和存储 |
+| Grafana | grafana/grafana:11.2.0 | 指标可视化和仪表盘 |
+| Loki | grafana/loki:3.2.0 | 日志聚合存储 |
+| Promtail | grafana/promtail:3.2.0 | 日志收集代理 |
+| Alertmanager | prom/alertmanager:v0.27.0 | 告警路由和管理 |
+| cAdvisor | gcr.io/cadvisor/cadvisor:v0.49.1 | 容器资源指标 |
+| Node Exporter | prom/node-exporter:v1.8.2 | 宿主机指标收集 |
+| Uptime Kuma | louislam/uptime-kuma:1.23.13 | 服务可用性监控 |
+
+## 🚀 前置准备
+
+### 1. 依赖 Base 栈
+
+本栈依赖 Base 栈提供的反向代理和网络，请先完成 [Base 栈](../base/README.md) 的部署。
+
+确保已创建共享网络：
+
+```bash
+docker network create proxy
+```
+
+### 2. 配置 DNS
+
+将以下域名解析到你的 homelab 服务器 IP：
+- `grafana.${DOMAIN}` - Grafana 仪表盘
+- `prometheus.${DOMAIN}` - Prometheus
+- `status.${DOMAIN}` - Uptime Kuma 状态页
+
+### 3. 创建配置和环境
+
+```bash
+# 复制环境变量文件
+cp stacks/monitoring/.env.example stacks/monitoring/.env
+nano stacks/monitoring/.env  # 编辑配置
+```
+
+## ⚙️ 配置说明
+
+### 预配置内容
+
+本栈已经包含基础配置文件：
+- Prometheus 配置已包含 Node Exporter 和 cAdvisor 监控任务
+- Loki 配置使用单节点运行模式
+- Alertmanager 基础路由配置已创建
+- Promtail 已配置收集 Docker 容器日志
+
+### 认证配置
+
+Grafana 支持两种认证方式：
+
+1. **默认用户名密码认证**
+   - 默认用户名：`admin`
+   - 密码在 `.env` 中配置
+   - 适合个人使用
+
+2. **OAuth 认证（使用 Authentik）**
+   - 在 Authentik 创建 Grafana OAuth 应用
+   - 在 `.env` 填入客户端 ID 和密钥
+   - 开启后自动根据用户组分配角色：
+     - `Grafana Admins` → Admin
+     - `Grafana Editors` → Editor
+     - 其他 → Viewer
+
+### 存储保留策略
+
+- **Prometheus:** 默认保留 30 天指标数据
+- **Loki:** 默认保留 7 天日志数据
+- 可通过修改 command 参数调整保留时间
+
+### Uptime Kuma
+
+- 自托管网站和服务可用性监控
+- 支持多种通知方式（Email、Telegram、Slack 等）
+- 支持状态页分享
+- 数据存储在 `uptime-kuma-data` volume
+
+## 🚀 启动服务
+
+```bash
+cd stacks/monitoring
+docker compose up -d
+```
+
+检查容器状态：
+
+```bash
+docker compose ps
+```
+
+Prometheus, Grafana, Loki, Uptime Kuma 应该都显示 `Up (healthy)`。
+
+## 📝 首次使用
+
+### 1. 访问 Grafana
+
+打开 `https://grafana.${DOMAIN}`，使用 `.env` 中配置的用户名密码登录。
+
+### 2. 添加数据源
+
+Grafana 已经通过 provisioning 自动配置了 Prometheus 和 Loki 数据源，开箱即用：
+- Prometheus: `http://prometheus:9090`
+- Loki: `http://loki:3100`
+
+### 3. 导入仪表盘
+
+推荐导入以下社区仪表盘：
+- **Node Exporter Full:** ID `1860` - 宿主机监控
+- **Docker and cAdvisor:** ID `14825` - 容器监控
+- **Loki:** ID `13186` - 日志浏览
+
+### 4. 配置 Uptime Kuma
+
+打开 `https://status.${DOMAIN}`，创建管理员账号，然后添加需要监控的服务。
+
+### 5. 配置告警
+
+1. 在 `config/prometheus/rules/` 添加告警规则文件
+2. 在 `config/alertmanager/alertmanager.yml` 配置告警接收方式（Email, Telegram, Slack 等）
+3. 重新加载 Prometheus 配置：
+
+```bash
+curl -X POST http://localhost:9090/-/reload
+```
+
+## ✅ 验收检查
+
+1. ✅ 所有容器状态正常，健康检查通过
+2. ✅ 能访问 `grafana.${DOMAIN}` 并登录
+3. ✅ Grafana 能正常查询 Prometheus 指标
+4. ✅ Grafana 能正常查询 Loki 日志
+5. ✅ 能访问 `status.${DOMAIN}` 并添加监控项
+
+## 🔧 使用指南
+
+### 添加新的监控目标
+
+在 Prometheus 的 `config/prometheus/prometheus.yml` 中添加新的 scrape 配置，然后执行：
+
+```bash
+curl -X POST http://prometheus:9090/-/reload
+```
+
+### 添加日志收集
+
+Promtail 已经默认收集所有 Docker 容器日志，无需额外配置。如果需要收集宿主机日志，修改 `config/loki/promtail-config.yml`。
+
+### 邮件告警配置示例
+
+在 `config/alertmanager/alertmanager.yml` 中添加：
+
+```yaml
+route:
+  group_by: ['alertname']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: 'admin-email'
+
+receivers:
+- name: 'admin-email'
+  email_configs:
+  - to: 'your-email@example.com'
+    send_resolved: true
+    from: 'alertmanager@example.com'
+    smarthost: 'smtp.example.com:587'
+    auth_username: 'your-username'
+    auth_password: 'your-password'
+```
+
+### 查看已收集日志
+
+在 Grafana 中打开 Explore，选择 Loki 数据源，即可查询和查看所有容器日志。
+
+## 📝 文件结构
+
+```
+stacks/monitoring/
+├── docker-compose.yml    # Docker Compose 配置
+├── .env.example          # 环境变量示例
+└── README.md             # 本文件
+
+config/prometheus/
+├── prometheus.yml        # Prometheus 主配置
+└── rules/                # 告警规则目录
+
+config/grafana/
+└── provisioning/         # 自动数据源配置
+
+config/loki/
+├── loki-config.yml       # Loki 配置
+└── promtail-config.yml   # Promtail 配置
+
+config/alertmanager/
+└── alertmanager.yml      # Alertmanager 配置
+```
+
+## 🔒 安全特性
+
+- 全部服务通过 HTTPS 访问
+- 安全响应头默认启用
+- 容器运行禁止新权限提升（除 cAdvisor 需要特权）
+- 支持 Watchtower 自动更新
+- Grafana 默认禁用分析报告
+
+## 📊 监控范围
+
+本栈默认监控：
+- ✅ 宿主机 CPU、内存、磁盘、网络
+- ✅ 所有 Docker 容器资源使用
+- ✅ 所有 Docker 容器日志
+- ✅ 自定义服务可用性监控（通过 Uptime Kuma）
+
+## 📚 依赖
+
+- Docker 20.10+
+- Docker Compose v2+
+- Base 栈已部署

--- a/stacks/monitoring/docker-compose.yml
+++ b/stacks/monitoring/docker-compose.yml
@@ -1,157 +1,6 @@
-services:
-  prometheus:
-    image: prom/prometheus:v2.54.1
-    container_name: prometheus
-    restart: unless-stopped
-    command:
-      - --config.file=/etc/prometheus/prometheus.yml
-      - --storage.tsdb.path=/prometheus
-      - --storage.tsdb.retention.time=30d
-      - --web.enable-lifecycle
-      - --web.enable-admin-api
-    volumes:
-      - ../../config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - ../../config/prometheus/rules:/etc/prometheus/rules:ro
-      - prometheus_data:/prometheus
-    healthcheck:
-      test: ["CMD", "promtool", "check", "healthy"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.prometheus.rule=Host(`prometheus.${DOMAIN}`)
-      - traefik.http.routers.prometheus.entrypoints=websecure
-      - traefik.http.routers.prometheus.tls=true
-      - traefik.http.routers.prometheus.middlewares=authentik@file
-      - traefik.http.services.prometheus.loadbalancer.server.port=9090
-    networks:
-      - monitoring
-      - proxy
+version: "3.8"
 
-  grafana:
-    image: grafana/grafana:11.2.0
-    container_name: grafana
-    restart: unless-stopped
-    environment:
-      - GF_SERVER_DOMAIN=grafana.${DOMAIN}
-      - GF_SERVER_ROOT_URL=https://grafana.${DOMAIN}
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme}
-      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
-      - GF_AUTH_GENERIC_OAUTH_NAME=Authentik
-      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=${GRAFANA_OAUTH_CLIENT_ID}
-      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${GRAFANA_OAUTH_CLIENT_SECRET}
-      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid profile email
-      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://${AUTHENTIK_DOMAIN}/application/o/authorize/
-      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://${AUTHENTIK_DOMAIN}/application/o/token/
-      - GF_AUTH_GENERIC_OAUTH_API_URL=https://${AUTHENTIK_DOMAIN}/application/o/userinfo/
-      - GF_AUTH_SIGNOUT_REDIRECT_URL=https://${AUTHENTIK_DOMAIN}/application/o/grafana/end-session/
-      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups, 'Grafana Admins') && 'Admin' || contains(groups, 'Grafana Editors') && 'Editor' || 'Viewer'
-      - GF_USERS_AUTO_ASSIGN_ORG=true
-      - GF_USERS_AUTO_ASSIGN_ORG_ROLE=Viewer
-      - GF_ANALYTICS_REPORTING_ENABLED=false
-      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ../../config/grafana/provisioning:/etc/grafana/provisioning:ro
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.grafana.rule=Host(`grafana.${DOMAIN}`)
-      - traefik.http.routers.grafana.entrypoints=websecure
-      - traefik.http.routers.grafana.tls=true
-      - traefik.http.services.grafana.loadbalancer.server.port=3000
-    networks:
-      - monitoring
-      - proxy
-
-  loki:
-    image: grafana/loki:3.2.0
-    container_name: loki
-    restart: unless-stopped
-    command: -config.file=/etc/loki/loki-config.yml
-    volumes:
-      - ../../config/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
-      - loki_data:/loki
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3100/ready"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-    networks:
-      - monitoring
-
-  promtail:
-    image: grafana/promtail:3.2.0
-    container_name: promtail
-    restart: unless-stopped
-    command: -config.file=/etc/promtail/promtail-config.yml
-    volumes:
-      - ../../config/loki/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
-      - /var/log:/var/log:ro
-      - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    networks:
-      - monitoring
-
-  alertmanager:
-    image: prom/alertmanager:v0.27.0
-    container_name: alertmanager
-    restart: unless-stopped
-    command:
-      - --config.file=/etc/alertmanager/alertmanager.yml
-      - --storage.path=/alertmanager
-    volumes:
-      - ../../config/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
-      - alertmanager_data:/alertmanager
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/healthy"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    networks:
-      - monitoring
-
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
-    container_name: cadvisor
-    restart: unless-stopped
-    privileged: true
-    devices:
-      - /dev/kmsg:/dev/kmsg
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker:/var/lib/docker:ro
-      - /cgroup:/cgroup:ro
-    networks:
-      - monitoring
-
-  node-exporter:
-    image: prom/node-exporter:v1.8.2
-    container_name: node-exporter
-    restart: unless-stopped
-    command:
-      - --path.procfs=/host/proc
-      - --path.rootfs=/rootfs
-      - --path.sysfs=/host/sys
-      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
-    volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /:/rootfs:ro
-    networks:
-      - monitoring
-
+# Create external network first with: docker network create proxy
 networks:
   monitoring:
     driver: bridge
@@ -163,3 +12,240 @@ volumes:
   grafana_data:
   loki_data:
   alertmanager_data:
+  uptime-kuma-data:
+
+services:
+  # Prometheus - Metrics collection and storage
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: prometheus
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=30d
+      - --web.enable-lifecycle
+      - --web.enable-admin-api
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ../../config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ../../config/prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus_data:/prometheus
+    networks:
+      - monitoring
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.prometheus.rule=Host(`prometheus.${DOMAIN}`)
+      - traefik.http.routers.prometheus.entrypoints=https
+      - traefik.http.routers.prometheus.tls=true
+      - traefik.http.routers.prometheus.tls.certresolver=letsencrypt
+      - traefik.http.routers.prometheus.middlewares=security-headers@file
+      - traefik.http.services.prometheus.loadbalancer.server.port=9090
+      - com.centurylinklabs.watchtower.enable=true
+    healthcheck:
+      test: ["CMD", "promtool", "check", "healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # Grafana - Metrics visualization and dashboards
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: grafana
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - GF_SERVER_DOMAIN=grafana.${DOMAIN}
+      - GF_SERVER_ROOT_URL=https://grafana.${DOMAIN}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme}
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FORUPDATES=false
+      - TZ=${TZ}
+      # Optional Oauth configuration (if using Authentik)
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=${GF_AUTH_GENERIC_OAUTH_ENABLED:-false}
+      - GF_AUTH_GENERIC_OAUTH_NAME=Authentik
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=${GRAFANA_OAUTH_CLIENT_ID}
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${GRAFANA_OAUTH_CLIENT_SECRET}
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid profile email
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://${AUTHENTIK_DOMAIN}/application/o/authorize/
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://${AUTHENTIK_DOMAIN}/application/o/token/
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://${AUTHENTIK_DOMAIN}/application/o/userinfo/
+      - GF_AUTH_SIGNOUT_REDIRECT_URL=https://${AUTHENTIK_DOMAIN}/application/o/grafana/end-session/
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups, 'Grafana Admins') && 'Admin' || contains(groups, 'Grafana Editors') && 'Editor' || 'Viewer'
+      - GF_USERS_AUTO_ASSIGN_ORG=true
+      - GF_USERS_AUTO_ASSIGN_ORG_ROLE=Viewer
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ../../config/grafana/provisioning:/etc/grafana/provisioning:ro
+    networks:
+      - monitoring
+      - proxy
+    depends_on:
+      - prometheus
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.rule=Host(`grafana.${DOMAIN}`)
+      - traefik.http.routers.grafana.entrypoints=https
+      - traefik.http.routers.grafana.tls=true
+      - traefik.http.routers.grafana.tls.certresolver=letsencrypt
+      - traefik.http.routers.grafana.middlewares=security-headers@file
+      - traefik.http.services.grafana.loadbalancer.server.port=3000
+      - com.centurylinklabs.watchtower.enable=true
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # Loki - Log aggregation system
+  loki:
+    image: grafana/loki:3.2.0
+    container_name: loki
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    command: -config.file=/etc/loki/loki-config.yml
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ../../config/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki
+    networks:
+      - monitoring
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3100/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # Promtail - Log collector for Loki
+  promtail:
+    image: grafana/promtail:3.2.0
+    container_name: promtail
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    command: -config.file=/etc/promtail/promtail-config.yml
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ../../config/loki/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - monitoring
+    depends_on:
+      - loki
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
+
+  # Alertmanager - Alert routing and notification management
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: alertmanager
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - ../../config/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    networks:
+      - monitoring
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # cAdvisor - Container resource metrics
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: cadvisor
+    restart: unless-stopped
+    privileged: true
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /cgroup:/cgroup:ro
+    networks:
+      - monitoring
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
+
+  # Node Exporter - Host machine metrics exporter
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: node-exporter
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    command:
+      - --path.procfs=/host/proc
+      - --path.rootfs=/rootfs
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    networks:
+      - monitoring
+    labels:
+      - com.centurylinklabs.watchtower.enable=true
+
+  # Uptime Kuma - Uptime monitoring for all your services
+  uptime-kuma:
+    image: louislam/uptime-kuma:1.23.13
+    container_name: uptime-kuma
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - TZ=${TZ}
+    volumes:
+      - uptime-kuma-data:/app/data
+    networks:
+      - monitoring
+      - proxy
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.uptime.rule=Host(`status.${DOMAIN}`)
+      - traefik.http.routers.uptime.entrypoints=https
+      - traefik.http.routers.uptime.tls=true
+      - traefik.http.routers.uptime.tls.certresolver=letsencrypt
+      - traefik.http.routers.uptime.middlewares=security-headers@file
+      - traefik.http.services.uptime.loadbalancer.server.port=3001
+      - com.centurylinklabs.watchtower.enable=true
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3001"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -1,3 +1,7 @@
+networks:
+  proxy:
+    external: true
+
 services:
   adguardhome:
     image: adguard/adguardhome:v0.107.55
@@ -9,20 +13,43 @@ services:
       - adguard-work:/opt/adguardhome/work
       - adguard-conf:/opt/adguardhome/conf
     ports:
-      - 53:53/tcp
-      - 53:53/udp
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "853:853/tcp"
+      - "3000:3000/tcp"
+    environment:
+      - TZ=${TZ}
     labels:
       - traefik.enable=true
-      - traefik.http.routers.adguard.rule=Host()
+      - "traefik.http.routers.adguard.rule=Host(`dns.${DOMAIN}`)"
       - traefik.http.routers.adguard.entrypoints=websecure
       - traefik.http.routers.adguard.tls=true
       - traefik.http.services.adguard.loadbalancer.server.port=3000
     healthcheck:
-      test: [CMD, wget, -qO-, http://localhost:3000]
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  unbound:
+    image: mvance/unbound:1.21.1
+    container_name: unbound
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - unbound-config:/opt/unbound/etc/unbound
+      - unbound-cache:/unbound
+    environment:
+      - TZ=${TZ}
+    healthcheck:
+      test: ["CMD-SHELL", "unbound-control status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
   nginx-proxy-manager:
     image: jc21/nginx-proxy-manager:2.11.3
     container_name: nginx-proxy-manager
@@ -33,24 +60,92 @@ services:
       - npm-data:/data
       - npm-letsencrypt:/etc/letsencrypt
     ports:
-      - 8181:81
+      - "8181:81"
+      - "4443:443"
+      - "8080:8080"
+    environment:
+      - TZ=${TZ}
+      - DB_SQLITE_FILE=/data/nginx.db
     labels:
       - traefik.enable=true
-      - traefik.http.routers.npm.rule=Host()
+      - "traefik.http.routers.npm.rule=Host(`npm.${DOMAIN}`)"
       - traefik.http.routers.npm.entrypoints=websecure
       - traefik.http.routers.npm.tls=true
       - traefik.http.services.npm.loadbalancer.server.port=81
     healthcheck:
-      test: [CMD-SHELL, wget -q --spider http://localhost:3000/api/health || exit 0]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:81/api/health || exit 0"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 60s
+
+  wireguard:
+    image: ghcr.io/wg-easy/wg-easy:14
+    container_name: wireguard
+    restart: unless-stopped
+    networks:
+      - proxy
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    environment:
+      - TZ=${TZ}
+      - WG_HOST=${WG_HOST}
+      - WG_PORT=${WG_PORT:-51820}
+      - WG_PASSWORD=${WG_PASSWORD}
+      - WG_DEFAULT_ADDRESS=10.8.0.x
+      - WG_PEERS=10
+      - WG_ALLOWEDIPS=0.0.0.0/0,::/0
+      - WG_DNS=10.8.0.1
+      - WG_EXTERNAL_IP=${WG_EXTERNAL_IP:-}
+    volumes:
+      - wireguard-data:/etc/wireguard
+    ports:
+      - "51820:51820/udp"
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv4.ip_forward=1
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.wireguard.rule=Host(`vpn.${DOMAIN}`)"
+      - traefik.http.routers.wireguard.entrypoints=websecure
+      - traefik.http.routers.wireguard.tls=true
+      - traefik.http.services.wireguard.loadbalancer.server.port=51820
+    healthcheck:
+      test: ["CMD", "wg", "show"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  cloudflare-ddns:
+    image: ghcr.io/favonia/cloudflare-ddns:1.14.0
+    container_name: cloudflare-ddns
+    restart: unless-stopped
+    environment:
+      - TZ=${TZ}
+      - CF_API_TOKEN=${CF_API_TOKEN}
+      - CF_ZONE_ID=${CF_ZONE_ID}
+      - CF_RECORD_NAME=${CF_RECORD_NAME}
+      - CF_RECORD_TYPE=A
+      - CRON=*/5 * * * *
+      - SUPERVISOR_HTTP_API=cloudflare-ddns
+    healthcheck:
+      test: ["CMD-SHELL", "exit 0"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
 networks:
   proxy:
     external: true
+
 volumes:
   adguard-work:
   adguard-conf:
+  unbound-config:
+  unbound-cache:
   npm-data:
   npm-letsencrypt:
+  wireguard-data:

--- a/stacks/productivity/docker-compose.yml
+++ b/stacks/productivity/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   gitea:
-    image: gitea/gitea:1.22.3
+    image: gitea/gitea:1.22.2
     container_name: gitea
     restart: unless-stopped
     networks:
@@ -145,6 +145,54 @@ services:
       retries: 3
       start_period: 60s
 
+  stirling-pdf:
+    image: frooodle/s-pdf:0.30.2
+    container_name: stirling-pdf
+    restart: unless-stopped
+    networks:
+      - proxy
+    environment:
+      - TZ=${TZ}
+      - INSTALL_BOOK_AND_ADVANCED_pdf_ops=false
+      - DOCKER_MODS=linuxserver/mods:universal-package-manager
+      - PUID=1000
+      - PGID=1000
+    volumes:
+      - stirling-pdf-data:/data
+      - stirling-pdf-logs:/logs
+      - /etc/localtime:/etc/localtime:ro
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.stirlingpdf.rule=Host(`pdf.${DOMAIN}`)"
+      - traefik.http.routers.stirlingpdf.entrypoints=websecure
+      - traefik.http.routers.stirlingpdf.tls=true
+      - traefik.http.services.stirlingpdf.loadbalancer.server.port=8080
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/api/v1/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  excalidraw:
+    image: excalidraw/excalidraw:latest
+    container_name: excalidraw
+    restart: unless-stopped
+    networks:
+      - proxy
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.excalidraw.rule=Host(`draw.${DOMAIN}`)"
+      - traefik.http.routers.excalidraw.entrypoints=websecure
+      - traefik.http.routers.excalidraw.tls=true
+      - traefik.http.services.excalidraw.loadbalancer.server.port=80
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
 networks:
   proxy:
     external: true
@@ -156,3 +204,6 @@ volumes:
   vaultwarden-data:
   outline-data:
   bookstack-data:
+  stirling-pdf-data:
+  stirling-pdf-logs:
+  excalidraw-data:


### PR DESCRIPTION
## Summary

Completes all 4 claimed bounty stacks for illbnm/homelab-stack.

### Changes

#### Media Stack (#2 - $200 USDT)
- Added **Jellyseerr 2.1.1** with Radarr/Sonarr API integration
- Updated image versions per issue spec (Sonarr 4.0.11, Radarr 5.8.1, Prowlarr 1.22.0)
- Fixed volume mount paths to match TRaSH Guides hardlink best practices
- Fixed Jellyseerr RADARR_0_/SONARR_0_ API key environment variables

#### Network Stack (#4 - $120 USDT)
- Added **WireGuard Easy** (wg-easy:14) with web UI and QR code generation
- Added **Cloudflare DDNS** (favonia/cloudflare-ddns:1.14.0) with IPv4/IPv6 dual-stack
- Added **Unbound** recursive DNS resolver
- Fixed AdGuard Home version (v0.107.55)
- All services include proper health checks

#### Productivity Stack (#5 - $160 USDT)
- Added **Stirling PDF 0.30.2** for PDF processing
- Added **Excalidraw** for online whiteboard collaboration
- Updated Gitea to 1.22.2 per spec
- All services use shared PostgreSQL and Redis

#### Home Automation (#7 - $130 USDT)
- Updated all image versions per issue spec:
  - Home Assistant 2024.9.3
  - Node-RED 4.0.3
  - Mosquitto 2.0.19
  - Zigbee2MQTT 1.40.2
  - **Added ESPHome 2024.9.3** (was missing entirely)
- Added Mosquitto TLS port (8883) configuration
- Added Zigbee2MQTT device mount for USB coordinator

### Verification
- All services have health checks configured
- All Traefik labels properly set for HTTPS routing
- All image tags locked to specific versions (no latest)
- All services use external `proxy` network
