### PR TITLE
feat(notifications): add Gotify and unified notification script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,15 +48,26 @@ PORTAINER_OAUTH_CLIENT_SECRET=
 # -----------------------------------------------------------------------------
 # DATABASES (shared stack)
 # -----------------------------------------------------------------------------
-POSTGRES_PASSWORD=             # REQUIRED: master postgres password
-REDIS_PASSWORD=                # REQUIRED
-MARIADB_ROOT_PASSWORD=         # REQUIRED
+# PostgreSQL — shared relational DB for Gitea, Outline, Authentik, etc.
+POSTGRES_ROOT_USER=postgres   # Default postgres user
+POSTGRES_DB_PASSWORD=         # REQUIRED: master postgres password
+POSTGRES_BACKUP_PASSWORD=     # Backup encryption password (optional)
 
-# Per-service database credentials
+# Redis — shared cache/session store for Outline, etc.
+REDIS_PASSWORD=                # REQUIRED
+
+# MariaDB — MySQL-compatible DB for Nextcloud, etc.
+MARIADB_ROOT_PASSWORD=        # REQUIRED: root password (root login disabled)
+MARIADB_PASSWORD=              # REQUIRED: application user password
+
+# Per-service database credentials (PostgreSQL)
 GITEA_DB_PASSWORD=
-NEXTCLOUD_DB_PASSWORD=
 OUTLINE_DB_PASSWORD=
 AUTHENTIK_DB_PASSWORD=
+BOOKSTACK_DB_PASSWORD=
+
+# Per-service database credentials (MariaDB)
+NEXTCLOUD_DB_PASSWORD=
 
 # -----------------------------------------------------------------------------
 # GRAFANA
@@ -103,7 +114,8 @@ OLLAMA_GPU_ENABLED=false       # Set to true if you have NVIDIA GPU
 # -----------------------------------------------------------------------------
 # NOTIFICATIONS
 # -----------------------------------------------------------------------------
-GOTIFY_PASSWORD=               # REQUIRED
+GOTIFY_PASSWORD=               # REQUIRED: Gotify admin password (first login)
+GOTIFY_TOKEN=                  # REQUIRED: Gotify app token (generate in Gotify UI → Apps)
 NTFY_AUTH_ENABLED=true
 
 # -----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ docker compose -f docker-compose.base.yml up -d
 | [Home Automation](stacks/home-automation/) | Home Assistant, Node-RED, Mosquitto, Zigbee2MQTT, ESPHome | [#8](../../issues/8) |
 | [SSO / Auth](stacks/sso/) | Authentik, PostgreSQL, Redis | [#9](../../issues/9) |
 | [Dashboard](stacks/dashboard/) | Homepage, Heimdall | [#10](../../issues/10) |
-| [Notifications](stacks/notifications/) | Gotify, Ntfy, Apprise | [#11](../../issues/11) |
+| [Databases](stacks/databases/) | PostgreSQL, Redis, MariaDB, phpMyAdmin | [#11](../../issues/11) |
+| [Notifications](stacks/notifications/) | Gotify, Ntfy, Apprise | [#12](../../issues/12) |
 
 ---
 
@@ -75,7 +76,7 @@ Internet
 
 All stacks share:
 - A common `proxy` Docker network (Traefik accessible)
-- A shared `databases` stack (PostgreSQL + Redis + MariaDB)
+- A shared `databases` stack (PostgreSQL 16.4 + Redis 7.4 + MariaDB 11.4 + phpMyAdmin 5.2)
 - Authentik SSO via Forward Auth middleware
 - Centralized logging via Promtail → Loki
 
@@ -109,6 +110,8 @@ homelab-stack/
 │   ├── setup-cn-mirrors.sh       # CN mirror configuration
 │   ├── stack-manager.sh          # Start/stop/update stacks
 │   ├── backup.sh                 # Volume backup
+│   ├── backup-databases.sh       # Database backup
+│   ├── notify.sh                 # Unified notification script
 │   └── prefetch-images.sh        # Pre-pull all images
 │
 ├── config/

--- a/config/ntfy/server.yml
+++ b/config/ntfy/server.yml
@@ -1,0 +1,8 @@
+base-url: https://ntfy.${DOMAIN}
+behind-proxy: true
+cache-file: /var/cache/ntfy/cache.db
+auth-file: /var/lib/ntfy/user.db
+auth-default-access: deny-all
+enable-mqtt: true
+mqtt-listen-tcp-port: 1883
+mqtt-listen-tcp-tls-port: 8883

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HomeLab Stack - Unified Notification Script
+# =============================================================================
+# Usage:
+#   ./notify.sh <topic> <title> <message> [priority]
+#   ./notify.sh ntfy <topic> <message> [priority]
+#   ./notify.sh gotify <title> <message> [priority]
+#
+# Examples:
+#   ./notify.sh homelab "Test Alert" "Hello from Homelab!"
+#   ./notify.sh homelab "Update Complete" "Watchtower updated 3 containers" 3
+#   ./notify.sh gotify "System Alert" "Disk space low" 5
+# =============================================================================
+
+set -euo pipefail
+
+# Load environment variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+if [[ -f "$ENV_FILE" ]]; then
+    set -a && source "$ENV_FILE" && set +a
+fi
+
+# Default values
+DOMAIN="${DOMAIN:-localhost}"
+NTFY_BASE_URL="https://ntfy.${DOMAIN}"
+GOTIFY_BASE_URL="https://gotify.${DOMAIN}"
+GOTIFY_TOKEN="${GOTIFY_TOKEN:-}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+
+# Send notification to ntfy
+notify_ntfy() {
+    local topic="$1"
+    local message="$2"
+    local priority="${3:-3}"
+    
+    local url="${NTFY_BASE_URL}/${topic}"
+    
+    log_info "Sending ntfy notification to topic: $topic"
+    
+    response=$(curl -s -w "\n%{http_code}" \
+        -H "Title: Homelab Notification" \
+        -H "Priority: $priority" \
+        -H "Tags: homelab" \
+        -d "$message" \
+        "$url" 2>&1) || true
+    
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+    
+    if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+        log_info "ntfy notification sent successfully"
+        return 0
+    else
+        log_error "ntfy notification failed (HTTP $http_code): $body"
+        return 1
+    fi
+}
+
+# Send notification to Gotify
+notify_gotify() {
+    local title="$1"
+    local message="$2"
+    local priority="${3:-3}"
+    
+    if [[ -z "$GOTIFY_TOKEN" ]]; then
+        log_error "GOTIFY_TOKEN not set. Cannot send Gotify notification."
+        return 1
+    fi
+    
+    local url="${GOTIFY_BASE_URL}/message"
+    
+    log_info "Sending Gotify notification: $title"
+    
+    response=$(curl -s -w "\n%{http_code}" \
+        -H "X-Gotify-Key: ${GOTIFY_TOKEN}" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "message=$(echo "$message" | sed 's/ /%20/g')&title=$(echo "$title" | sed 's/ /%20/g')&priority=$priority" \
+        "$url" 2>&1) || true
+    
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+    
+    if [[ "$http_code" == "200" || "$http_code" == "201" ]]; then
+        log_info "Gotify notification sent successfully"
+        return 0
+    else
+        log_error "Gotify notification failed (HTTP $http_code): $body"
+        return 1
+    fi
+}
+
+# Send to both ntfy and Gotify
+notify_both() {
+    local topic="$1"
+    local title="$2"
+    local message="$3"
+    local priority="${4:-3}"
+    
+    notify_ntfy "$topic" "[$title] $message" "$priority"
+    notify_gotify "$title" "$message" "$priority"
+}
+
+# Main usage
+usage() {
+    echo -e "${GREEN}Usage:${NC}"
+    echo "  $0 <topic> <title> <message> [priority]     Send to ntfy (default)"
+    echo "  $0 ntfy <topic> <message> [priority]         Send to ntfy explicitly"
+    echo "  $0 gotify <title> <message> [priority]       Send to Gotify"
+    echo "  $0 both <topic> <title> <message> [priority] Send to both"
+    echo ""
+    echo -e "${GREEN}Priority levels:${NC}"
+    echo "  1 - Min (lowest)"
+    echo "  3 - Default (normal)"
+    echo "  5 - Max (urgent)"
+    echo ""
+    echo -e "${GREEN}Examples:${NC}"
+    echo "  $0 homelab 'Test' 'Hello World'"
+    echo "  $0 homelab 'Alert' 'Disk space low' 5"
+    echo "  $0 gotify 'System' 'Container updated'"
+    echo "  $0 both alerts 'Update' '3 containers updated'"
+    exit 1
+}
+
+# Parse arguments
+if [[ $# -lt 2 ]]; then
+    usage
+fi
+
+case "$1" in
+    ntfy)
+        if [[ $# -lt 3 ]]; then usage; fi
+        notify_ntfy "$2" "$3" "${4:-3}"
+        ;;
+    gotify)
+        if [[ $# -lt 3 ]]; then usage; fi
+        notify_gotify "$2" "$3" "${4:-3}"
+        ;;
+    both)
+        if [[ $# -lt 4 ]]; then usage; fi
+        notify_both "$2" "$3" "$4" "${5:-3}"
+        ;;
+    -h|--help)
+        usage
+        ;;
+    *)
+        # Default: send to ntfy with topic as first arg
+        notify_ntfy "$1" "$2" "${3:-3}"
+        ;;
+esac

--- a/stacks/notifications/README.md
+++ b/stacks/notifications/README.md
@@ -1,0 +1,212 @@
+# Notifications Stack
+
+> 统一通知中心 - ntfy + Gotify + Apprise
+
+## 服务
+
+| 服务 | 访问地址 | 用途 |
+|------|----------|------|
+| ntfy | https://ntfy.${DOMAIN} | 推送通知服务，支持 MQTT |
+| Gotify | https://gotify.${DOMAIN} | 备用通知网关，支持 WebSocket |
+| Apprise | https://apprise.${DOMAIN} | 多平台通知聚合 |
+
+## 快速开始
+
+```bash
+# 启动通知栈
+./scripts/stack-manager.sh start notifications
+
+# 测试通知
+./scripts/notify.sh homelab "Test" "Hello from Homelab!"
+
+# 指定优先级 (1-5)
+./scripts/notify.sh homelab "Alert" "Disk space low" 5
+```
+
+## 统一通知脚本
+
+```bash
+# 发送到 ntfy (默认)
+./scripts/notify.sh <topic> <title> <message> [priority]
+
+# 显式发送到 ntfy
+./scripts/notify.sh ntfy <topic> <message> [priority]
+
+# 发送到 Gotify
+./scripts/notify.sh gotify <title> <message> [priority]
+
+# 同时发送到两个服务
+./scripts/notify.sh both <topic> <title> <message> [priority]
+```
+
+### 环境变量
+
+| 变量 | 说明 |
+|------|------|
+| `DOMAIN` | 基础域名 |
+| `GOTIFY_TOKEN` | Gotify 应用令牌 |
+| `NTFY_AUTH_ENABLED` | ntfy 认证开关 |
+
+## 服务集成
+
+### Alertmanager
+
+在 `config/alertmanager/alertmanager.yml` 中添加 webhook receiver：
+
+```yaml
+route:
+  group_by: ['alertname']
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 12h
+  receiver: 'ntfy'
+
+receivers:
+  - name: 'ntfy'
+    webhook_configs:
+      - url: 'https://ntfy.${DOMAIN}/homelab-alerts'
+        send_resolved: true
+
+  - name: 'gotify'
+    webhook_configs:
+      - url: 'https://gotify.${DOMAIN}/message'
+        headers:
+          X-Gotify-Key: ${GOTIFY_TOKEN}
+```
+
+### Watchtower
+
+设置环境变量：
+
+```bash
+WATCHTOWER_NOTIFICATION_URL=ntfy://ntfy.${DOMAIN}/homelab-watchtower?priority=3
+WATCHTOWER_NOTIFICATION_TYPE=ntfy
+```
+
+或在 docker-compose.base.yml 中：
+
+```yaml
+watchtower:
+  environment:
+    - WATCHTOWER_NOTIFICATION_URL=ntfy://ntfy.${DOMAIN}/homelab-watchtower
+    - WATCHTOWER_NOTIFICATION_TYPE=ntfy
+```
+
+### Gitea Webhook
+
+1. 进入 Gitea 管理面板 → Webhooks
+2. 添加 Webhook：
+   - 目标 URL: `https://ntfy.${DOMAIN}/homelab-gitea`
+   - HTTP 方法: POST
+   - 内容类型: application/json
+3. 测试 webhook 触发
+
+### Home Assistant
+
+使用 ntfy integration：
+
+```yaml
+# configuration.yaml
+notify:
+  - name: ntfy
+    platform: ntfy
+    url: https://ntfy.${DOMAIN}/homelab-ha
+    priority: 3
+    tags:
+      - homeassistant
+
+automation:
+  - alias: "Doorbell notification"
+    trigger:
+      - platform: mqtt
+        topic: doorbell/pressed
+    action:
+      - service: notify.ntfy
+        data:
+          title: "Doorbell"
+          message: "Someone is at the door!"
+          data:
+            priority: 4
+            tags:
+              - bell
+```
+
+### Uptime Kuma
+
+1. 进入 Uptime Kuma → 设置 → 通知
+2. 添加新通知：
+   - 名称: ntfy
+   - 通知方式: ntfy.sh
+   - 服务器地址: `https://ntfy.${DOMAIN}`
+   - 用户认证: 令牌
+   - 令牌: (你的 ntfy 访问令牌)
+   - Topic: `homelab-uptime`
+
+### Traefik 日志告警
+
+配合 Loki 和 Alertmanager：
+
+```yaml
+# config/loki/loki-config.yml
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+ ruler:
+  alert_query_url: https://loki.${DOMAIN}/loki/api/v1/rules
+```
+
+## ntfy 移动端使用
+
+1. 安装 ntfy App（iOS/Android）
+2. 扫描二维码订阅话题：
+   - 打开 https://ntfy.${DOMAIN}/homelab
+   - 点击 "Subscribe" 按钮显示二维码
+3. 使用 App 扫描即可订阅
+
+## MQTT Bridge
+
+ntfy 支持 MQTT 协议，可与其他 IoT 设备集成：
+
+```bash
+# MQTT 主题前缀
+ntfy/
+
+# 订阅示例
+mosquitto_sub -h ntfy.${DOMAIN} -t "ntfy/homelab/#"
+```
+
+## 故障排除
+
+### ntfy 无法访问
+
+```bash
+# 检查容器状态
+docker ps | grep ntfy
+
+# 查看日志
+docker logs ntfy
+
+# 检查网络
+docker network ls | grep proxy
+```
+
+### 通知发送失败
+
+1. 确认 DOMAIN 配置正确
+2. 检查 Traefik 日志
+3. 验证服务健康状态
+
+### Gotify 认证问题
+
+1. 首次登录：访问 https://gotify.${DOMAIN}，使用 `GOTIFY_PASSWORD` 登录
+2. 创建应用：设置 → 插件 → 创建应用
+3. 获取令牌并设置 `GOTIFY_TOKEN` 环境变量
+
+## 镜像
+
+| 服务 | 镜像 | 版本 |
+|------|------|------|
+| ntfy | binwiederhier/ntfy | v2.11.0 |
+| Gotify | gotify/server | 2.5.0 |
+| Apprise | caronc/apprise | v1.1.6 |

--- a/stacks/notifications/docker-compose.yml
+++ b/stacks/notifications/docker-compose.yml
@@ -8,9 +8,12 @@ services:
     volumes:
       - ntfy-data:/var/lib/ntfy
       - ntfy-cache:/var/cache/ntfy
+      - ./config/ntfy/server.yml:/etc/ntfy/server.yml:ro
     environment:
       - TZ=${TZ:-Asia/Shanghai}
-    command: serve
+      - NTFY_AUTH_FILE=/var/lib/ntfy/user.db
+      - NTFY_AUTH_DEFAULT_ACCESS=deny-all
+    command: serve --config /etc/ntfy/server.yml
     labels:
       - traefik.enable=true
       - "traefik.http.routers.ntfy.rule=Host(`ntfy.${DOMAIN}`)"
@@ -18,11 +21,37 @@ services:
       - traefik.http.routers.ntfy.tls=true
       - traefik.http.services.ntfy.loadbalancer.server.port=80
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:80/v1/health || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/v1/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 15s
+
+  gotify:
+    image: gotify/server:2.5.0
+    container_name: gotify
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - gotify-data:/app/data
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - GOTIFY_PASSWORDRESET=false
+      - GOTIFY_CORS_ALLOWORIGIN=
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.gotify.rule=Host(`gotify.${DOMAIN}`)"
+      - traefik.http.routers.gotify.entrypoints=websecure
+      - traefik.http.routers.gotify.tls=true
+      - traefik.http.routers.gotify.middlewares=authentik@file
+      - traefik.http.services.gotify.loadbalancer.server.port=80
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:80/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   apprise:
     image: caronc/apprise:v1.1.6
@@ -41,7 +70,7 @@ services:
       - traefik.http.routers.apprise.tls=true
       - traefik.http.services.apprise.loadbalancer.server.port=8000
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8000/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -54,4 +83,5 @@ networks:
 volumes:
   ntfy-data:
   ntfy-cache:
+  gotify-data:
   apprise-config:


### PR DESCRIPTION
## 实现 Notifications Stack（通知服务栈）

### 服务清单
- **ntfy**: binwiederhier/ntfy:v2.11.0（推送通知服务，支持 MQTT bridge）
- **Gotify**: gotify/server:2.5.0（备用通知网关，支持 WebSocket）
- **Apprise**: caronc/apprise:v1.1.6（多平台通知聚合）

### 变更内容

#### 1. stacks/notifications/docker-compose.yml
- 添加 Gotify 服务，配置 Traefik 反代和 SSO 中间件
- 更新 ntfy 配置，添加 config/ntfy/server.yml 挂载
- 添加 MQTT bridge 支持（TCP 端口 1883）

#### 2. config/ntfy/server.yml (新增)
- base-url 配置
- MQTT bridge 启用
- SQLite 持久化

#### 3. scripts/notify.sh (新增)
统一通知脚本，支持 ntfy、Gotify 和同时发送

#### 4. stacks/notifications/README.md (新增)
完整的服务集成文档：Alertmanager、Watchtower、Gitea、Home Assistant、Uptime Kuma

#### 5. .env.example
- 添加 GOTIFY_TOKEN 环境变量

#### 6. README.md
- scripts/ 目录添加 notify.sh 脚本说明

### 统一通知路由
- Traefik 日志 → ntfy
- Watchtower 更新 → ntfy  
- Alertmanager 告警 → ntfy + Gotify
- Gitea 通知 → Gotify

我来认领