### PR TITLE
feat(cn): CN network robustness — 6 scripts + mirror map [Bounty #8 $250]

### DIFF
--- a/config/cn-mirrors.yml
+++ b/config/cn-mirrors.yml
@@ -1,0 +1,37 @@
+# CN Mirror Mapping — gcr.io/ghcr.io → domestic registries
+# Used by scripts/localize-images.sh
+# =============================================================================
+
+mirrors:
+  # ── ghcr.io ───────────────────────────────────────────────────────────────
+  ghcr.io/goauthentik/server:
+    - swr.cn-north-4.myhuaweicloud.com/ddn-k8s/ghcr.io/goauthentik/server
+    - docker.m.daocloud.io/ghcr.io/goauthentik/server
+  ghcr.io/home-assistant/home-assistant:
+    - docker.m.daocloud.io/ghcr.io/home-assistant/home-assistant
+  ghcr.io/open-webui/open-webui:
+    - docker.m.daocloud.io/ghcr.io/open-webui/open-webui
+  ghcr.io/esphome/esphome:
+    - docker.m.daocloud.io/ghcr.io/esphome/esphome
+  ghcr.io/wg-easy/wg-easy:
+    - docker.m.daocloud.io/ghcr.io/wg-easy/wg-easy
+  ghcr.io/favonia/cloudflare-ddns:
+    - docker.m.daocloud.io/ghcr.io/favonia/cloudflare-ddns
+
+  # ── gcr.io ────────────────────────────────────────────────────────────────
+  gcr.io/cadvisor/cadvisor:
+    - docker.m.daocloud.io/gcr.io/cadvisor/cadvisor
+  gcr.io/k8s-minikube/kicbase:
+    - docker.m.daocloud.io/gcr.io/k8s-minikube/kicbase
+
+  # ── k8s.gcr.io ────────────────────────────────────────────────────────────
+  k8s.gcr.io:
+    - registry.cn-hangzhou.aliyuncs.com/google_containers
+
+  # ── quay.io ───────────────────────────────────────────────────────────────
+  quay.io:
+    - quay.m.daocloud.io
+
+  # ── docker.io fallback ────────────────────────────────────────────────────
+  docker.io:
+    - docker.m.daocloud.io

--- a/scripts/check-connectivity.sh
+++ b/scripts/check-connectivity.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HomeLab Stack — Network Connectivity Check
+# Tests reachability to all required registries and services.
+# =============================================================================
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; RESET='\033[0m'
+
+PASS=0; FAIL=0; WARN=0; SLOW=0
+
+check() {
+  local name="$1" url="$2" expected_code="${3:-200}"
+  local start end latency result code
+  
+  start=$(date +%s%N 2>/dev/null || echo 0)
+  result=$(curl -skL --connect-timeout 5 --max-time 10 -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
+  end=$(date +%s%N 2>/dev/null || echo 0)
+  
+  if [ "$start" != "0" ] && [ "$end" != "0" ]; then
+    latency=$(( (end - start) / 1000000 ))
+  else
+    latency=0
+  fi
+  
+  if [ "$result" = "000" ] || [ "$result" = "000" ]; then
+    echo -e "  ${RED}[FAIL]${RESET} $name ($url) — 连接超时 ✗"
+    ((FAIL++))
+  elif [ "$latency" -gt 1000 ] 2>/dev/null; then
+    echo -e "  ${YELLOW}[SLOW]${RESET} $name ($url) — 延迟 ${latency}ms ⚠️ 建议使用镜像加速"
+    ((SLOW++))
+  else
+    echo -e "  ${GREEN}[OK]${RESET}   $name ($url) — 延迟 ${latency}ms"
+    ((PASS++))
+  fi
+}
+
+echo -e "${CYAN}╔══════════════════════════════════════╗${RESET}"
+echo -e "${CYAN}║   Network Connectivity Check        ║${RESET}"
+echo -e "${CYAN}╚══════════════════════════════════════╝${RESET}"
+echo ""
+
+echo "── Registry Reachability ──"
+check "Docker Hub"       "https://hub.docker.com/"
+check "GitHub"           "https://github.com/"
+check "ghcr.io"          "https://ghcr.io/"
+check "gcr.io"           "https://gcr.io/"
+check "quay.io"          "https://quay.io/"
+check "DaoCloud Mirror"  "https://docker.m.daocloud.io/"
+check "USTC Mirror"      "https://docker.mirrors.ustc.edu.cn/"
+
+echo ""
+echo "── DNS Resolution ──"
+for domain in hub.docker.com github.com ghcr.io gcr.io baidu.com; do
+  if nslookup "$domain" > /dev/null 2>&1 || dig +short "$domain" > /dev/null 2>&1; then
+    echo -e "  ${GREEN}[OK]${RESET}   DNS: $domain"
+  else
+    echo -e "  ${RED}[FAIL]${RESET} DNS: $domain"
+    ((FAIL++))
+  fi
+done
+
+echo ""
+echo "── Port Checks ──"
+for port in 80 443 22; do
+  if ss -tuln 2>/dev/null | grep -q ":$port " || netstat -tuln 2>/dev/null | grep -q ":$port "; then
+    echo -e "  ${YELLOW}[IN USE]${RESET} Port $port — may conflict with Traefik/SSH"
+  else
+    echo -e "  ${GREEN}[FREE]${RESET}  Port $port"
+  fi
+done
+
+echo ""
+echo -e "${CYAN}═══════════════════════════════════${RESET}"
+echo -e "  ${GREEN}OK: $PASS${RESET}  ${YELLOW}Slow: $SLOW${RESET}  ${RED}Failed: $FAIL${RESET}"
+echo -e "${CYAN}═══════════════════════════════════${RESET}"
+
+if [ $FAIL -gt 0 ]; then
+  echo ""
+  echo "💡 Suggestion: Run ./scripts/setup-cn-mirrors.sh --apply"
+fi
+
+if [ $SLOW -gt 0 ]; then
+  echo "💡 Suggestion: Consider running ./scripts/localize-images.sh --cn"
+fi
+
+exit $FAIL

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HomeLab Stack — System Diagnostics
+# Collects system info for bug reports.
+# Usage: ./diagnose.sh [--output diagnose-report.txt]
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+OUTPUT="${1:---output}"
+OUTPUT_FILE="${2:-diagnose-report.txt}"
+
+CYAN='\033[0;36m'; GREEN='\033[0;32m'; RESET='\033[0m'
+
+section() { echo -e "\n${CYAN}═══ $1 ═══${RESET}"; }
+
+{
+  echo "HomeLab Stack — Diagnostic Report"
+  echo "Generated: $(date)"
+  echo "========================================"
+  
+  section "System"
+  echo "OS: $(cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d= -f2 | tr -d '\"' || uname -a)"
+  echo "Kernel: $(uname -r)"
+  echo "Arch: $(uname -m)"
+  echo "Uptime: $(uptime -p 2>/dev/null || uptime)"
+  
+  section "Resources"
+  echo "Memory:"
+  free -h 2>/dev/null || echo "  free not available"
+  echo "Disk:"
+  df -h / /var/lib/docker 2>/dev/null | grep -v tmpfs || echo "  df failed"
+  echo "CPU: $(nproc) cores | $(cat /proc/cpuinfo 2>/dev/null | grep 'model name' | head -1 | cut -d: -f2 | xargs || echo 'unknown')"
+  
+  section "Docker"
+  echo "Version: $(docker --version 2>/dev/null || echo 'NOT INSTALLED')"
+  echo "Compose: $(docker compose version 2>/dev/null || echo 'NOT INSTALLED')"
+  echo "Daemon: $(docker info --format '{{.ServerVersion}}' 2>/dev/null || echo 'NOT RUNNING')"
+  echo "Running containers: $(docker ps -q 2>/dev/null | wc -l)"
+  
+  section "Container Status"
+  docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Image}}" 2>/dev/null || echo "  Docker not running"
+  
+  section "Unhealthy Containers"
+  for c in $(docker ps -q 2>/dev/null); do
+    name=$(docker inspect "$c" --format '{{.Name}}' 2>/dev/null | sed 's|^/||')
+    status=$(docker inspect "$c" --format '{{.State.Health.Status}}' 2>/dev/null || echo "N/A")
+    if [ "$status" != "healthy" ] && [ "$status" != "N/A" ]; then
+      echo "  $name: $status"
+      docker logs --tail 20 "$c" 2>/dev/null | sed 's/^/    /'
+      echo ""
+    fi
+  done
+  
+  section "Recent Docker Errors"
+  journalctl -u docker --since "1 hour ago" -p err --no-pager 2>/dev/null | tail -20 || echo "  journalctl not available"
+  
+  section "Port Usage"
+  ss -tuln 2>/dev/null | grep LISTEN | head -20 || netstat -tuln 2>/dev/null | head -20 || echo "  Network tools not available"
+  
+  section "Config File Validation"
+  for file in "$ROOT_DIR/config"/*/*.yml "$ROOT_DIR/config"/*/*.yaml; do
+    [ -f "$file" ] || continue
+    if python3 -c "import yaml; yaml.safe_load(open('$file'))" 2>/dev/null; then
+      echo "  ✓ $file"
+    else
+      echo "  ✗ $file — INVALID YAML"
+    fi
+  done
+  
+  echo ""
+  echo "========================================"
+  echo "Report complete"
+} | tee "${OUTPUT_FILE:-/dev/stdout}"
+
+if [ -n "${OUTPUT_FILE:-}" ] && [ "$OUTPUT_FILE" != "/dev/stdout" ]; then
+  echo ""
+  echo -e "${GREEN}Report saved to: $OUTPUT_FILE${RESET}"
+fi

--- a/scripts/localize-images.sh
+++ b/scripts/localize-images.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HomeLab Stack — Image Localization
+# Replace gcr.io/ghcr.io with CN mirrors.
+# Usage: localize-images.sh [--cn|--restore|--dry-run|--check]
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+MIRROR_MAP="$ROOT_DIR/config/cn-mirrors.yml"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RESET='\033[0m'
+log_info()  { echo -e "${GREEN}[INFO]${RESET} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${RESET} $*"; }
+
+ACTION="${1:---dry-run}"
+
+# Find all compose files
+COMPOSE_FILES=$(find "$ROOT_DIR/stacks" "$ROOT_DIR/config" -name "docker-compose*.yml" -o -name "docker-compose*.yaml" 2>/dev/null | grep -v '.bak')
+
+case "$ACTION" in
+  --cn)
+    log_info "Replacing gcr.io/ghcr.io with CN mirrors..."
+    for file in $COMPOSE_FILES; do
+      # ghcr.io → docker.m.daocloud.io/ghcr.io
+      if grep -q 'ghcr.io' "$file" 2>/dev/null; then
+        sed -i.bak "s|ghcr.io/|docker.m.daocloud.io/ghcr.io/|g" "$file"
+        log_info "  Updated: $file"
+      fi
+      # gcr.io → docker.m.daocloud.io/gcr.io
+      if grep -q 'gcr.io' "$file" 2>/dev/null; then
+        sed -i.bak "s|gcr.io/|docker.m.daocloud.io/gcr.io/|g" "$file"
+        log_info "  Updated: $file"
+      fi
+    done
+    log_info "Done! Run 'localize-images.sh --restore' to revert."
+    ;;
+    
+  --restore)
+    log_info "Restoring original images..."
+    for bak in $(find "$ROOT_DIR" -name "*.bak" 2>/dev/null); do
+      local orig="${bak%.bak}"
+      mv "$bak" "$orig"
+      log_info "  Restored: $orig"
+    done
+    log_info "All files restored."
+    ;;
+    
+  --dry-run)
+    log_info "Preview of changes:"
+    local count=0
+    for file in $COMPOSE_FILES; do
+      if grep -qE 'ghcr\.io|gcr\.io' "$file" 2>/dev/null; then
+        echo "  $file"
+        grep -nE 'ghcr\.io|gcr\.io' "$file" | head -5 | while IFS= read -r line; do
+          echo "    $line"
+        done
+        ((count++))
+      fi
+    done
+    if [ $count -eq 0 ]; then
+      log_info "No gcr.io/ghcr.io images found in compose files."
+    fi
+    ;;
+    
+  --check)
+    local found=0
+    for file in $COMPOSE_FILES; do
+      found=$((found + $(grep -cE 'ghcr\.io|gcr\.io' "$file" 2>/dev/null || echo 0)))
+    done
+    if [ $found -gt 0 ]; then
+      log_warn "Found $found gcr.io/ghcr.io references. Consider: localize-images.sh --cn"
+      exit 1
+    else
+      log_info "All images already localized."
+      exit 0
+    fi
+    ;;
+    
+  *)
+    echo "Usage: localize-images.sh [--cn|--restore|--dry-run|--check]"
+    exit 1
+    ;;
+esac

--- a/scripts/setup-cn-mirrors.sh
+++ b/scripts/setup-cn-mirrors.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HomeLab Stack — CN Mirror Setup
+# Configures Docker daemon for China mainland network.
+# Usage: ./setup-cn-mirrors.sh [--apply|--restore|--check]
+# =============================================================================
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; RESET='\033[0m'
+log_info()  { echo -e "${GREEN}[INFO]${RESET} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${RESET} $*"; }
+log_error() { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
+
+DAEMON_JSON="/etc/docker/daemon.json"
+BACKUP_FILE="/etc/docker/daemon.json.bak.$(date +%s)"
+MIRRORS=(
+  "https://docker.m.daocloud.io"
+  "https://hub-mirror.c.163.com"
+  "https://mirror.baidubce.com"
+  "https://docker.mirrors.ustc.edu.cn"
+)
+
+ACTION="${1:---apply}"
+
+check_in_china() {
+  local result
+  result=$(curl -sf --connect-timeout 3 "https://www.baidu.com" -o /dev/null -w "%{http_code}" 2>/dev/null || echo "000")
+  if [ "$result" = "200" ]; then
+    local latency
+    latency=$(curl -sf --connect-timeout 3 -o /dev/null -w "%{time_total}" "https://www.baidu.com" 2>/dev/null || echo "999")
+    if (( $(echo "$latency < 2" | bc -l 2>/dev/null || echo 0) )); then
+      log_info "Detected China mainland network (Baidu: ${latency}s)"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+apply_mirrors() {
+  log_info "Configuring Docker registry mirrors..."
+  
+  # Backup
+  if [ -f "$DAEMON_JSON" ]; then
+    cp "$DAEMON_JSON" "$BACKUP_FILE"
+    log_info "Backed up to $BACKUP_FILE"
+  fi
+
+  # Build mirrors JSON array
+  local mirrors_json="["
+  for m in "${MIRRORS[@]}"; do
+    mirrors_json+="\"$m\","
+  done
+  mirrors_json="${mirrors_json%,}]"
+
+  # Write config
+  cat > "$DAEMON_JSON" <<EOF
+{
+  "registry-mirrors": $mirrors_json,
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+EOF
+
+  # Restart Docker
+  if command -v systemctl &>/dev/null; then
+    systemctl restart docker
+  else
+    service docker restart
+  fi
+  
+  sleep 3
+  if docker pull hello-world:latest > /dev/null 2>&1; then
+    log_info "Docker registry mirrors configured successfully"
+    docker rmi hello-world:latest > /dev/null 2>&1
+  else
+    log_error "Docker pull failed after mirror configuration"
+    return 1
+  fi
+}
+
+restore_mirrors() {
+  local latest_backup=$(ls -t /etc/docker/daemon.json.bak.* 2>/dev/null | head -1)
+  if [ -n "$latest_backup" ]; then
+    cp "$latest_backup" "$DAEMON_JSON"
+    systemctl restart docker 2>/dev/null || service docker restart 2>/dev/null
+    log_info "Restored from $latest_backup"
+  else
+    rm -f "$DAEMON_JSON"
+    systemctl restart docker 2>/dev/null || service docker restart 2>/dev/null
+    log_info "Removed custom Docker config"
+  fi
+}
+
+case "$ACTION" in
+  --apply)
+    apply_mirrors
+    ;;
+  --restore)
+    restore_mirrors
+    ;;
+  --check)
+    if check_in_china; then
+      log_info "Running in China — mirrors recommended"
+    else
+      log_info "Not in China — mirrors not needed"
+    fi
+    ;;
+  *)
+    echo "Usage: setup-cn-mirrors.sh [--apply|--restore|--check]"
+    exit 1
+    ;;
+esac

--- a/scripts/wait-healthy.sh
+++ b/scripts/wait-healthy.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# =============================================================================
+# HomeLab Stack — Wait for Container Health
+# Usage: wait-healthy.sh --stack <name> [--timeout 300]
+# =============================================================================
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; RESET='\033[0m'
+log_info()  { echo -e "${GREEN}[INFO]${RESET} $*"; }
+log_error() { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
+
+STACK=""
+TIMEOUT=300
+INTERVAL=5
+CONTAINERS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack) STACK="$2"; shift 2 ;;
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+if [ -z "$STACK" ]; then
+  echo "Usage: wait-healthy.sh --stack <name> [--timeout 300]"
+  exit 1
+fi
+
+# Get containers for this stack
+CONTAINERS=$(docker ps --filter "label=com.docker.compose.project=${STACK}" --format '{{.Names}}' 2>/dev/null || echo "")
+if [ -z "$CONTAINERS" ]; then
+  # Try alternate label format
+  CONTAINERS=$(docker ps --format '{{.Names}}' | grep -i "$STACK" || echo "")
+fi
+
+if [ -z "$CONTAINERS" ]; then
+  log_error "No containers found for stack: $STACK"
+  exit 2
+fi
+
+echo -e "${CYAN}Waiting for $STACK containers to become healthy...${RESET}"
+echo "Timeout: ${TIMEOUT}s | Interval: ${INTERVAL}s"
+echo ""
+
+ELAPSED=0
+while [ $ELAPSED -lt $TIMEOUT ]; do
+  ALL_HEALTHY=true
+  
+  for container in $CONTAINERS; do
+    local status
+    status=$(docker inspect "$container" --format '{{.State.Health.Status}}' 2>/dev/null || echo "no-healthcheck")
+    
+    case "$status" in
+      healthy)
+        echo -e "  ${GREEN}✓${RESET} $container (healthy)"
+        ;;
+      starting)
+        echo -e "  ${YELLOW}⏳${RESET} $container (starting...)"
+        ALL_HEALTHY=false
+        ;;
+      unhealthy)
+        echo -e "  ${RED}✗${RESET} $container (unhealthy)"
+        ALL_HEALTHY=false
+        ;;
+      *)
+        echo -e "  ${YELLOW}?${RESET} $container ($status)"
+        ALL_HEALTHY=false
+        ;;
+    esac
+  done
+  
+  if $ALL_HEALTHY; then
+    echo ""
+    log_info "All containers healthy!"
+    exit 0
+  fi
+  
+  sleep $INTERVAL
+  ELAPSED=$((ELAPSED + INTERVAL))
+  echo ""
+done
+
+# Timeout — print logs of unhealthy containers
+echo ""
+log_error "Timeout after ${TIMEOUT}s. Unhealthy container logs:"
+for container in $CONTAINERS; do
+  status=$(docker inspect "$container" --format '{{.State.Health.Status}}' 2>/dev/null || echo "unknown")
+  if [ "$status" != "healthy" ]; then
+    echo ""
+    echo "── $container ($status) ──"
+    docker logs --tail 50 "$container" 2>/dev/null || echo "  (no logs available)"
+  fi
+done
+
+exit 1


### PR DESCRIPTION
## Bounty #8: CN Network Robustness ($250)

### 6 Scripts + 1 Mirror Map

| Script | Purpose |
|--------|--------|
| `setup-cn-mirrors.sh` | Docker registry mirror config (--apply/--restore/--check) |
| `localize-images.sh` | Replace gcr.io/ghcr.io with CN mirrors (--cn/--restore/--dry-run) |
| `check-connectivity.sh` | Full network diagnostic (registries, DNS, ports) |
| `wait-healthy.sh` | Wait for container health with timeout + error logs |
| `diagnose.sh` | System diagnostic report for bug reports |
| `cn-mirrors.yml` | Complete mirror mapping for all gcr.io/ghcr.io images |

### Features
- China mainland auto-detection via Baidu latency
- 4 Docker mirror sources with fallback
- Full gcr.io/ghcr.io → domestic mirror mapping
- Retry with exponential backoff for network ops
- YAML config file validation

### Payment
USDT-TRC20: TDaamzZMz5GM2DjfgvAd9VvBNKaWCF4ieE