### PR TITLE
[BOUNTY $180] Base Infrastructure — Add Docker Socket Proxy

### DIFF
--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -81,9 +81,10 @@ certificatesResolvers:
 # -----------------------------------------------------------------------------
 providers:
   docker:
-    endpoint: "unix:///var/run/docker.sock"
+    # Use socket-proxy for secure Docker API access (replaces direct socket mount)
+    endpoint: "http://socket-proxy:2375"
     exposedByDefault: false    # Containers must opt-in with traefik.enable=true
-    network: proxy             # Default network for routing
+    network: proxy              # Default network for routing
     watch: true
 
   file:

--- a/stacks/base/README.md
+++ b/stacks/base/README.md
@@ -9,6 +9,7 @@ The foundation of HomeLab Stack. Must be deployed **before any other stack**.
 | Traefik | 3.1 | `traefik.<DOMAIN>` | Reverse proxy + TLS termination |
 | Portainer CE | 2.21 | `portainer.<DOMAIN>` | Docker management UI |
 | Watchtower | latest-stable | — | Automatic container updates |
+| Docker Socket Proxy | 0.2.0 | internal | Secure Docker API proxy (no public URL) |
 
 ## Architecture
 
@@ -22,10 +23,26 @@ Internet
     │
     ├──► portainer.<DOMAIN>  → Portainer
     ├──► traefik.<DOMAIN>    → Traefik Dashboard
-    └──► *..<DOMAIN>         → Other stacks via 'proxy' network
+    └──► *.<DOMAIN>           → Other stacks via 'proxy' network
+
+[socket-proxy] ←── Traefik reads container labels via this secure proxy
+    │
+    └──► /var/run/docker.sock (restricted API — no dangerous ops)
 
 [proxy] ← shared Docker network — all stacks attach here
 ```
+
+## Security: Docker Socket Proxy
+
+Traefik accesses the Docker API through `socket-proxy` instead of the raw socket. This
+provides defense-in-depth:
+
+- **Read-only API**: Traefik can only list containers and read metadata — it cannot
+  create, destroy, or modify containers
+- **No exec access**: Even if Traefik is compromised, attackers cannot use the Docker
+  socket to escape to the host
+- **Portainer exception**: Portainer retains direct socket access (full API) since it
+  needs it for container management
 
 ## Prerequisites
 
@@ -74,3 +91,42 @@ htpasswd -nbB admin 'yourpassword' | sed -e 's/\$$/\$\$\$/g'
 ### TLS Certificates
 
 Traefik uses Let's Encrypt HTTP-01 challenge by default. Certificates are stored in
+`config/traefik/acme.json` (created automatically on first run).
+
+### DNS Configuration
+
+Point your domain's A record to your server IP. For subdomains used by other stacks
+(e.g. `portainer.<DOMAIN>`, `traefik.<DOMAIN>`), add corresponding CNAME or A records.
+
+### Container Update Labels
+
+Other stacks inherit the base network automatically. To enable Traefik routing and
+Watchtower updates, add these labels to your containers:
+
+```yaml
+services:
+  my-service:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.my-service.rule=Host(`my-service.${DOMAIN}`)"
+      - "traefik.http.routers.my-service.entrypoints=websecure"
+      - "traefik.http.routers.my-service.tls.certresolver=letsencrypt"
+      # Watchtower update scope (add to .env of the stack):
+      # WATCHTOWER_LABEL_ENABLE=true
+```
+
+## Troubleshooting
+
+### Traefik dashboard returns 404
+
+Ensure the container has `traefik.enable=true` label and is on the `proxy` network.
+
+### Socket proxy connection errors in Traefik logs
+
+Verify `socket-proxy` container is running: `docker ps | grep socket-proxy`. If it's
+not running, check logs with `docker logs socket-proxy`.
+
+### Certificates not issued
+
+Ensure port 80 is open and accessible. Let's Encrypt HTTP-01 challenge requires port 80
+to be reachable from the internet.

--- a/stacks/base/docker-compose.yml
+++ b/stacks/base/docker-compose.yml
@@ -1,7 +1,7 @@
 # =============================================================================
 # HomeLab Stack — Base Infrastructure
 # Services: Traefik (reverse proxy) + Portainer (container management)
-#           + Watchtower (auto-updates)
+#           + Watchtower (auto-updates) + Docker Socket Proxy (security)
 #
 # Prerequisites:
 #   1. cp .env.example .env && fill in required values
@@ -12,6 +12,35 @@
 # =============================================================================
 
 services:
+
+  # ---------------------------------------------------------------------------
+  # Docker Socket Proxy — Secure Docker API Proxy
+  # Provides read-only Docker API access to Traefik over TCP.
+  # Blocks dangerous operations (container deletion, image removal, etc.)
+  # Docs: https://github.com/Tecnativa/docker-socket-proxy
+  # ---------------------------------------------------------------------------
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.2.0
+    container_name: socket-proxy
+    restart: unless-stopped
+    networks:
+      - proxy
+    expose:
+      - "2375"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      # Restrict to only what Traefik Docker provider needs
+      - CONTAINERS=1
+      - INFO=1
+      - VERSION=1
+      # Explicitly deny dangerous operations
+      - POST=0
+      - DELETE=0
+      - PUT=0
+      - PATCH=0
+    # Security: socket-proxy only needs access to the socket
+    # No ports exposed to host — internal network only
 
   # ---------------------------------------------------------------------------
   # Traefik — Reverse Proxy & TLS Termination
@@ -30,7 +59,7 @@ services:
     environment:
       - TZ=${TZ}
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Removed raw docker.sock — now routes through socket-proxy (more secure)
       - ../../config/traefik/traefik.yml:/traefik.yml:ro
       - ../../config/traefik/dynamic:/dynamic:ro
       - ../../config/traefik/acme.json:/acme.json
@@ -51,11 +80,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+    depends_on:
+      - socket-proxy
 
   # ---------------------------------------------------------------------------
   # Portainer — Docker Management UI
   # URL: https://portainer.${DOMAIN}
   # First login: set admin password within 5 minutes
+  # NOTE: Portainer needs full Docker API access — keeps direct socket mount
   # ---------------------------------------------------------------------------
   portainer:
     image: portainer/portainer-ce:2.21.4


### PR DESCRIPTION
## Summary

Adds `docker-socket-proxy` (tecnativa/docker-socket-proxy:0.2.0) to the base infrastructure stack, replacing Traefik direct Docker socket mount with a secure TCP proxy.

## Problem

Traefik accessing `/var/run/docker.sock` directly is a security risk — any Traefik vulnerability could allow container escape to the host.

## Solution

- **socket-proxy** service: HAProxy-based proxy that exposes a read-only Docker API over TCP (port 2375), blocking dangerous operations (POST, DELETE, PUT, PATCH)
- **Traefik Docker provider** updated to `http://socket-proxy:2375` instead of `unix:///var/run/docker.sock`
- **Portainer retains direct socket** (needs full API for management)
- README updated with security architecture diagram and troubleshooting section

## Changes

| File | Change |
|------|--------|
| `stacks/base/docker-compose.yml` | Add socket-proxy service; remove raw socket mount from Traefik |
| `config/traefik/traefik.yml` | Change Docker provider endpoint from Unix socket to HTTP proxy |
| `stacks/base/README.md` | Add socket-proxy to services table; security architecture diagram |

## Test Plan

- [ ] `docker compose up -d` starts all 4 containers
- [ ] Traefik logs show no socket errors
- [ ] `docker logs socket-proxy` shows healthy HAProxy startup
- [ ] Other stack containers still discoverable via Traefik
- [ ] Portainer container management still fully functional

## Bounty

Fixes #1