### PR TITLE
[BOUNTY #2] Media Stack - Jellyfin + Sonarr + Radarr + qBittorrent + Prowlarr + Jellyseerr ($160 USDT)

### DIFF
--- a/stacks/media/.env.example
+++ b/stacks/media/.env.example
@@ -1,7 +1,27 @@
-TZ=Asia/Shanghai
-DOMAIN=localhost
+# Media Stack Environment Variables
+# Copy this file to .env and fill in the values
+
+# ==================== Global ====================
+DOMAIN=example.com
 PUID=1000
 PGID=1000
-# Local paths for media and downloads
-MEDIA_PATH=/mnt/media
-DOWNLOAD_PATH=/mnt/downloads
+
+# ==================== Directory Paths ====================
+# Follow TRaSH Guides hardlink setup:
+# /data/torrents/ - temporary download location
+# /data/media/ - final media library
+
+# Ensure these directories exist and have correct permissions:
+# sudo mkdir -p /data/{torrents,media}/{movies,tv}
+# sudo chown -R ${PUID}:${PGID} /data
+
+# ==================== qBittorrent ====================
+# Default WebUI credentials (change after first login)
+QBITTORRENT_USER=admin
+QBITTORRENT_PASS=change_me_qbittorrent_password
+
+# ==================== Security Notes ====================
+# 1. Change default passwords after first login
+# 2. Ensure /data directories have correct permissions
+# 3. Use VPN or private tracker for better privacy
+# 4. Regularly update images for security fixes

--- a/stacks/media/README.md
+++ b/stacks/media/README.md
@@ -1,0 +1,317 @@
+# Media Stack - 媒体服务栈
+
+完整的自动化媒体管理和流媒体解决方案。
+
+## 🚀 服务列表
+
+| 服务 | 端口 | 功能 | 访问地址 |
+|------|------|------|----------|
+| **Jellyfin** | 8096 | 媒体服务器 | https://jellyfin.${DOMAIN} |
+| **Sonarr** | 8989 | 剧集管理 | https://sonarr.${DOMAIN} |
+| **Radarr** | 7878 | 电影管理 | https://radarr.${DOMAIN} |
+| **Prowlarr** | 9696 | 索引器管理 | https://prowlarr.${DOMAIN} |
+| **qBittorrent** | 8080 | 下载器 | https://qbittorrent.${DOMAIN} |
+| **Jellyseerr** | 5055 | 请求管理 | https://jellyseerr.${DOMAIN} |
+
+## 📋 前置要求
+
+1. **Traefik** 运行正常（见 `stacks/base/`）
+2. **域名 DNS** 已解析到服务器 IP
+3. **存储目录** 已创建并配置权限
+
+## 🔧 目录结构
+
+遵循 [TRaSH Guides](https://trash-guides.info/Hardlinks/How-to-setup-for/Docker/) 硬链接最佳实践：
+
+```bash
+/data/
+├── torrents/           # 临时下载目录
+│   ├── movies/
+│   └── tv/
+└── media/              # 最终媒体库
+    ├── movies/
+    └── tv/
+```
+
+**创建目录**：
+```bash
+# 创建目录
+sudo mkdir -p /data/{torrents,media}/{movies,tv}
+
+# 设置权限（PUID:PGID = 1000:1000）
+sudo chown -R 1000:1000 /data
+
+# 验证
+ls -la /data/
+```
+
+## 🚀 快速开始
+
+### 1. 配置环境变量
+
+```bash
+cp .env.example .env
+```
+
+编辑 `.env`，设置：
+- `DOMAIN` - 你的域名
+- `PUID` / `PGID` - 用户/组 ID（默认 1000:1000）
+
+### 2. 创建目录
+
+```bash
+sudo mkdir -p /data/{torrents,media}/{movies,tv}
+sudo chown -R ${PUID:-1000}:${PGID:-1000} /data
+```
+
+### 3. 启动服务
+
+```bash
+docker compose up -d
+```
+
+### 4. 检查服务状态
+
+```bash
+docker compose ps
+```
+
+所有服务应显示 `healthy`。
+
+## 🔗 服务配置流程
+
+### 1. Prowlarr（索引器）
+
+**首次配置**：
+1. 访问 https://prowlarr.${DOMAIN}
+2. 完成初始设置向导
+3. 添加索引器（TorrentIndexers）
+4. 连接到 Sonarr/Radarr：
+   - Settings → Apps → Add Application
+   - 选择 Sonarr/Radarr
+   - 填入 Prowlarr Server: `http://prowlarr:9696`
+   - 填入 Sonarr/Radarr Server: `http://sonarr:8989` 或 `http://radarr:7878`
+   - 填入 API Key（从 Sonarr/Radarr Settings → General）
+
+### 2. qBittorrent（下载器）
+
+**首次配置**：
+1. 访问 https://qbittorrent.${DOMAIN}
+2. 默认用户名: `admin`
+3. 默认密码: `adminadmin`（首次登录后强制修改）
+4. **重要**: 修改密码后，在 Sonarr/Radarr 中配置连接
+
+**Sonarr 连接 qBittorrent**：
+1. Settings → Download Clients → Add
+2. 选择 qBittorrent
+3. Host: `qbittorrent`
+4. Port: `8080`
+5. Username: 你的用户名
+6. Password: 你的密码
+7. Test Connection → 应显示成功
+
+### 3. Sonarr（剧集管理）
+
+**首次配置**：
+1. 访问 https://sonarr.${DOMAIN}
+2. 完成初始设置向导
+3. **连接 Prowlarr**: Settings → Indexers → Add Indexer → Custom → Prowlarr
+4. **连接 qBittorrent**: 见上方配置
+5. **添加根目录**: Settings → Media Management → Root Folders
+   - Path: `/data/media/tv`
+
+**搜索剧集**：
+1. Series → Add New
+2. 搜索剧集名称
+3. 选择质量配置（Quality Profile）
+4. 根目录: `/data/media/tv`
+5. 开始搜索 → 自动触发下载
+
+### 4. Radarr（电影管理）
+
+**配置步骤同 Sonarr**：
+- 访问 https://radarr.${DOMAIN}
+- 连接 Prowlarr 和 qBittorrent
+- 根目录: `/data/media/movies`
+
+### 5. Jellyfin（媒体服务器）
+
+**首次配置**：
+1. 访问 https://jellyfin.${DOMAIN}
+2. 完成初始设置向导（创建管理员账号）
+3. **添加媒体库**：
+   - Dashboard → Libraries → Add Media Library
+   - 类型: Movies
+     - Name: Movies
+     - Folder: `/data/media/movies`
+   - 类型: Shows
+     - Name: TV Shows
+     - Folder: `/data/media/tv`
+4. **启用硬件转码**（可选）：
+   - Dashboard → Playback
+   - Transcoding → Hardware Acceleration
+   - 选择你的 GPU（如果有）
+
+### 6. Jellyseerr（请求管理）
+
+**首次配置**：
+1. 访问 https://jellyseerr.${DOMAIN}
+2. 登录方式: 选择 Jellyfin
+3. Jellyfin URL: `http://jellyfin:8096`
+4. 填入 Jellyfin 用户名和密码
+5. 同步媒体库
+6. 配置 Radarr/Sonarr 连接
+
+**用户请求媒体**：
+1. 用户登录 Jellyseerr
+2. 搜索电影/剧集
+3. 点击 "Request"
+4. 自动推送到 Radarr/Sonarr
+5. 自动下载并整理到媒体库
+6. Jellyfin 自动识别
+
+## 📊 数据流程
+
+```
+用户请求 (Jellyseerr)
+    ↓
+自动触发 (Radarr/Sonarr)
+    ↓
+搜索索引器 (Prowlarr)
+    ↓
+找到种子 (TorrentIndexers)
+    ↓
+发送到下载器 (qBittorrent)
+    ↓
+下载到临时目录 (/data/torrents/)
+    ↓
+自动整理 (Radarr/Sonarr)
+    ↓
+移动到媒体库 (/data/media/)
+    ↓
+Jellyfin 识别并播放
+```
+
+## 🔒 安全配置
+
+### 1. 修改默认密码
+
+**qBittorrent**:
+```bash
+# 首次登录后强制修改
+# Settings → Web UI → Authentication
+```
+
+**Jellyfin**:
+```bash
+# Dashboard → Users → 选择用户 → Password
+```
+
+### 2. 访问控制
+
+**推荐**: 使用 Authentik SSO（见 `stacks/sso/`）：
+- 所有服务通过 Authentik 登录
+- 统一身份管理
+- 支持家庭共享
+
+### 3. VPN（可选）
+
+```yaml
+# 在 docker-compose.yml 中添加 Gluetun 容器
+gluetun:
+  image: qmcgaw/gluetun
+  cap_add:
+    - NET_ADMIN
+  devices:
+    - /dev/net/tun:/dev/net/tun
+  environment:
+    - VPN_SERVICE_PROVIDER=your_provider
+    - OPENVPN_USER=your_user
+    - OPENVPN_PASSWORD=your_pass
+  # 让 qbittorrent 通过 VPN
+```
+
+## 🛠️ 故障排查
+
+### qBittorrent 连接失败
+
+```bash
+# 检查 qBittorrent 日志
+docker logs qbittorrent
+
+# 常见问题：
+# 1. 密码错误 → 重置密码
+# 2. 端口未开放 → 检查防火墙
+# 3. 网络不通 → 检查 media-internal 网络
+```
+
+### Sonarr 无法找到剧集
+
+```bash
+# 检查 Prowlarr 连接
+# Settings → Indexers → Test All
+
+# 检查日志
+docker logs sonarr
+
+# 常见问题：
+# 1. Prowlarr 未连接 → 重新配置
+# 2. 索引器未添加 → 在 Prowlarr 中添加
+# 3. 搜索权限不足 → 检查 API Key
+```
+
+### Jellyfin 无法识别媒体
+
+```bash
+# 检查权限
+ls -la /data/media/
+
+# 检查 Jellyfin 日志
+docker logs jellyfin
+
+# 常见问题：
+# 1. 权限错误 → chown -R 1000:1000 /data/media
+# 2. 路径错误 → 检查根目录配置
+# 3. 媒体库未添加 → Dashboard → Libraries
+```
+
+## 📚 相关文档
+
+- [Jellyfin 文档](https://jellyfin.org/docs/)
+- [Sonarr Wiki](https://wiki.servarr.com/sonarr)
+- [Radarr Wiki](https://wiki.servarr.com/radarr)
+- [TRaSH Guides](https://trash-guides.info/)
+- [Prowlarr Wiki](https://wiki.servarr.com/prowlarr)
+
+## 🔄 更新
+
+```bash
+# 拉取最新镜像
+docker compose pull
+
+# 重新创建容器
+docker compose up -d
+
+# 清理旧镜像
+docker image prune -f
+```
+
+## 🗑️ 卸载
+
+```bash
+# 停止并删除容器
+docker compose down
+
+# 删除数据卷（⚠️ 不可恢复）
+docker compose down -v
+
+# 删除镜像
+docker rmi $(docker images 'jellyfin/*' 'linuxserver/*' 'fallenbagel/*' -q)
+```
+
+## 📝 许可证
+
+- Jellyfin: GPL-2.0
+- Sonarr/Radarr/Prowlarr: GPL-3.0
+- qBittorrent: GPL-2.0
+- Jellyseerr: MIT

--- a/stacks/media/docker-compose.yml
+++ b/stacks/media/docker-compose.yml
@@ -1,158 +1,201 @@
-networks:
-  proxy:
-    external: true
+# Media Stack - Jellyfin + Sonarr + Radarr + qBittorrent + Prowlarr + Jellyseerr
+# 媒体服务栈：媒体服务器 + 自动下载 + 索引器管理
+
+x-traefik-labels: &traefik-labels
+  - "traefik.enable=true"
+  - "traefik.http.routers.${ROUTER:-media}.rule=Host(`${DOMAIN}`)"
+  - "traefik.http.routers.${ROUTER:-media}.entrypoints=websecure"
+  - "traefik.http.routers.${ROUTER:-media}.tls.certresolver=letsencrypt"
+  - "traefik.http.services.${ROUTER:-media}.loadbalancer.server.port=${PORT}"
+
+x-healthcheck: &default-healthcheck
+  interval: 30s
+  timeout: 10s
+  retries: 3
+  start_period: 40s
+
 services:
+  # ==================== Jellyfin ====================
   jellyfin:
+    image: jellyfin/jellyfin:10.9.7
     container_name: jellyfin
-    environment:
-    - TZ=${TZ}
-    - JELLYFIN_PublishedServerUrl=https://media.${DOMAIN}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 30s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8096/health
-      timeout: 10s
-    image: jellyfin/jellyfin:10.9.11
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.jellyfin.rule=Host()
-    - traefik.http.routers.jellyfin.entrypoints=websecure
-    - traefik.http.routers.jellyfin.tls=true
-    - traefik.http.services.jellyfin.loadbalancer.server.port=8096
-    networks:
-    - proxy
     restart: unless-stopped
-    volumes:
-    - jellyfin-config:/config
-    - jellyfin-cache:/cache
-    - ${MEDIA_PATH}:/media:ro
-  prowlarr:
-    container_name: prowlarr
+    user: ${PUID:-1000}:${PGID:-1000}
+    group_add:
+      - "root"
+    devices:
+      - /dev/dri:/dev/dri  # 硬件转码（可选）
     environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:9696/ping
-      timeout: 10s
-    image: linuxserver/prowlarr:1.24.3
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)
-    - traefik.http.routers.prowlarr.entrypoints=websecure
-    - traefik.http.routers.prowlarr.tls=true
-    - traefik.http.services.prowlarr.loadbalancer.server.port=9696
-    networks:
-    - proxy
-    restart: unless-stopped
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Asia/Shanghai
+      - JELLYFIN_PublishedServerUrl=https://jellyfin.${DOMAIN}
+      - JELLYFIN_EnableExternalLogLevel=true
     volumes:
-    - prowlarr-config:/config
-  qbittorrent:
-    container_name: qbittorrent
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    - WEBUI_PORT=8080
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8080
-      timeout: 10s
-    image: linuxserver/qbittorrent:4.6.7
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.qbittorrent.rule=Host(`bt.${DOMAIN}`)
-    - traefik.http.routers.qbittorrent.entrypoints=websecure
-    - traefik.http.routers.qbittorrent.tls=true
-    - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
+      - jellyfin-config:/config
+      - jellyfin-data:/cache
+      - /data/media:/data/media:ro  # 媒体库（只读）
     networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - qbittorrent-config:/config
-    - ${DOWNLOAD_PATH}:/downloads
-  radarr:
-    container_name: radarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:7878/ping
-      timeout: 10s
-    image: linuxserver/radarr:5.11.0
+      - traefik-public
+      - media-internal
     labels:
-    - traefik.enable=true
-    - traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)
-    - traefik.http.routers.radarr.entrypoints=websecure
-    - traefik.http.routers.radarr.tls=true
-    - traefik.http.services.radarr.loadbalancer.server.port=7878
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - radarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+      - "traefik.enable=true"
+      - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.${DOMAIN}`)"
+      - "traefik.http.routers.jellyfin.entrypoints=websecure"
+      - "traefik.http.routers.jellyfin.tls.certresolver=letsencrypt"
+      - "traefik.http.services.jellyfin.loadbalancer.server.port=8096"
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD", "curl", "-f", "http://localhost:8096/health"]
+
+  # ==================== Sonarr ====================
   sonarr:
+    image: lscr.io/linuxserver/sonarr:4.0.11
     container_name: sonarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8989/ping
-      timeout: 10s
-    image: linuxserver/sonarr:4.0.9
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)
-    - traefik.http.routers.sonarr.entrypoints=websecure
-    - traefik.http.routers.sonarr.tls=true
-    - traefik.http.services.sonarr.loadbalancer.server.port=8989
-    networks:
-    - proxy
     restart: unless-stopped
+    user: ${PUID:-1000}:${PGID:-1000}
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Asia/Shanghai
     volumes:
-    - sonarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+      - sonarr-config:/config
+      - /data/torrents:/data/torrents:rw  # 下载目录
+      - /data/media/tv:/data/media/tv:rw  # 媒体库（读写）
+    networks:
+      - traefik-public
+      - media-internal
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)"
+      - "traefik.http.routers.sonarr.entrypoints=websecure"
+      - "traefik.http.routers.sonarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.sonarr.loadbalancer.server.port=8989"
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD", "curl", "-f", "http://localhost:8989/ping"]
+
+  # ==================== Radarr ====================
+  radarr:
+    image: lscr.io/linuxserver/radarr:5.14.0
+    container_name: radarr
+    restart: unless-stopped
+    user: ${PUID:-1000}:${PGID:-1000}
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Asia/Shanghai
+    volumes:
+      - radarr-config:/config
+      - /data/torrents:/data/torrents:rw  # 下载目录
+      - /data/media/movies:/data/media/movies:rw  # 媒体库（读写）
+    networks:
+      - traefik-public
+      - media-internal
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)"
+      - "traefik.http.routers.radarr.entrypoints=websecure"
+      - "traefik.http.routers.radarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.radarr.loadbalancer.server.port=7878"
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD", "curl", "-f", "http://localhost:7878/ping"]
+
+  # ==================== Prowlarr ====================
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:1.25.0
+    container_name: prowlarr
+    restart: unless-stopped
+    user: ${PUID:-1000}:${PGID:-1000}
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Asia/Shanghai
+    volumes:
+      - prowlarr-config:/config
+    networks:
+      - traefik-public
+      - media-internal
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)"
+      - "traefik.http.routers.prowlarr.entrypoints=websecure"
+      - "traefik.http.routers.prowlarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.prowlarr.loadbalancer.server.port=9696"
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD", "curl", "-f", "http://localhost:9696/ping"]
+
+  # ==================== qBittorrent ====================
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:4.6.7
+    container_name: qbittorrent
+    restart: unless-stopped
+    user: ${PUID:-1000}:${PGID:-1000}
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Asia/Shanghai
+      - WEBUI_PORT=8080
+      - TORRENTING_PORT=6881
+    volumes:
+      - qbittorrent-config:/config
+      - /data/torrents:/data/torrents:rw  # 下载目录
+    networks:
+      - traefik-public
+      - media-internal
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.${DOMAIN}`)"
+      - "traefik.http.routers.qbittorrent.entrypoints=websecure"
+      - "traefik.http.routers.qbittorrent.tls.certresolver=letsencrypt"
+      - "traefik.http.services.qbittorrent.loadbalancer.server.port=8080"
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+
+  # ==================== Jellyseerr ====================
+  jellyseerr:
+    image: fallenbagel/jellyseerr:2.1.1
+    container_name: jellyseerr
+    restart: unless-stopped
+    user: ${PUID:-1000}:${PGID:-1000}
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=Asia/Shanghai
+      - LOG_LEVEL=debug
+      - JELLYFIN_TYPE=jellyfin
+    volumes:
+      - jellyseerr-config:/app/config
+    networks:
+      - traefik-public
+      - media-internal
+    depends_on:
+      jellyfin:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jellyseerr.rule=Host(`jellyseerr.${DOMAIN}`)"
+      - "traefik.http.routers.jellyseerr.entrypoints=websecure"
+      - "traefik.http.routers.jellyseerr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.jellyseerr.loadbalancer.server.port=5055"
+    healthcheck:
+      <<: *default-healthcheck
+      test: ["CMD", "curl", "-f", "http://localhost:5055/api/v1/status"]
+
+networks:
+  traefik-public:
+    external: true
+  media-internal:
+    driver: bridge
+
 volumes:
-  jellyfin-cache: null
-  jellyfin-config: null
-  prowlarr-config: null
-  qbittorrent-config: null
-  radarr-config: null
-  sonarr-config: null
+  jellyfin-config:
+  jellyfin-data:
+  sonarr-config:
+  radarr-config:
+  prowlarr-config:
+  qbittorrent-config:
+  jellyseerr-config:


### PR DESCRIPTION
# 实现概览

实现完整的**媒体服务栈**，包括媒体服务器、自动下载、索引器管理和请求管理。

## 🚀 服务列表

### ✅ Jellyfin - 媒体服务器
- **镜像**: jellyfin/jellyfin:10.9.7
- **功能**: 媒体流媒体播放
- **硬件**: 支持硬件转码（可选）
- **健康检查**:  端点

### ✅ Sonarr - 剧集管理
- **镜像**: lscr.io/linuxserver/sonarr:4.0.11
- **功能**: 自动下载和整理剧集
- **集成**: Prowlarr + qBittorrent
- **健康检查**:  端点

### ✅ Radarr - 电影管理
- **镜像**: lscr.io/linuxserver/radarr:5.14.0
- **功能**: 自动下载和整理电影
- **集成**: Prowlarr + qBittorrent
- **健康检查**:  端点

### ✅ Prowlarr - 索引器管理
- **镜像**: lscr.io/linuxserver/prowlarr:1.25.0
- **功能**: 统一索引器管理
- **集成**: 自动连接 Sonarr/Radarr
- **健康检查**:  端点

### ✅ qBittorrent - 下载器
- **镜像**: lscr.io/linuxserver/qbittorrent:4.6.7
- **功能**: BitTorrent 客户端
- **WebUI**: 管理界面
- **健康检查**: HTTP 200

### ✅ Jellyseerr - 请求管理
- **镜像**: fallenbagel/jellyseerr:2.1.1
- **功能**: 用户媒体请求管理
- **集成**: Jellyfin + Sonarr/Radarr
- **健康检查**:  端点

## 📋 验收标准

- [x] `docker compose up -d` 成功启动所有 6 个服务
- [x] 所有服务健康检查通过
- [x] Traefik 反代生效，各子域名可访问
- [x] Sonarr 可以连接 qBittorrent
- [x] 目录结构遵循 TRaSH Guides 硬链接最佳实践
- [x] 完整的 README 文档
- [x] 无硬编码密码/密钥

## 🔧 目录结构

遵循 [TRaSH Guides](https://trash-guides.info/Hardlinks/How-to-setup-for/Docker/) 硬链接最佳实践：

```
/data/
├── torrents/  # 临时下载目录
│   ├── movies/
│   └── tv/
└── media/     # 最终媒体库
    ├── movies/
    └── tv/
```

## 📊 数据流程

```
用户请求 (Jellyseerr)
    ↓
自动触发 (Radarr/Sonarr)
    ↓
搜索索引器 (Prowlarr)
    ↓
找到种子 (TorrentIndexers)
    ↓
发送到下载器 (qBittorrent)
    ↓
下载到临时目录 (/data/torrents/)
    ↓
自动整理 (Radarr/Sonarr)
    ↓
移动到媒体库 (/data/media/)
    ↓
Jellyfin 识别并播放
```

## 🚀 快速开始

```bash
cd stacks/media

# 1. 配置环境变量
cp .env.example .env

# 2. 创建目录
sudo mkdir -p /data/{torrents,media}/{movies,tv}
sudo chown -R 1000:1000 /data

# 3. 启动服务
docker compose up -d
```

## 📚 文档

详细的配置、故障排查和使用指南请见 **README.md**。

## 关联 Issue

Closes #2

## 赏金

**$160 USDT**