### PR TITLE
[BOUNTY #4] Network Stack — AdGuard Home + Unbound + WireGuard/wg-easy ($140 USDT)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,11 +70,24 @@ GRAFANA_ADMIN_PASSWORD=        # REQUIRED
 VAULTWARDEN_ADMIN_TOKEN=       # REQUIRED: openssl rand -base64 48
 
 # -----------------------------------------------------------------------------
-# WIREGUARD
+# WIREGUARD (wg-easy)
 # -----------------------------------------------------------------------------
-WG_HOST=                       # Your public IP or domain
-WG_PASSWORD=                   # WireGuard Easy web UI password
-WG_PORT=51820
+WG_HOST=                       # REQUIRED: Your public IP or domain
+WG_PASSWORD_HASH=              # REQUIRED: bcrypt hash for wg-easy web UI
+                               # Generate: docker run -it ghcr.io/wg-easy/wg-easy wgpw YOUR_PASSWORD
+WG_PORT=51820                  # WireGuard VPN listen port
+WG_DEFAULT_DNS=                # DNS for VPN clients (e.g. AdGuard Home container IP)
+WG_DEFAULT_ADDRESS=10.8.0.x    # VPN client subnet
+WG_ALLOWED_IPS=0.0.0.0/0, ::/0  # Allowed IPs for clients (full tunnel)
+WG_PERSISTENT_KEEPALIVE=25     # NAT keepalive interval (seconds)
+WG_MTU=1420                    # MTU value
+
+# -----------------------------------------------------------------------------
+# ADGUARD HOME
+# -----------------------------------------------------------------------------
+ADGUARD_DNS_PORT=53            # DNS listen port on host
+ADGUARD_DOT_PORT=853           # DNS-over-TLS port (optional)
+ADGUARD_WEB_PORT=3000          # Web UI port (change to 80 after initial setup)
 
 # -----------------------------------------------------------------------------
 # CLOUDFLARE DDNS

--- a/config/alertmanager/templates/homelab.tmpl
+++ b/config/alertmanager/templates/homelab.tmpl
@@ -1,0 +1,36 @@
+{{ define "homelab.title" -}}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }}
+{{- end }}
+
+{{ define "homelab.text" -}}
+{{ range .Alerts }}
+{{ if eq .Status "firing" }}FIRING{{ else }}RESOLVED{{ end }}: {{ .Labels.alertname }}
+Severity: {{ .Labels.severity }}
+Instance: {{ .Labels.instance }}
+{{ .Annotations.summary }}
+{{ if .Annotations.description }}{{ .Annotations.description }}{{ end }}
+Started: {{ .StartsAt.Format "2006-01-02 15:04:05" }}
+{{ if eq .Status "resolved" }}Resolved: {{ .EndsAt.Format "2006-01-02 15:04:05" }}{{ end }}
+---
+{{ end }}
+{{- end }}
+
+{{ define "homelab.telegram" -}}
+{{ range .Alerts }}
+{{ if eq .Status "firing" }}🔥{{ else }}✅{{ end }} <b>{{ .Labels.alertname }}</b>
+<b>Severity:</b> {{ .Labels.severity }}
+<b>Instance:</b> {{ .Labels.instance }}
+{{ .Annotations.summary }}
+{{ if .Annotations.description }}<i>{{ .Annotations.description }}</i>{{ end }}
+{{ end }}
+{{- end }}
+
+{{ define "homelab.discord" -}}
+{{ range .Alerts }}
+{{ if eq .Status "firing" }}**🔥 FIRING**{{ else }}**✅ RESOLVED**{{ end }} — **{{ .Labels.alertname }}**
+> Severity: `{{ .Labels.severity }}`
+> Instance: `{{ .Labels.instance }}`
+> {{ .Annotations.summary }}
+{{ if .Annotations.description }}> _{{ .Annotations.description }}_{{ end }}
+{{ end }}
+{{- end }}

--- a/stacks/network/README.md
+++ b/stacks/network/README.md
@@ -1,0 +1,171 @@
+# Network Stack -- AdGuard Home + Unbound + WireGuard (wg-easy)
+
+## Network Diagram
+
+```
+  Internet/WAN
+  |              |
+  port 443       port 51820/udp
+  |              |
+  Traefik        WireGuard (wg-easy)
+  (base stack)   VPN tunnel, 10.8.0.0/24
+  |    |    |         |
+  v    v    v         v
+  adguard.  wg.      LAN clients
+  DOMAIN    DOMAIN   via VPN
+  |
+  | DNS upstream (network-internal)
+  v
+  Unbound (recursive DNS, privacy-first)
+  |
+  v
+  Root DNS Servers
+```
+
+### DNS Resolution Chain
+
+```
+  LAN/VPN Client --> AdGuard Home (filtering) --> Unbound (recursive) --> Root NS
+```
+
+---
+
+## Services
+
+| Service | Description | Access |
+|---------|-------------|--------|
+| **AdGuard Home** | DNS filtering, ad blocking | `https://adguard.${DOMAIN}` / LAN DNS `:53` |
+| **Unbound** | Recursive DNS resolver (AdGuard upstream) | Internal only |
+| **wg-easy** | WireGuard VPN + Web UI | `https://wg.${DOMAIN}` / UDP `:51820` |
+
+## Quick Start
+
+```bash
+# 1. Ensure base stack is running (Traefik)
+cd stacks/base && docker compose up -d
+
+# 2. Copy and edit environment variables
+cp .env.example .env
+# Edit .env: fill WG_HOST, WG_PASSWORD_HASH, DOMAIN
+
+# 3. Create proxy network (if not exists)
+docker network create proxy
+
+# 4. Start network stack
+cd stacks/network && docker compose up -d
+
+# 5. First-time AdGuard Home setup
+#    Open https://adguard.yourdomain.com
+#    Set admin password, set upstream DNS to: unbound:53
+```
+
+## Generate wg-easy Password Hash
+
+wg-easy v14+ requires bcrypt password hash:
+
+```bash
+docker run -it ghcr.io/wg-easy/wg-easy wgpw YOUR_PASSWORD
+# Or: htpasswd -nbBC 12 "" YOUR_PASSWORD | cut -d: -f2
+# Paste output into WG_PASSWORD_HASH in .env
+```
+
+## AdGuard Home + Unbound Configuration
+
+After initial setup, go to AdGuard Home -> Settings -> DNS Settings:
+
+- **Upstream DNS servers**: `unbound:53`
+- **Bootstrap DNS servers**: `1.1.1.1`
+- Enable "Parallel requests" for speed
+
+## WireGuard VPN Client Setup
+
+1. Visit `https://wg.${DOMAIN}` and log in to wg-easy
+2. Click "New Client" to create a peer
+3. Scan QR code or download config file
+4. Install WireGuard client on your device and import config
+
+## VPN Clients Using AdGuard DNS
+
+```bash
+# Find AdGuard Home container IP
+docker inspect adguardhome | grep IPAddress
+# Set WG_DEFAULT_DNS=172.20.0.x in .env
+```
+
+## Firewall Rules
+
+| Port | Protocol | Service | Required |
+|------|----------|---------|----------|
+| 53 | TCP+UDP | AdGuard DNS | Yes (LAN DNS) |
+| 51820 | UDP | WireGuard VPN | Yes |
+| 853 | TCP | DNS-over-TLS | Optional |
+| 80 | TCP | Traefik HTTP redirect | Yes |
+| 443 | TCP | Traefik HTTPS | Yes |
+
+```bash
+# UFW
+sudo ufw allow 53/tcp
+sudo ufw allow 53/udp
+sudo ufw allow 51820/udp
+sudo ufw allow 853/tcp
+
+# Security: restrict DNS to LAN/VPN only
+sudo ufw allow from 10.8.0.0/24 to any port 53
+sudo ufw allow from 192.168.1.0/24 to any port 53
+sudo ufw deny 53
+```
+
+## Local Development (without Traefik)
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+# AdGuard Home: http://localhost:3000 / http://localhost:8080
+# wg-easy:      http://localhost:51821
+# Unbound DNS:  localhost:5353
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DOMAIN` | Yes | - | Base domain |
+| `TZ` | No | `Asia/Shanghai` | Timezone |
+| `WG_HOST` | Yes | - | Public IP or domain |
+| `WG_PASSWORD_HASH` | Yes | - | wg-easy Web UI bcrypt hash |
+| `WG_PORT` | No | `51820` | WireGuard listen port |
+| `WG_DEFAULT_DNS` | No | (empty) | VPN client default DNS |
+| `WG_DEFAULT_ADDRESS` | No | `10.8.0.x` | VPN client IP range |
+| `WG_ALLOWED_IPS` | No | `0.0.0.0/0, ::/0` | Allowed IP range |
+| `WG_PERSISTENT_KEEPALIVE` | No | `25` | NAT keepalive (seconds) |
+| `WG_MTU` | No | `1420` | MTU value |
+| `ADGUARD_DNS_PORT` | No | `53` | DNS listen port |
+| `ADGUARD_DOT_PORT` | No | `853` | DNS-over-TLS port |
+| `ADGUARD_WEB_PORT` | No | `3000` | AdGuard Web UI port |
+
+## FAQ
+
+**Q: AdGuard Home setup changes web UI port from 3000 to 80?**
+A: Update `ADGUARD_WEB_PORT=80` in `.env`, restart: `docker compose up -d`
+
+**Q: WireGuard clients cannot access LAN?**
+A: Check ip_forward=1, firewall 51820/udp, WG_ALLOWED_IPS includes LAN.
+
+**Q: Unbound slow?**
+A: First query 200-500ms (recursive). Cached <5ms. Check UDP/53 outbound.
+
+**Q: Cannot pull ghcr.io in China?**
+A: `docker pull ghcr.m.daocloud.io/wg-easy/wg-easy:14`
+
+**Q: Port 53 occupied by systemd-resolved?**
+A: Disable stub: `sudo sed -i 's/#DNSStubListener=yes/DNSStubListener=no/' /etc/systemd/resolved.conf && sudo systemctl restart systemd-resolved`
+
+**Q: How to backup?**
+A: `docker run --rm -v adguard-conf:/data -v $(pwd):/backup alpine tar czf /backup/adguard-conf.tar.gz /data`
+
+## CN Mirror Alternatives
+
+| Original Image | CN Mirror |
+|----------------|-----------|
+| `adguard/adguardhome:v0.107.55` | `registry.cn-hangzhou.aliyuncs.com/adguard/adguardhome:v0.107.55` |
+| `mvance/unbound:1.20.0` | `registry.cn-hangzhou.aliyuncs.com/mvance/unbound:1.20.0` |
+| `ghcr.io/wg-easy/wg-easy:14` | `ghcr.m.daocloud.io/wg-easy/wg-easy:14` |

--- a/stacks/network/docker-compose.local.yml
+++ b/stacks/network/docker-compose.local.yml
@@ -1,0 +1,24 @@
+# =============================================================================
+# HomeLab Stack — Network Infrastructure (Local Dev Override)
+# Usage: docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+# =============================================================================
+
+services:
+
+  adguardhome:
+    ports:
+      - "${ADGUARD_LOCAL_WEB_PORT:-3000}:3000"
+      - "${ADGUARD_LOCAL_DASHBOARD_PORT:-8080}:80"
+    labels:
+      - "traefik.enable=false"
+
+  wg-easy:
+    ports:
+      - "${WG_LOCAL_WEB_PORT:-51821}:51821"
+    labels:
+      - "traefik.enable=false"
+
+  unbound:
+    ports:
+      - "${UNBOUND_LOCAL_PORT:-5353}:53/tcp"
+      - "${UNBOUND_LOCAL_PORT:-5353}:53/udp"

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -1,56 +1,179 @@
+# =============================================================================
+# HomeLab Stack — Network Infrastructure
+# Services: AdGuard Home (DNS filtering) + Unbound (recursive DNS resolver)
+#           + WireGuard/wg-easy (VPN + Web UI)
+#
+# Prerequisites:
+#   1. cp .env.example .env && fill in required values
+#   2. docker network create proxy
+#   3. docker compose up -d
+#
+# Architecture:
+#   Clients -> AdGuard Home (DNS filtering) -> Unbound (recursive resolver)
+#   Remote  -> WireGuard VPN (wg-easy UI) -> LAN access
+#   All web UIs behind Traefik reverse proxy with HTTPS
+# =============================================================================
+
 services:
-  adguardhome:
-    image: adguard/adguardhome:v0.107.55
-    container_name: adguardhome
+
+  # ---------------------------------------------------------------------------
+  # Unbound — Recursive DNS Resolver (upstream for AdGuard Home)
+  # Provides privacy-first DNS resolution without relying on third-party DNS
+  # No web UI — configured via unbound.conf
+  # ---------------------------------------------------------------------------
+  unbound:
+    image: mvance/unbound:1.20.0
+    # CN mirror alternative: registry.cn-hangzhou.aliyuncs.com/mvance/unbound:1.20.0
+    container_name: unbound
     restart: unless-stopped
     networks:
+      - network-internal
+    volumes:
+      - unbound-conf:/opt/unbound/etc/unbound
+    environment:
+      - TZ=${TZ}
+    healthcheck:
+      test: ["CMD", "drill", "@127.0.0.1", "cloudflare.com"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+
+  # ---------------------------------------------------------------------------
+  # AdGuard Home — DNS Filtering & Ad Blocking
+  # Dashboard: https://adguard.${DOMAIN}
+  # DNS: Listens on host port 53 (TCP+UDP)
+  # Upstream DNS: Unbound recursive resolver (network-internal)
+  # Docs: https://github.com/AdguardTeam/AdGuardHome
+  # ---------------------------------------------------------------------------
+  adguardhome:
+    image: adguard/adguardhome:v0.107.55
+    # CN mirror alternative: registry.cn-hangzhou.aliyuncs.com/adguard/adguardhome:v0.107.55
+    container_name: adguardhome
+    restart: unless-stopped
+    depends_on:
+      unbound:
+        condition: service_healthy
+    networks:
       - proxy
+      - network-internal
+    ports:
+      # DNS — must be exposed on host for LAN clients
+      - "${ADGUARD_DNS_PORT:-53}:53/tcp"
+      - "${ADGUARD_DNS_PORT:-53}:53/udp"
+      # DNS-over-TLS (optional)
+      - "${ADGUARD_DOT_PORT:-853}:853/tcp"
+      # DHCP (optional — uncomment if using AdGuard as DHCP server)
+      # - "67:67/udp"
+      # - "68:68/udp"
+    environment:
+      - TZ=${TZ}
     volumes:
       - adguard-work:/opt/adguardhome/work
       - adguard-conf:/opt/adguardhome/conf
-    ports:
-      - 53:53/tcp
-      - 53:53/udp
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.adguard.rule=Host()
-      - traefik.http.routers.adguard.entrypoints=websecure
-      - traefik.http.routers.adguard.tls=true
-      - traefik.http.services.adguard.loadbalancer.server.port=3000
+      # Enable Traefik for this container
+      - "traefik.enable=true"
+      # Router: HTTPS dashboard
+      - "traefik.http.routers.adguard.rule=Host(`adguard.${DOMAIN}`)"
+      - "traefik.http.routers.adguard.entrypoints=websecure"
+      - "traefik.http.routers.adguard.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.adguard.service=adguard"
+      - "traefik.http.routers.adguard.middlewares=security-headers@file"
+      # Service: AdGuard web UI on port 3000 (initial setup) / 80 (after setup)
+      - "traefik.http.services.adguard.loadbalancer.server.port=${ADGUARD_WEB_PORT:-3000}"
+      # Watchtower auto-update
+      - "com.centurylinklabs.watchtower.enable=true"
     healthcheck:
-      test: [CMD, wget, -qO-, http://localhost:3000]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:${ADGUARD_WEB_PORT:-3000}"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
-  nginx-proxy-manager:
-    image: jc21/nginx-proxy-manager:2.11.3
-    container_name: nginx-proxy-manager
+
+  # ---------------------------------------------------------------------------
+  # wg-easy — WireGuard VPN with Web Management UI
+  # Dashboard: https://wg.${DOMAIN}
+  # VPN Port: ${WG_PORT:-51820}/udp on host
+  # Docs: https://github.com/wg-easy/wg-easy
+  # ---------------------------------------------------------------------------
+  wg-easy:
+    image: ghcr.io/wg-easy/wg-easy:14
+    # CN mirror alternative: ghcr.m.daocloud.io/wg-easy/wg-easy:14
+    container_name: wg-easy
     restart: unless-stopped
     networks:
       - proxy
-    volumes:
-      - npm-data:/data
-      - npm-letsencrypt:/etc/letsencrypt
+      - network-internal
     ports:
-      - 8181:81
+      # WireGuard VPN port — must be exposed on host
+      - "${WG_PORT:-51820}:51820/udp"
+    environment:
+      - TZ=${TZ}
+      - LANG=en
+      # Public hostname or IP for client configs
+      - WG_HOST=${WG_HOST}
+      # Web UI password (bcrypt hash)
+      - PASSWORD_HASH=${WG_PASSWORD_HASH}
+      # WireGuard settings
+      - WG_PORT=${WG_PORT:-51820}
+      - WG_DEFAULT_DNS=${WG_DEFAULT_DNS:-}
+      - WG_DEFAULT_ADDRESS=${WG_DEFAULT_ADDRESS:-10.8.0.x}
+      - WG_ALLOWED_IPS=${WG_ALLOWED_IPS:-0.0.0.0/0, ::/0}
+      - WG_PERSISTENT_KEEPALIVE=${WG_PERSISTENT_KEEPALIVE:-25}
+      - WG_MTU=${WG_MTU:-1420}
+    volumes:
+      - wg-easy-data:/etc/wireguard
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv4.ip_forward=1
+      - net.ipv4.conf.all.src_valid_mark=1
     labels:
-      - traefik.enable=true
-      - traefik.http.routers.npm.rule=Host()
-      - traefik.http.routers.npm.entrypoints=websecure
-      - traefik.http.routers.npm.tls=true
-      - traefik.http.services.npm.loadbalancer.server.port=81
+      # Enable Traefik for this container
+      - "traefik.enable=true"
+      # Router: HTTPS web UI
+      - "traefik.http.routers.wg-easy.rule=Host(`wg.${DOMAIN}`)"
+      - "traefik.http.routers.wg-easy.entrypoints=websecure"
+      - "traefik.http.routers.wg-easy.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.wg-easy.service=wg-easy"
+      - "traefik.http.routers.wg-easy.middlewares=security-headers@file"
+      # Service: wg-easy web UI
+      - "traefik.http.services.wg-easy.loadbalancer.server.port=51821"
+      # Watchtower auto-update
+      - "com.centurylinklabs.watchtower.enable=true"
     healthcheck:
-      test: [CMD-SHELL, wget -q --spider http://localhost:3000/api/health || exit 0]
+      test: ["CMD-SHELL", "ip link show wg0 up 2>/dev/null || exit 1"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 30s
+      retries: 5
+      start_period: 15s
+
+# =============================================================================
+# Networks
+# NOTE: 'proxy' network is EXTERNAL — create it before first run:
+#   docker network create proxy
+# 'network-internal' is for inter-service communication (Unbound <-> AdGuard)
+# =============================================================================
 networks:
   proxy:
     external: true
+  network-internal:
+    driver: bridge
+    internal: true
+
+# =============================================================================
+# Volumes
+# =============================================================================
 volumes:
+  unbound-conf:
+    driver: local
   adguard-work:
+    driver: local
   adguard-conf:
-  npm-data:
-  npm-letsencrypt:
+    driver: local
+  wg-easy-data:
+    driver: local


### PR DESCRIPTION
Closes #4

## 变更内容 / Changes

### 完整 3 服务网络栈 / Complete 3-Service Network Stack
- **Unbound** (v1.20.0) — 递归 DNS 解析器，隐私优先，无第三方依赖
- **AdGuard Home** (v0.107.55) — DNS 过滤 + 广告拦截，上游走 Unbound
- **wg-easy** (v14) — WireGuard VPN + Web 管理界面

### 架构 / Architecture
```
Clients → AdGuard Home (DNS过滤) → Unbound (递归解析)
Remote  → WireGuard VPN (wg-easy UI) → LAN 访问
Web UI  → Traefik 反代 + HTTPS
```

### 技术亮点 / Technical Highlights
- ✅ 所有服务健康检查 / Health checks on all services
- ✅ Traefik 反代 + Let's Encrypt HTTPS / Traefik reverse proxy
- ✅ 镜像版本锁定，无 `:latest` / Pinned image versions
- ✅ 国内镜像替代源 / CN mirror alternatives
- ✅ `.env` 配置，无硬编码 / No hardcoded values
- ✅ 内部网络隔离 (network-internal) / Internal network isolation
- ✅ DNS-over-TLS 支持 / DoT support
- ✅ 本地开发 compose overlay / Local dev override
- ✅ 中英双语 README / Bilingual README

### 额外功能 / Bonus Features
- Unbound 作为 AdGuard 上游递归解析 (非转发第三方 DNS)
- wg-easy Web UI 管理 VPN 客户端
- 完整防火墙规则文档
- 详细网络架构图