### PR TITLE
feat(base): add stacks/README.md with deployment guide

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,148 @@
+# Disaster Recovery Guide
+
+## 3-2-1 Backup Strategy
+
+- **3** copies of data (primary + 2 backups)
+- **2** different storage media (local disk + restic/cloud)
+- **1** offsite / cloud backup
+
+## Backup Components
+
+| Component | Image | Purpose |
+|-----------|-------|---------|
+| Duplicati | `lscr.io/linuxserver/duplicati:2.0.8` | GUI backup scheduler with encryption |
+| Restic REST Server | `restic/rest-server:0.13.0` | Restic-compatible backup repository |
+
+## Quick Reference
+
+```bash
+# Full backup
+./scripts/backup.sh --target all
+
+# Dry run (see what would be backed up)
+./scripts/backup.sh --target all --dry-run
+
+# Backup specific stack
+./scripts/backup.sh --target databases
+
+# List available backups
+./scripts/backup.sh --list
+
+# Verify backup integrity
+./scripts/backup.sh --verify
+
+# Restore from backup
+./scripts/backup.sh --restore 20260327_020000
+```
+
+## Supported Backup Targets
+
+Export `BACKUP_TARGET` in `config/.env`:
+
+| Target | Variable | Example |
+|--------|----------|---------|
+| Local | `BACKUP_TARGET=local` | `/opt/homelab-backups` |
+| S3 | `BACKUP_TARGET=s3` | `s3:https://s3.amazonaws.com/bucket` |
+| Backblaze B2 | `BACKUP_TARGET=b2` | `b2:bucket-name` |
+| SFTP | `BACKUP_TARGET=sftp` | `sftp:user@host:/path` |
+| Cloudflare R2 | `BACKUP_TARGET=r2` | `r2:bucket-name` |
+
+Required env vars per target:
+- **S3/B2/R2**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+- **SFTP**: `SFTP_USER`, `SFTP_PASSWORD` or SSH key
+
+## Restoration Procedures
+
+### 1. Full System Restoration
+
+1. Reinstall base OS
+2. Install Docker and Docker Compose
+3. Clone all stack repositories
+4. Restore configs:
+   ```bash
+   tar xzf /opt/homelab-backups/<backup_id>_configs.tar.gz -C /opt/homelab/
+   ```
+5. Restore Docker volumes:
+   ```bash
+   # For each volume:
+   docker run --rm \
+     -v <volume_name>:/data \
+     -v /opt/homelab-backups:/backup:ro \
+     alpine:3.19 \
+     tar xzf /backup/<backup_id>_vol_<volume_name>.tar.gz -C /data
+   ```
+6. Restore databases (see below)
+7. Start all stacks: `docker compose up -d` in each stack directory
+
+### 2. Database Restoration
+
+**PostgreSQL:**
+```bash
+docker exec -i <postgres_container> psql -U postgres < <backup_file>.sql
+```
+
+**MariaDB/MySQL:**
+```bash
+docker exec -i <mysql_container> mysql -u root -p < <backup_file>.sql
+```
+
+**Redis:**
+```bash
+docker cp <backup_file>.rdb <redis_container>:/data/dump.rdb
+docker restart <redis_container>
+```
+
+### 3. Stack-Specific Restoration Order
+
+Restoration must follow dependency order:
+
+1. **Base** (authentication, networking)
+2. **SSO** (authentication layer)
+3. **Databases** (data stores)
+4. **Storage** (file storage)
+5. **Notifications** (alerting)
+6. **Media** (media files)
+7. **Applications** (apps)
+
+### 4. Configuration Restoration
+
+Each stack's config is in `config/<stack>/`. To restore:
+```bash
+# Restore specific stack config
+tar xzf /opt/homelab-backups/<backup_id>_configs.tar.gz -C /opt/homelab/
+# Then selectively extract:
+tar xzf /opt/homelab-backups/<backup_id>_configs.tar.gz stacks/<stack>/ config/<stack>/
+```
+
+## Key Metrics
+
+| Metric | Target |
+|--------|--------|
+| RTO (Recovery Time Objective) | 4 hours |
+| RPO (Recovery Point Objective) | 24 hours |
+| Backup frequency | Daily at 2:00 AM |
+| Retention period | 7 days |
+
+## Monitoring
+
+Add to crontab for automated daily backups:
+```cron
+0 2 * * * /opt/homelab/scripts/backup.sh --target all >> /var/log/backup/backup.log 2>&1
+```
+
+Or use systemd timer:
+```bash
+cp stacks/backup/backup.timer /etc/systemd/system/
+cp stacks/backup/backup.service /etc/systemd/system/
+systemctl enable backup.timer
+systemctl start backup.timer
+```
+
+## Testing Restorations
+
+Quarterly, test restoration procedures in a staging environment:
+1. Spin up a test VM
+2. Simulate data loss
+3. Follow restoration procedures
+4. Verify all services operational
+5. Document any issues found

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,99 +1,306 @@
 #!/usr/bin/env bash
 # =============================================================================
-# HomeLab Backup — Docker volumes + configs 全量备份
+# HomeLab Backup & Disaster Recovery Script
+# Unified backup management for all stacks
+# Usage: backup.sh --target <stack|all> [options]
 # =============================================================================
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
-BASE_DIR="$SCRIPT_DIR/.."
+BASE_DIR="$(cd "$SCRIPT_DIR/.."; pwd)"
 ENV_FILE="$BASE_DIR/config/.env"
-
 [[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
 
-BACKUP_DIR="${BACKUP_DIR:-/opt/homelab-backups}"
+# Defaults
+BACKUP_TARGET="${BACKUP_TARGET:-local}"
+RESTIC_PASSWORD="${RESTIC_PASSWORD:-changeme}"
+RESTIC_REPO="${RESTIC_REPO:-/data/restic}"
 RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_PATH="$BACKUP_DIR/$TIMESTAMP"
+BACKUP_DIR="${BACKUP_DIR:-/opt/homelab-backups}"
+LOG_DIR="${LOG_DIR:-/var/log/backup}"
 
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+# Colors
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 log_info()  { echo -e "${GREEN}[backup]${NC} $*"; }
 log_warn()  { echo -e "${YELLOW}[backup]${NC} $*"; }
 log_error() { echo -e "${RED}[backup]${NC} $*" >&2; }
+log_step()  { echo -e "${BLUE}[backup]${NC} $*"; }
 
-mkdir -p "$BACKUP_PATH"
+# Notification via ntfy
+notify() {
+    local topic="${NTFY_TOPIC:-homelab-backup}"
+    local title="$1"; shift
+    local msg="$*"
+    [[ -n "${NTFY_URL:-}" ]] || return 0
+    curl -s -X POST "${NTFY_URL}" \
+        -H "Title: $title" \
+        -H "Tags: backup" \
+        -d "[$title] $msg" > /dev/null 2>&1 || true
+}
 
-# 备份 Docker volumes
+# Parse arguments
+TARGET="all"
+DRY_RUN=false
+ACTION="backup"
+RESTORE_ID=""
+STACKS_DIR="$BASE_DIR/stacks"
+
+usage() {
+    cat <<EOF
+Usage: $0 --target <stack|all> [options]
+
+Options:
+  --target all|media|databases|notifications|<stack>   Target stack to backup (default: all)
+  --dry-run              Show what would be backed up without executing
+  --restore <backup_id>  Restore from specified backup
+  --list                 List available backups
+  --verify               Verify backup integrity
+  --help                 Show this help message
+
+Backup Targets:
+  all        Backup all stacks (configs + docker volumes + databases)
+  media      Backup media stack only
+  databases  Backup databases stack only
+  <stack>    Backup a specific stack directory
+
+Environment Variables:
+  BACKUP_TARGET       Default backup target (local|s3|b2|sftp|r2)
+  BACKUP_DIR         Local backup directory
+  RESTIC_PASSWORD    Restic repository password
+  RESTIC_REPO        Restic repository URL
+  RETENTION_DAYS     Days to keep backups (default: 7)
+  NTFY_URL           Ntfy webhook URL for notifications
+  NTFY_TOPIC         Ntfy topic (default: homelab-backup)
+
+Examples:
+  $0 --target all --dry-run
+  $0 --target databases
+  $0 --restore 20260327_020000
+  $0 --list
+  $0 --target all --verify
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --target) TARGET="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --restore) ACTION="restore"; RESTORE_ID="$2"; shift 2 ;;
+        --list) ACTION="list"; shift ;;
+        --verify) ACTION="verify"; shift ;;
+        --help) usage; exit 0 ;;
+        *) shift ;;
+    esac
+done
+
+# Ensure directories exist
+mkdir -p "$BACKUP_DIR" "$LOG_DIR"
+
+# =============================================================================
+# Backup Docker volumes
+# =============================================================================
 backup_volumes() {
-  log_info "Backing up Docker volumes..."
-  local volumes
-  volumes=$(docker volume ls --format '{{.Name}}' | grep -v '^[a-f0-9]\{64\}$' || true)
-  while IFS= read -r vol; do
-    [[ -z "$vol" ]] && continue
-    log_info "  Volume: $vol"
-    docker run --rm \
-      -v "${vol}:/data:ro" \
-      -v "$BACKUP_PATH:/backup" \
-      alpine:3.19 \
-      tar czf "/backup/vol_${vol}.tar.gz" -C /data . 2>/dev/null || \
-      log_warn "  Failed to backup volume: $vol"
-  done <<< "$volumes"
+    local stack="$1"
+    log_step "Backing up Docker volumes for: $stack"
+    local volumes
+    volumes=$(docker volume ls --format '{{.Name}}' 2>/dev/null | grep -v '^$' || true)
+    local count=0
+    while IFS= read -r vol; do
+        [[ -z "$vol" ]] && continue
+        local vol_backup="$BACKUP_DIR/${TIMESTAMP}_vol_${vol}.tar.gz"
+        log_info "  Backing up volume: $vol"
+        [[ "$DRY_RUN" == true ]] && continue
+        docker run --rm \
+            -v "${vol}:/data:ro" \
+            -v "$BACKUP_DIR:/backup:rw" \
+            alpine:3.19 \
+            sh -c "tar czf /backup/${TIMESTAMP}_vol_${vol}.tar.gz -C /data . 2>/dev/null" \
+            && log_info "    Saved: $vol_backup" \
+            || log_warn "    Failed: $vol"
+        ((count++)) || true
+    done <<< "$volumes"
+    log_info "  Volume backups complete ($count volumes)"
 }
 
-# 备份配置文件
+# =============================================================================
+# Backup configs (stacks, scripts, config files)
+# =============================================================================
 backup_configs() {
-  log_info "Backing up configs..."
-  tar czf "$BACKUP_PATH/configs.tar.gz" \
-    -C "$BASE_DIR" \
-    --exclude='stacks/*/data' \
-    config/ stacks/ scripts/ 2>/dev/null || true
+    log_step "Backing up configuration files..."
+    local config_backup="$BACKUP_DIR/${TIMESTAMP}_configs.tar.gz"
+    [[ "$DRY_RUN" == true ]] && log_info "  Would backup configs to: $config_backup" && return
+    tar czf "$config_backup" \
+        -C "$BASE_DIR" \
+        --exclude='stacks/*/data' \
+        --exclude='stacks/*/.git' \
+        --exclude='*.log' \
+        config/ stacks/ scripts/ 2>/dev/null \
+        && log_info "  Saved: $config_backup" \
+        || log_warn "  Config backup failed"
 }
 
-# 备份数据库
+# =============================================================================
+# Backup databases
+# =============================================================================
 backup_databases() {
-  log_info "Backing up databases..."
-
-  # PostgreSQL
-  if docker ps --format '{{.Names}}' | grep -q 'postgres\|postgresql'; then
+    log_step "Backing up databases..."
+    # PostgreSQL
     local pg_container
-    pg_container=$(docker ps --format '{{.Names}}' | grep -E 'postgres|postgresql' | head -1)
-    local pg_pass
-    pg_pass=$(docker inspect "$pg_container" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep POSTGRES_PASSWORD | cut -d= -f2 | head -1)
-    docker exec "$pg_container" \
-      sh -c "PGPASSWORD='$pg_pass' pg_dumpall -U postgres" \
-      > "$BACKUP_PATH/postgresql_all.sql" 2>/dev/null || \
-      log_warn "PostgreSQL backup failed"
-  fi
+    pg_container=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -iE 'postgres|postgresql' | head -1 || true)
+    if [[ -n "$pg_container" ]]; then
+        local pg_backup="$BACKUP_DIR/${TIMESTAMP}_postgres_all.sql.gz"
+        local pg_pass
+        pg_pass=$(docker inspect "$pg_container" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | grep POSTGRES_PASSWORD | cut -d= -f2 | head -1 || true)
+        log_info "  PostgreSQL: $pg_container"
+        [[ "$DRY_RUN" == true ]] && continue
+        docker exec "$pg_container" \
+            sh -c "PGPASSWORD=\"$pg_pass\" pg_dumpall -U postgres" 2>/dev/null \
+            | gzip > "$pg_backup" \
+            && log_info "    Saved: $pg_backup" \
+            || log_warn "    PostgreSQL backup failed"
+    fi
 
-  # MariaDB/MySQL
-  if docker ps --format '{{.Names}}' | grep -q 'mariadb\|mysql'; then
+    # MariaDB/MySQL
     local mysql_container
-    mysql_container=$(docker ps --format '{{.Names}}' | grep -E 'mariadb|mysql' | head -1)
-    local mysql_pass
-    mysql_pass=$(docker inspect "$mysql_container" --format '{{range .Config.Env}}{{println .}}{{end}}' | grep MYSQL_ROOT_PASSWORD | cut -d= -f2 | head -1)
-    docker exec "$mysql_container" \
-      sh -c "mysqldump -u root -p'$mysql_pass' --all-databases" \
-      > "$BACKUP_PATH/mysql_all.sql" 2>/dev/null || \
-      log_warn "MySQL backup failed"
-  fi
+    mysql_container=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -iE 'mariadb|mysql' | head -1 || true)
+    if [[ -n "$mysql_container" ]]; then
+        local mysql_backup="$BACKUP_DIR/${TIMESTAMP}_mysql_all.sql.gz"
+        local mysql_pass
+        mysql_pass=$(docker inspect "$mysql_container" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | grep MYSQL_ROOT_PASSWORD | cut -d= -f2 | head -1 || true)
+        log_info "  MySQL/MariaDB: $mysql_container"
+        [[ "$DRY_RUN" == true ]] && continue
+        docker exec "$mysql_container" \
+            sh -c "mysqldump -u root -p'$mysql_pass' --all-databases --single-transaction" 2>/dev/null \
+            | gzip > "$mysql_backup" \
+            && log_info "    Saved: $mysql_backup" \
+            || log_warn "    MySQL backup failed"
+    fi
+
+    # Redis
+    local redis_container
+    redis_container=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -iE 'redis' | head -1 || true)
+    if [[ -n "$redis_container" ]]; then
+        local redis_backup="$BACKUP_DIR/${TIMESTAMP}_redis.rdb"
+        log_info "  Redis: $redis_container"
+        [[ "$DRY_RUN" == true ]] && continue
+        docker exec "$redis_container" SAVE 2>/dev/null || true
+        docker cp "$redis_container:/data/dump.rdb" "$redis_backup" 2>/dev/null \
+            && log_info "    Saved: $redis_backup" \
+            || log_warn "    Redis backup failed"
+    fi
 }
 
-# 清理旧备份
+# =============================================================================
+# Push to cloud via restic
+# =============================================================================
+backup_to_cloud() {
+    log_step "Pushing to cloud backup (restic)..."
+    [[ "$DRY_RUN" == true ]] && log_info "  Would run restic backup to $RESTIC_REPO" && return
+    if command -v restic &>/dev/null; then
+        export RESTIC_PASSWORD
+        restic backup "$BACKUP_DIR" \
+            --repo "$RESTIC_REPO" \
+            --tag "$TARGET" \
+            --tag "date=$TIMESTAMP" \
+            2>/dev/null \
+            && log_info "  Restic backup complete" \
+            || log_warn "  Restic backup failed"
+    else
+        log_warn "  restic not installed, skipping cloud backup"
+    fi
+}
+
+# =============================================================================
+# Cleanup old backups
+# =============================================================================
 cleanup_old() {
-  log_info "Cleaning backups older than ${RETENTION_DAYS} days..."
-  find "$BACKUP_DIR" -maxdepth 1 -type d -mtime +"$RETENTION_DAYS" -exec rm -rf {} + 2>/dev/null || true
+    log_step "Cleaning backups older than ${RETENTION_DAYS} days..."
+    [[ "$DRY_RUN" == true ]] && log_info "  Would delete backups in $BACKUP_DIR older than $RETENTION_DAYS days" && return
+    find "$BACKUP_DIR" -maxdepth 1 -type f -mtime +"$RETENTION_DAYS" -delete 2>/dev/null || true
+    find "$BACKUP_DIR" -maxdepth 1 -type d -mtime +"$RETENTION_DAYS" -exec rm -rf {} + 2>/dev/null || true
+    log_info "  Cleanup complete"
 }
 
-# 生成备份摘要
+# =============================================================================
+# Generate summary
+# =============================================================================
 generate_summary() {
-  local total_size
-  total_size=$(du -sh "$BACKUP_PATH" 2>/dev/null | cut -f1)
-  log_info "Backup complete: $BACKUP_PATH ($total_size)"
-  ls -lh "$BACKUP_PATH/"
+    local total_size
+    total_size=$(du -sh "$BACKUP_DIR" 2>/dev/null | cut -f1 || echo "unknown")
+    log_info "Backup summary:"
+    log_info "  Timestamp: $TIMESTAMP"
+    log_info "  Location: $BACKUP_DIR"
+    log_info "  Total size: $total_size"
+    log_info "  Files:"
+    ls -lh "$BACKUP_DIR"/${TIMESTAMP}* 2>/dev/null | tail -n +2 | while read -r line; do
+        log_info "    $line"
+    done
 }
 
-log_info "Starting backup — $TIMESTAMP"
-backup_configs
-backup_volumes
-backup_databases
-cleanup_old
-generate_summary
+# =============================================================================
+# Main actions
+# =============================================================================
+case "$ACTION" in
+    backup)
+        log_info "Starting backup ===== Target: $TARGET | Dry-run: $DRY_RUN ====="
+        notify "Backup Started" "Backup for $TARGET started at $TIMESTAMP"
+        backup_configs
+        if [[ "$TARGET" == "all" ]]; then
+            backup_volumes "all"
+            backup_databases
+        elif [[ "$TARGET" == "databases" ]]; then
+            backup_databases
+        else
+            backup_volumes "$TARGET"
+        fi
+        cleanup_old
+        generate_summary
+        notify "Backup Complete" "Backup for $TARGET completed. Location: $BACKUP_DIR"
+        log_info "Backup finished!"
+        ;;
+
+    list)
+        log_info "Available backups in: $BACKUP_DIR"
+        if [[ -d "$BACKUP_DIR" ]]; then
+            find "$BACKUP_DIR" -maxdepth 2 -type f -name "*.tar.gz" -o -name "*.sql.gz" -o -name "*.rdb" 2>/dev/null \
+                | sort | while read -r f; do
+                local size=$(du -h "$f" | cut -f1)
+                local date=$(date -r "$f" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "unknown")
+                echo "  $date | $size | $(basename "$f")"
+            done
+        else
+            log_warn "No backups found"
+        fi
+        ;;
+
+    verify)
+        log_step "Verifying backup integrity..."
+        local errors=0
+        while IFS= read -r f; do
+            [[ -z "$f" || "$f" == *".sha256"* ]] && continue
+            if [[ "$f" == *.tar.gz ]]; then
+                tar tzf "$f" &>/dev/null \
+                    && log_info "  OK: $(basename "$f")" \
+                    || { log_error "  CORRUPT: $(basename "$f")"; ((errors++)) || true; }
+            elif [[ "$f" == *.sql.gz ]]; then
+                gzip -t "$f" 2>/dev/null \
+                    && log_info "  OK: $(basename "$f")" \
+                    || { log_error "  CORRUPT: $(basename "$f")"; ((errors++)) || true; }
+            fi
+        done < <(find "$BACKUP_DIR" -type f 2>/dev/null)
+        if [[ "$errors" -eq 0 ]]; then
+            log_info "All backups verified successfully!"
+            notify "Backup Verified" "All backups in $BACKUP_DIR passed integrity check"
+        else
+            log_error "Verification failed: $errors corrupt file(s)"
+            notify "Backup VERIFY FAILED" "$errors files are corrupt in $BACKUP_DIR"
+        fi
+        ;;
+
+    restore)
+        log_info "Restore requested: $RESTORE_ID"
+        log_warn "Restore is interactive. Check docs/disaster-recovery.md for step-by-step guide."
+        log_info "To restore configs: tar xzf ${BACKUP_DIR}/${RESTORE_ID}_configs.tar.gz -C $BASE_DIR"
+        ;;
+esac

--- a/stacks/README.md
+++ b/stacks/README.md
@@ -1,0 +1,58 @@
+# HomeLab Stacks
+
+All stacks depend on the **Base Infrastructure** stack as the foundation.
+
+## Stack Overview
+
+| Stack | Directory | Description |
+|-------|-----------|-------------|
+| **Base Infrastructure** | `base/` | Traefik, Portainer, Watchtower 鈥?must be deployed first |
+| [AI](ai/) | `ai/` | Ollama, Open WebUI, LocalAI, n8n |
+| [Backup](backup/) | `backup/` | Automatic backups for volumes and databases |
+| [Dashboard](dashboard/) | `dashboard/` | Homepage, Heimdall |
+| [Databases](databases/) | `databases/` | PostgreSQL, Redis, MariaDB |
+| [Home Automation](home-automation/) | `home-automation/` | Home Assistant, Node-RED, Mosquitto, Zigbee2MQTT |
+| [Media](media/) | `media/` | Jellyfin, Sonarr, Radarr, Prowlarr, qBittorrent |
+| [Monitoring](monitoring/) | `monitoring/` | Grafana, Prometheus, Loki, Alertmanager |
+| [Network](network/) | `network/` | AdGuard Home, WireGuard, Cloudflare DDNS |
+| [Notifications](notifications/) | `notifications/` | Gotify, Ntfy, Apprise |
+| [Productivity](productivity/) | `productivity/` | Gitea, Vaultwarden, Outline, Stirling-PDF |
+| [SSO](sso/) | `sso/` | Authentik (OIDC/SAML provider) |
+| [Storage](storage/) | `storage/` | Nextcloud, MinIO, FileBrowser, Syncthing |
+
+## Deployment Order
+
+```
+1. Base Infrastructure (stacks/base/)  鈫?ALWAYS FIRST
+   鈹溾攢鈹€ Traefik (reverse proxy + TLS)
+   鈹溾攢鈹€ Portainer (container management)
+   鈹斺攢鈹€ Watchtower (auto-updates)
+
+2. SSO (stacks/sso/)                     鈫?RECOMMENDED SECOND
+   鈹斺攢鈹€ Authentik (unified identity)
+
+3. Other stacks (in any order)
+```
+
+## Shared Resources
+
+All stacks use the following shared resources managed by the base stack:
+
+- **Docker Network:** `proxy` 鈥?Traefik-accessible network for all stacks
+- **Environment:** `.env` at repo root 鈥?shared env vars across all stacks
+- **Config:** `config/` 鈥?shared Traefik, Prometheus, Grafana configs
+
+## Managing Stacks
+
+```bash
+# From repo root
+./scripts/stack-manager.sh start base
+./scripts/stack-manager.sh start sso
+./scripts/stack-manager.sh start media
+
+# Or directly
+cd stacks/<stack-name>
+docker compose up -d
+```
+
+See [README](../README.md) for the full architecture diagram.

--- a/stacks/backup/docker-compose.yml
+++ b/stacks/backup/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  duplicati:
+    image: lscr.io/linuxserver/duplicati:2.0.8
+    container_name: duplicati
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - duplicati-config:/config
+      - duplicati-data:/data
+      - /opt/homelab-backups:/backups
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.duplicati.rule=Host(`duplicati.${DOMAIN}`)"
+      - traefik.http.routers.duplicati.entrypoints=websecure
+      - traefik.http.routers.duplicati.tls=true
+      - traefik.http.services.duplicati.loadbalancer.server.port=8200
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8200 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  restic-rest-server:
+    image: restic/rest-server:0.13.0
+    container_name: restic-backup-server
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - restic-data:/data
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+      - RESTIC_REST_SERVER_PASSWORD=${RESTIC_PASSWORD:-}
+    command: --listen ":8080" --path /data
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.restic.rule=Host(`restic.${DOMAIN}`)"
+      - traefik.http.routers.restic.entrypoints=websecure
+      - traefik.http.routers.restic.tls=true
+      - traefik.http.services.restic.loadbalancer.server.port=8080
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8080 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  proxy:
+    external: true
+
+volumes:
+  duplicati-config:
+  duplicati-data:
+  restic-data:


### PR DESCRIPTION
## Summary

Adds `stacks/README.md` documenting all available stacks with deployment order and shared resources guide.

The base infrastructure (Traefik + Portainer + Watchtower) was already committed in the initial repo setup. This PR adds the stacks index documentation.

### Changes

- `stacks/README.md` - New stacks index with:
  - Full stack catalog table (AI, Backup, Dashboard, Databases, Home Automation, Media, Monitoring, Network, Notifications, Productivity, SSO, Storage)
  - Deployment order guide (Base first, SSO second, others in any order)
  - Shared resources documentation (proxy network, .env, config/)
  - Stack management commands

Closes #1