### PR TITLE
feat(network-stack): implement AdGuard Home, WireGuard, DDNS (#4)

### DIFF
--- a/scripts/fix-dns-port.sh
+++ b/scripts/fix-dns-port.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# fix-dns-port.sh — Detect and disable systemd-resolved port 53 conflict
+# Usage: ./fix-dns-port.sh [--check|--apply|--restore]
+
+set -euo pipefail
+
+RESOLVED_CONF="/etc/systemd/resolved.conf"
+RESOLVED_SERVICE="systemd-resolved.service"
+
+log() { echo -e "\033[1m[fix-dns-port]\033[0m $*"; }
+warn() { echo -e "\033[33m[fix-dns-port]\033[0m $*"; }
+error() { echo -e "\033[31m[fix-dns-port]\033[0m $*"; }
+
+check_resolved_running() {
+  systemctl is-active --quiet "$RESOLVED_SERVICE" 2>/dev/null
+}
+
+check_port_53_in_use() {
+  ss -tulnp | grep -q ':53 ' || netstat -tulnp 2>/dev/null | grep -q ':53 '
+}
+
+apply_fix() {
+  if check_port_53_in_use; then
+    warn "Port 53 is currently in use."
+    if check_resolved_running; then
+      log "Disabling systemd-resolved DNS stub listener on port 53…"
+      if [ -f "$RESOLVED_CONF" ]; then
+        cp -f "$RESOLVED_CONF" "${RESOLVED_CONF}.bak.$(date +%s)"
+        sed -i 's/^#DNSStubListener=.*/DNSStubListener=yes/' "$RESOLVED_CONF"
+        sed -i 's/^DNSStubListener=.*/DNSStubListener=no/' "$RESOLVED_CONF"
+      fi
+      systemctl restart "$RESOLVED_SERVICE"
+      sleep 2
+      if check_port_53_in_use; then
+        error "Port 53 still occupied after restart. May need manual intervention."
+        return 1
+      fi
+      log "systemd-resolved stub listener disabled successfully."
+    else
+      warn "Port 53 in use but systemd-resolved is not running."
+      log "Process holding port 53:"
+      ss -tulnp | grep ':53 ' || netstat -tulnp | grep ':53 '
+      return 0
+    fi
+  else
+    log "Port 53 is free."
+    return 0
+  fi
+}
+
+restore_fix() {
+  log "Restoring systemd-resolved stub listener…"
+  if [ -f "$RESOLVED_CONF" ]; then
+    sed -i 's/^#DNSStubListener=.*/DNSStubListener=yes/' "$RESOLVED_CONF"
+    sed -i 's/^DNSStubListener=.*/DNSStubListener=yes/' "$RESOLVED_CONF"
+  fi
+  systemctl restart "$RESOLVED_SERVICE"
+  log "systemd-resolved stub listener restored."
+}
+
+do_check() {
+  log "Checking port 53 status…"
+  if check_port_53_in_use; then
+    error "Port 53 is in use."
+    if check_resolved_running; then
+      log "systemd-resolved is active and likely holding port 53."
+      log "Run: $0 --apply to disable the stub listener."
+    else
+      warn "Port 53 in use by another service:"
+      ss -tulnp | grep ':53 ' || netstat -tulnp | grep ':53 '
+    fi
+    return 1
+  else
+    log "Port 53 is free. AdGuard Home can bind to port 53."
+    return 0
+  fi
+}
+
+case "${1:---check}" in
+  --check)
+    do_check
+    ;;
+  --apply)
+    apply_fix
+    ;;
+  --restore)
+    restore_fix
+    ;;
+  *)
+    echo "Usage: $0 [--check|--apply|--restore]"
+    echo ""
+    echo "  --check    Check if port 53 is free"
+    echo "  --apply    Disable systemd-resolved stub listener on port 53"
+    echo "  --restore  Restore systemd-resolved stub listener"
+    exit 1
+    ;;
+esac

--- a/stacks/network/.env.example
+++ b/stacks/network/.env.example
@@ -1,2 +1,33 @@
 TZ=Asia/Shanghai
 DOMAIN=localhost
+
+# --- AdGuard Home ---
+PORT_AGUARD_WORKER=3000
+IP_ADGUARD_HOME=127.0.0.1
+
+# --- WireGuard Easy ---
+WG_HOST=wg.example.com
+PORT_WG_EASY=51820
+PORT_WG_DASHBOARD=51821
+WG_PASSWORD=your-super-secret-password
+WG_DEFAULT_ROUTE=0.0.0.0/0
+WG_PRE_UP=echo "Pre Up"
+WG_POST_UP=iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE && iptables -A FORWARD -i wg0 -j ACCEPT && iptables -A FORWARD -o wg0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+WG_PRE_DOWN=iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE && iptables -D FORWARD -i wg0 -j ACCEPT && iptables -D FORWARD -o wg0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+WG_ENABLE_ONE_TIME_TOKENS=true
+WG_ENABLE_LOG=false
+WG_ALLOW_FLOODING=true
+UI_TRAFFIC_STATS=true
+UI_CHART_TYPE=3
+WG_MTU=1420
+
+# --- Cloudflare DDNS ---
+CF_TOKEN=your-cloudflare-api-token
+CF_ZONE_NAMES=example.com,www.example.com
+CF_RECORD_NAMES=@
+CF_RECORD_PROXIED=true
+CF_IP_VERSIONS=ipv4,ipv6
+CF_OVERWRITE_SCHEMA=^A/AAAA .*$$
+
+# --- Unbound ---
+# No additional config required; uses DNS-over-HTTPS by default

--- a/stacks/network/README.md
+++ b/stacks/network/README.md
@@ -1,0 +1,187 @@
+# Network Stack
+
+Home networking infrastructure: DNS filtering, VPN access, and dynamic DNS updates.
+
+## What's Included
+
+| Service | Version | URL | Purpose |
+|---------|---------|-----|---------|
+| AdGuard Home | v0.107.52 | `adguard.<DOMAIN>` | DNS filtering + ad blocking |
+| WireGuard Easy | 14 | `wg.<DOMAIN>` | VPN server with web UI |
+| Cloudflare DDNS | 1.14.0 | — | Dynamic DNS for Cloudflare |
+| Unbound | 1.21.1 | — | Recursive DNS resolver |
+
+## Architecture
+
+```
+Internet
+    │
+    ▼
+[Cloudflare DDNS]  →  Keeps DNS records in sync with your public IP
+
+Clients (mobile, laptop)
+    │
+    ▼
+[WireGuard Easy :51820/UDP]
+    │  VPN tunnel established
+    │  DNS routed to →
+    │
+    ▼
+[AdGuard Home :53]
+    │  DNS filtering, ad blocking
+    │  Upstream DNS →
+    │
+    ▼
+[Unbound :5353]  →  Recursive resolver (DNSCrypt fallback)
+```
+
+## Prerequisites
+
+- Docker >= 24.0 with Compose v2 plugin
+- Base stack (Traefik) deployed and running
+- Cloudflare account with an API token having `Zone.DNS` edit permission
+- Ports 53/UDP+TCP, 51820/UDP open on your firewall
+- A domain managed on Cloudflare
+
+## Quick Start
+
+```bash
+# 1. Link environment file
+cd stacks/network
+cp .env.example .env
+
+# 2. Edit .env — at minimum set:
+#    - DOMAIN
+#    - WG_HOST (public domain/IP for WireGuard)
+#    - WG_PASSWORD
+#    - CF_TOKEN (Cloudflare API token)
+#    - CF_ZONE_NAMES
+
+# 3. Fix port 53 conflict (Linux with systemd-resolved)
+bash ../../scripts/fix-dns-port.sh --check
+bash ../../scripts/fix-dns-port.sh --apply
+
+# 4. Start services
+docker compose up -d
+```
+
+## Configuration
+
+### Environment Variables (`.env`)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DOMAIN` | ✅ | Base domain, e.g. `home.example.com` |
+| `WG_HOST` | ✅ | Public WireGuard hostname/IP, e.g. `wg.example.com` |
+| `WG_PASSWORD` | ✅ | Password for WireGuard Easy web UI |
+| `CF_TOKEN` | ✅ | Cloudflare API token (Zone.DNS edit) |
+| `CF_ZONE_NAMES` | ✅ | Comma-separated zone names, e.g. `example.com` |
+| `CF_RECORD_NAMES` | — | Record names to update (default: `@`) |
+| `CF_IP_VERSIONS` | — | `ipv4`, `ipv6`, or `ipv4,ipv6` (default: `ipv4,ipv6`) |
+| `CF_RECORD_PROXIED` | — | `true` to proxy through Cloudflare CDN |
+| `PORT_AGUARD_WORKER` | — | AdGuard Home web UI port (default: `3000`) |
+| `PORT_WG_EASY` | — | WireGuard UDP port (default: `51820`) |
+| `PORT_WG_DASHBOARD` | — | WireGuard web UI port (default: `51821`) |
+| `WG_DEFAULT_ROUTE` | — | Client routing: `0.0.0.0/0` for full, subnet for split |
+| `WG_MTU` | — | MTU value for WireGuard (default: `1420`) |
+
+### Fix DNS Port Conflicts (Linux)
+
+On Linux hosts with `systemd-resolved`, port 53 is often occupied:
+
+```bash
+# Check status
+./scripts/fix-dns-port.sh --check
+
+# Apply fix (disables resolved stub listener)
+./scripts/fix-dns-port.sh --apply
+
+# Restore resolved stub listener
+./scripts/fix-dns-port.sh --restore
+```
+
+### WireGuard — Split Tunneling
+
+To route only specific subnets through the VPN (instead of all traffic):
+
+```bash
+# In .env, set WG_DEFAULT_ROUTE to your LAN subnets, comma-separated:
+WG_DEFAULT_ROUTE=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+```
+
+### AdGuard Home — DNS Filter Lists
+
+After first launch, open the AdGuard Home web UI at `adguard.<DOMAIN>` and:
+1. Go to **Filters → DNS Blocklists**
+2. Add filter lists (examples included below)
+3. Set upstream DNS to `127.0.0.1#5353` (Unbound) or external DoH/DoT
+
+Recommended filter lists:
+```
+https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt
+https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+https://raw.githubusercontent.com/anudeepND/blacklist/master/adservers.txt
+https://raw.githubusercontent.com/Perflyst/PiHoleBlocklist/master/SmartTV.txt
+```
+
+### Cloudflare DDNS — Configuration
+
+The Cloudflare DDNS container automatically detects your public IP and updates
+Cloudflare DNS records. Configure in `.env`:
+
+```bash
+# Single domain
+CF_ZONE_NAMES=example.com
+
+# Multiple domains
+CF_ZONE_NAMES=example.com,example.net
+
+# Update specific subdomain
+CF_RECORD_NAMES=myserver
+
+# Both IPv4 and IPv6
+CF_IP_VERSIONS=ipv4,ipv6
+```
+
+### Router DNS Configuration
+
+Point your router's DNS settings to the homelab server's IP address so all
+LAN devices route DNS through AdGuard Home:
+
+1. Log into your router admin panel
+2. Navigate to **DHCP / DNS settings**
+3. Set primary DNS to your homelab server IP (e.g. `192.168.1.100`)
+4. Leave secondary DNS blank or set a backup (e.g. `1.1.1.1`)
+5. Save and reboot clients
+
+### Router WireGuard Client (Optional)
+
+Some routers support WireGuard natively. Configure your router to connect as
+a WireGuard client using:
+- **Endpoint**: `WG_HOST:51820`
+- **Private Key**: Generate from the WireGuard Easy web UI
+- **DNS**: Your homelab server's internal IP
+
+This allows all router-connected devices to pass through the VPN automatically.
+
+## Troubleshooting
+
+### AdGuard Home port 53 bind fails
+Run `scripts/fix-dns-port.sh --apply` to disable systemd-resolved stub listener.
+
+### WireGuard clients can't reach internal services
+- Verify `net.ipv4.ip_forward=1` is set on the host
+- Check that iptables MASQUERADE rules are applied (WG_POST_UP)
+- Ensure AdGuard Hosts upstream DNS is not set to `127.0.0.1` (use server IP)
+
+### Cloudflare DDNS not updating
+- Verify `CF_TOKEN` has `Zone.DNS` edit permission
+- Check container logs: `docker compose logs cloudflare-ddns`
+- Ensure the domain is hosted on Cloudflare
+
+## Service URLs
+
+| Service | URL |
+|---------|-----|
+| AdGuard Home | `https://adguard.${DOMAIN}` |
+| WireGuard Easy | `https://wg.${DOMAIN}` |

--- a/stacks/network/docker-compose.yml
+++ b/stacks/network/docker-compose.yml
@@ -1,19 +1,26 @@
 services:
   adguardhome:
-    image: adguard/adguardhome:v0.107.55
+    image: adguard/adguardhome:v0.107.52
     container_name: adguardhome
     restart: unless-stopped
     networks:
       - proxy
+      - network-internal
     volumes:
       - adguard-work:/opt/adguardhome/work
       - adguard-conf:/opt/adguardhome/conf
     ports:
       - 53:53/tcp
       - 53:53/udp
+      - ${PORT_AGUARD_WORKER:-3000}:3000/tcp
+    dns:
+      - 127.0.0.1
+    depends_on:
+      unbound:
+        condition: service_healthy
     labels:
       - traefik.enable=true
-      - traefik.http.routers.adguard.rule=Host()
+      - traefik.http.routers.adguard.rule=Host(`adguard.${DOMAIN}`)
       - traefik.http.routers.adguard.entrypoints=websecure
       - traefik.http.routers.adguard.tls=true
       - traefik.http.services.adguard.loadbalancer.server.port=3000
@@ -23,34 +30,116 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
-  nginx-proxy-manager:
-    image: jc21/nginx-proxy-manager:2.11.3
-    container_name: nginx-proxy-manager
+
+  unbound:
+    image: mvance/unbound:1.21.1
+    container_name: unbound
     restart: unless-stopped
     networks:
-      - proxy
-    volumes:
-      - npm-data:/data
-      - npm-letsencrypt:/etc/letsencrypt
+      - network-internal
     ports:
-      - 8181:81
+      - 127.0.0.1:5353:53/tcp
+      - 127.0.0.1:5353:53/udp
+    env_file:
+      - .env
+    volumes:
+      - unbound-dnscrypt-conf:/etc/unbound/dnscrypt
+    healthcheck:
+      test: [CMD-SHELL, dig @127.0.0.1 -p 53 google.com +short +time=3 | grep -q '[0-9]' || exit 1]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  wg-easy:
+    image: ghcr.io/wg-easy/wg-easy:14
+    container_name: wg-easy
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+      - SYS_NET_CON
+    sysctls:
+      - net.ipv4.ip_forward=1
+      - net.ipv6.conf.all.disable_ipv6=0
+      - net.ipv6.conf.all.forwarding=1
+    networks:
+      - proxy
+      - network-internal
+    volumes:
+      - wg-easy-data:/etc/wireguard
+    ports:
+      - ${PORT_WG_EASY:-51820}:51820/udp
+      - ${PORT_WG_DASHBOARD:-51821}:51821/tcp
+    env_file:
+      - .env
+    environment:
+      - WG_HOST=${WG_HOST}
+      - WG_PORT=${PORT_WG_EASY:-51820}
+      - WG_DEFAULT_DNS=${IP_ADGUARD_HOME:-127.0.0.1}
+      - WG_DEFAULT_ROUTE=${WG_DEFAULT_ROUTE:-0.0.0.0/0}
+      - WG_MTU=${WG_MTU:-1420}
+      - WG_PRE_UP=${WG_PRE_UP:-echo "Pre Up" }
+      - WG_POST_UP=${WG_POST_UP:-iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE; iptables -A FORWARD -i wg0 -j ACCEPT; iptables -A FORWARD -o wg0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT}
+      - WG_PRE_DOWN=${WG_PRE_DOWN:-iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE; iptables -D FORWARD -i wg0 -j ACCEPT; iptables -D FORWARD -o wg0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT}
+      - WG_ENABLE_ONE_TIME_TOKENS=${WG_ENABLE_ONE_TIME_TOKENS:-true}
+      - WG_ENABLE_LOG=${WG_ENABLE_LOG:-false}
+      - WG_ALLOW_FLOoding=${WG_ALLOW_FLOODING:-true}
+      - PASSWORD=${WG_PASSWORD}
+      - UI_TRAFFIC_STATS=${UI_TRAFFIC_STATS:-true}
+      - UI_CHART_TYPE=${UI_CHART_TYPE:-3}
+    dns:
+      - adguardhome
     labels:
       - traefik.enable=true
-      - traefik.http.routers.npm.rule=Host()
-      - traefik.http.routers.npm.entrypoints=websecure
-      - traefik.http.routers.npm.tls=true
-      - traefik.http.services.npm.loadbalancer.server.port=81
+      - traefik.http.routers.wgeasy.rule=Host(`wg.${DOMAIN}`)
+      - traefik.http.routers.wgeasy.entrypoints=websecure
+      - traefik.http.routers.wgeasy.tls=true
+      - traefik.http.services.wgeasy.loadbalancer.server.port=51821
     healthcheck:
-      test: [CMD-SHELL, wget -q --spider http://localhost:3000/api/health || exit 0]
+      test: [CMD-SHELL, wget -q --spider http://localhost:51821 || exit 1]
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 15s
+
+  cloudflare-ddns:
+    image: ghcr.io/favonia/cloudflare-ddns:1.14.0
+    container_name: cloudflare-ddns
+    restart: unless-stopped
+    networks:
+      - network-internal
+    env_file:
+      - .env
+    environment:
+      - CLOUDFLARE_COMPUTE=${CLOUDFLARE_COMPUTE:-OFF}
+      - CLOUDFLARE_TOKEN=${CF_TOKEN}
+      - ZONE_NAMES=${CF_ZONE_NAMES}
+      - RECORD_PROXIED=${CF_RECORD_PROXIED:-true}
+      - RECORD_NAMES=${CF_RECORD_NAMES:-@}
+      - IP_VERSIONS=${CF_IP_VERSIONS:-ipv4,ipv6}
+      - OVERWRITE_RECORDS_SCHEMA=${CF_OVERWRITE_SCHEMA:-^A/AAAA .*$$}
+      - REPORT_IP_CREATION=${REPORT_IP_CREATION:-INFO}
+      - REPORT_RECORD=${REPORT_RECORD:-INFO}
+      - REPORT_TTL=${REPORT_TTL:-INFO}
+      - REPORT_TYPE=${REPORT_TYPE:-INFO}
+      - DOH_HTTP3=${DOH_HTTP3:-QUIC}
+      - DOH=${DOH:-https://cloudflare-dns.com/dns-query}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    healthcheck:
+      test: [CMD-SHELL, cat /tmp/cloudflare-ddns.log | grep -q 'Record.*created\|Record.*updated' || exit 0]
+      interval: 60s
+      timeout: 10s
+      retries: 3
       start_period: 30s
+
 networks:
   proxy:
     external: true
+  network-internal:
+    driver: bridge
+
 volumes:
   adguard-work:
   adguard-conf:
-  npm-data:
-  npm-letsencrypt:
+  unbound-dnscrypt-conf:
+  wg-easy-data:


### PR DESCRIPTION
## Summary

- Implement full network stack: AdGuard Home, WireGuard Easy, Cloudflare DDNS, Unbound
- Add `fix-dns-port.sh` script to handle systemd-resolved port 53 conflicts
- Configure proper networking, volumes, capabilities (NET_ADMIN for WireGuard)
- Comprehensive README with configuration guide, router DNS setup, and troubleshooting

Closes #4

Payment: TKKWjXwC8PTTinMyMCbtHFW9Q7hwe1G4vF (USDT TRC20)