### PR TITLE
feat(home-automation): Complete Home Automation Stack — Closes #7

### DIFF
--- a/stacks/home-automation/.env.example
+++ b/stacks/home-automation/.env.example
@@ -1,0 +1,39 @@
+# =============================================================================
+# HomeLab Stack — Home Automation Environment Configuration
+# Copy this file to .env and fill in your values
+# Run: cp .env.example .env
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# GENERAL
+# -----------------------------------------------------------------------------
+TZ=Asia/Shanghai
+DOMAIN=localhost
+
+# -----------------------------------------------------------------------------
+# MQTT (Mosquitto)
+# -----------------------------------------------------------------------------
+# Ports for MQTT broker (default: 1883 for MQTT, 9001 for WebSocket)
+MQTT_PORT=1883
+MQTT_WS_PORT=9001
+
+# MQTT credentials — used by all services to connect to the broker
+# IMPORTANT: Change these before deployment!
+MQTT_USER=homeassistant
+MQTT_PASSWORD=CHANGEME_MQTT_PASSWORD
+
+# -----------------------------------------------------------------------------
+# ZIGBEE
+# -----------------------------------------------------------------------------
+# Path to your Zigbee USB adapter
+# Common values:
+#   /dev/ttyUSB0  — CC2531, Sonoff Zigbee 3.0 USB Dongle Plus
+#   /dev/ttyACM0  — ConBee II, some Sonoff dongles
+# Check with: ls -la /dev/ttyUSB* /dev/ttyACM*
+ZIGBEE_SERIAL_DEVICE=/dev/ttyUSB0
+
+# -----------------------------------------------------------------------------
+# NODE-RED (optional)
+# -----------------------------------------------------------------------------
+# Node-RED uses Traefik for HTTPS access: https://nodered.<DOMAIN>
+# No additional configuration needed — data persisted in Docker volume

--- a/stacks/home-automation/README.md
+++ b/stacks/home-automation/README.md
@@ -1,0 +1,291 @@
+# Home Automation Stack
+
+完整的智能家居自动化栈，支持 Zigbee 设备接入、可视化流程编排和 ESP 设备固件管理。
+
+## 服务清单
+
+| 服务 | 版本 | URL | 用途 |
+|------|------|-----|------|
+| Home Assistant | 2024.9.3 | `http://<host_ip>:8123` | 智能家居中枢 |
+| Node-RED | 4.0.3 | `https://nodered.<DOMAIN>` | 可视化流程编排 |
+| Mosquitto | 2.0.19 | `mqtt://<host_ip>:1883` | MQTT Broker |
+| Zigbee2MQTT | 1.40.2 | `https://zigbee.<DOMAIN>` | Zigbee 设备网关 |
+| ESPHome | 2024.9.3 | `http://<host_ip>:6052` | ESP 设备固件管理 |
+
+## 架构图
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        LAN / Network                                │
+│                                                                     │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────────────┐  │
+│  │ Zigbee USB   │    │ ESP Devices  │    │ Smart Home Devices   │  │
+│  │ Dongle       │    │ (ESP32/8266) │    │ (mDNS/UPnP)          │  │
+│  └──────┬───────┘    └──────┬───────┘    └──────────┬───────────┘  │
+│         │                   │                        │              │
+│         ▼                   ▼                        ▼              │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────────────┐  │
+│  │ Zigbee2MQTT  │    │   ESPHome    │    │   Home Assistant     │  │
+│  │ :8080        │    │   :6052      │    │   :8123 (host net)   │  │
+│  └──────┬───────┘    └──────┬───────┘    └──────────┬───────────┘  │
+│         │                   │                        │              │
+│         └───────────────────┼────────────────────────┘              │
+│                             │                                       │
+│                             ▼                                       │
+│                    ┌─────────────────┐                              │
+│                    │    Mosquitto    │                              │
+│                    │  MQTT :1883     │                              │
+│                    │  WS   :9001     │                              │
+│                    └────────┬────────┘                              │
+│                             │                                       │
+│                             ▼                                       │
+│                    ┌─────────────────┐                              │
+│                    │    Node-RED     │                              │
+│                    │   :1880         │                              │
+│                    │  (Traefik)      │                              │
+│                    └─────────────────┘                              │
+│                                                                     │
+│                    ┌─────────────────┐                              │
+│                    │     Traefik     │                              │
+│                    │  (Reverse Proxy)│                              │
+│                    └─────────────────┘                              │
+└─────────────────────────────────────────────────────────────────────┘
+
+数据流:
+  Zigbee Device ──► Zigbee2MQTT ──► MQTT ──► Home Assistant
+  ESP Device ──────► ESPHome ──────► MQTT ──► Home Assistant
+  MQTT ────────────► Node-RED ─────► Automations ──► Devices
+```
+
+## 网络模式说明
+
+### Home Assistant — 为什么使用 host 网络模式？
+
+Home Assistant 使用 `network_mode: host` 是为了支持以下功能：
+
+1. **mDNS 设备发现** — 自动发现同一局域网内的智能家居设备（如 Chromecast、Sonos）
+2. **UPnP/SSDP** — 发现 UPnP 兼容设备
+3. **DHCP 服务器集成** — 用于设备追踪
+4. **ESPHome OTA 更新** — 通过网络更新 ESP 设备固件
+5. **HomeKit 集成** — HomeKit Accessory Protocol 需要 mDNS
+
+**不使用 host 模式的限制：**
+- 无法自动发现 Chromecast、Sonos 等设备
+- 需要手动配置每个集成
+- 部分设备追踪功能失效
+
+### Bridge 模式替代方案
+
+如果不需要 mDNS 发现，可以在 `docker-compose.yml` 中：
+1. 注释掉当前的 `homeassistant` 服务定义
+2. 取消注释标记为 "Bridge Mode Alternative" 的服务定义
+3. Home Assistant 将通过 Traefik 反代访问：`https://ha.<DOMAIN>`
+
+## 前置条件
+
+- Docker >= 24.0 with Compose v2 plugin
+- `proxy` Docker network 已创建 (`docker network create proxy`)
+- Zigbee USB 适配器（如 Sonoff Zigbee 3.0 USB Dongle Plus）
+- 基础设施栈（Traefik）已部署
+
+## 快速开始
+
+### 1. 配置环境变量
+
+```bash
+cd stacks/home-automation
+cp .env.example .env
+```
+
+编辑 `.env` 文件，修改以下关键配置：
+
+```bash
+# 必须修改
+DOMAIN=yourdomain.com
+MQTT_PASSWORD=<强密码>
+ZIGBEE_SERIAL_DEVICE=/dev/ttyUSB0  # 你的 Zigbee 适配器路径
+```
+
+### 2. 生成 Mosquitto 密码文件
+
+```bash
+# 替换 .env 中的 MQTT_PASSWORD 后，生成密码文件
+docker run --rm -v $(pwd)/config/mosquitto:/mosquitto/config \
+  eclipse-mosquitto:2.0.19 \
+  mosquitto_passwd -c -b /mosquitto/config/passwd \
+  homeassistant YOUR_PASSWORD_HERE
+
+# 添加其他用户
+docker run --rm -v $(pwd)/config/mosquitto:/mosquitto/config \
+  eclipse-mosquitto:2.0.19 \
+  mosquitto_passwd -b /mosquitto/config/passwd \
+  zigbee2mqtt YOUR_PASSWORD_HERE
+
+docker run --rm -v $(pwd)/config/mosquitto:/mosquitto/config \
+  eclipse-mosquitto:2.0.19 \
+  mosquitto_passwd -b /mosquitto/config/passwd \
+  nodered YOUR_PASSWORD_HERE
+
+docker run --rm -v $(pwd)/config/mosquitto:/mosquitto/config \
+  eclipse-mosquitto:2.0.19 \
+  mosquitto_passwd -b /mosquitto/config/passwd \
+  esphome YOUR_PASSWORD_HERE
+```
+
+### 3. 检查 Zigbee 适配器
+
+```bash
+# 查看可用的串口设备
+ls -la /dev/ttyUSB* /dev/ttyACM*
+
+# 确保当前用户有权限访问
+sudo usermod -aG dialout $USER
+# 重新登录后生效
+```
+
+### 4. 启动服务
+
+```bash
+docker compose up -d
+```
+
+### 5. 验证服务状态
+
+```bash
+# 检查所有容器状态
+docker compose ps
+
+# 检查健康状态
+docker compose ps --format "table {{.Name}}\t{{.Status}}"
+
+# 查看日志
+docker compose logs -f
+```
+
+## 配置说明
+
+### Zigbee2MQTT 首次配置
+
+启动后访问 Zigbee2MQTT Web UI，配置 MQTT 连接：
+
+```yaml
+# Zigbee2MQTT 配置（通过 Web UI 或 /app/data/configuration.yaml）
+mqtt:
+  base_topic: zigbee2mqtt
+  server: mqtt://mosquitto:1883
+  user: zigbee2mqtt
+  password: YOUR_PASSWORD_HERE
+
+serial:
+  port: /dev/ttyUSB0
+
+advanced:
+  network_key: GENERATE  # 首次启动自动生成
+  pan_id: GENERATE
+```
+
+### Home Assistant MQTT 集成
+
+1. 打开 Home Assistant → 设置 → 设备与服务
+2. 添加集成 → MQTT
+3. 配置：
+   - Broker: `localhost`（host 模式）或 `mosquitto`（bridge 模式）
+   - Port: `1883`
+   - Username: `homeassistant`
+   - Password: `<你的密码>`
+
+### Node-RED MQTT 连接
+
+1. 打开 Node-RED → 添加 MQTT 节点
+2. 配置连接：
+   - Server: `mosquitto`
+   - Port: `1883`
+   - Username: `nodered`
+   - Password: `<你的密码>`
+
+### ESPHome 首次使用
+
+1. 访问 `http://<host_ip>:6052`
+2. 创建新设备或导入现有配置
+3. ESPHome 通过 host 网络可直接进行 OTA 无线更新
+
+## 国内网络适配
+
+如遇到镜像拉取慢，使用国内镜像源：
+
+```bash
+# 替换 ghcr.io 镜像
+# Home Assistant
+ghcr.io/home-assistant/home-assistant:2024.9.3
+→ swr.cn-north-4.myhuaweicloud.com/ddn-k8s/ghcr.io/home-assistant/home-assistant:2024.9.3
+
+# ESPHome
+ghcr.io/esphome/esphome:2024.9.3
+→ swr.cn-north-4.myhuaweicloud.com/ddn-k8s/ghcr.io/esphome/esphome:2024.9.3
+```
+
+在 `docker-compose.yml` 中取消注释 CN alternative 镜像行，并注释原始镜像行。
+
+## 端口说明
+
+| 端口 | 协议 | 服务 | 说明 |
+|------|------|------|------|
+| 8123 | HTTP | Home Assistant | Web UI（host 模式） |
+| 1883 | MQTT | Mosquitto | MQTT 消息协议 |
+| 9001 | WS | Mosquitto | MQTT WebSocket |
+| 1880 | HTTP | Node-RED | Web UI（Traefik 反代） |
+| 8080 | HTTP | Zigbee2MQTT | Web UI（Traefik 反代） |
+| 6052 | HTTP | ESPHome | Web UI（host 模式） |
+
+## 常见问题
+
+### Q: Zigbee2MQTT 无法连接到串口设备
+
+```bash
+# 检查设备是否存在
+ls -la /dev/ttyUSB*
+
+# 检查权限
+sudo usermod -aG dialout $USER
+# 或临时：sudo chmod 666 /dev/ttyUSB0
+
+# 检查是否被其他程序占用
+sudo fuser /dev/ttyUSB0
+```
+
+### Q: Home Assistant 无法发现设备
+
+确保使用 `network_mode: host`。如果使用 bridge 模式，需要手动配置集成。
+
+### Q: Mosquitto 连接被拒绝
+
+```bash
+# 检查密码文件是否正确生成
+docker exec mosquitto cat /mosquitto/config/passwd
+
+# 重新生成密码文件
+docker run --rm -v $(pwd)/config/mosquitto:/mosquitto/config \
+  eclipse-mosquitto:2.0.19 \
+  mosquitto_passwd -c -b /mosquitto/config/passwd mqttuser mqttPass123
+```
+
+### Q: ESPHome OTA 更新失败
+
+确保 ESPHome 使用 host 网络模式，且 ESP 设备与服务器在同一局域网。
+
+## 数据持久化
+
+所有数据存储在 Docker volumes 中：
+
+| Volume | 服务 | 内容 |
+|--------|------|------|
+| `ha-config` | Home Assistant | 配置、自动化、设备数据 |
+| `mosquitto-data` | Mosquitto | 持久化消息 |
+| `mosquitto-log` | Mosquitto | 日志 |
+| `node-red-data` | Node-RED | 流程、配置 |
+| `zigbee2mqtt-data` | Zigbee2MQTT | 设备配对、配置 |
+| `esphome-data` | ESPHome | 设备固件配置 |
+
+## License
+
+MIT

--- a/stacks/home-automation/config/mosquitto/acl
+++ b/stacks/home-automation/config/mosquitto/acl
@@ -1,0 +1,14 @@
+# Mosquitto ACL — Access Control List
+# Format: user <username> / topic [read|write|readwrite] <topic>
+
+user homeassistant
+topic readwrite #
+
+user zigbee2mqtt
+topic readwrite zigbee2mqtt/#
+
+user nodered
+topic readwrite #
+
+user esphome
+topic readwrite esphome/#

--- a/stacks/home-automation/config/mosquitto/mosquitto.conf
+++ b/stacks/home-automation/config/mosquitto/mosquitto.conf
@@ -1,0 +1,21 @@
+# Mosquitto MQTT Broker Configuration
+# General
+per_listener_settings true
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
+log_type all
+
+# Listener 1883 — MQTT with authentication
+listener 1883
+allow_anonymous false
+password_file /mosquitto/config/passwd
+acl_file /mosquitto/config/acl
+
+# Listener 9001 — WebSocket (for browser-based MQTT clients)
+listener 9001
+protocol websockets
+allow_anonymous false
+password_file /mosquitto/config/passwd
+acl_file /mosquitto/config/acl

--- a/stacks/home-automation/config/mosquitto/passwd
+++ b/stacks/home-automation/config/mosquitto/passwd
@@ -1,0 +1,8 @@
+# Mosquitto Password File
+# Generate with: docker run --rm -v $(pwd)/config/mosquitto:/mosquitto/config \
+#   eclipse-mosquitto:2.0.19 mosquitto_passwd -c /mosquitto/config/passwd <user>
+# NOTE: Replace CHANGEME_MQTT_PASSWORD with actual credentials before deployment.
+homeassistant:CHANGEME_MQTT_PASSWORD
+zigbee2mqtt:CHANGEME_MQTT_PASSWORD
+nodered:CHANGEME_MQTT_PASSWORD
+esphome:CHANGEME_MQTT_PASSWORD

--- a/stacks/home-automation/docker-compose.yml
+++ b/stacks/home-automation/docker-compose.yml
@@ -1,30 +1,115 @@
+# =============================================================================
+# HomeLab Stack — Home Automation
+# Services: Home Assistant + Node-RED + Mosquitto + Zigbee2MQTT + ESPHome
+#
+# Prerequisites:
+#   1. cp .env.example .env && fill in required values
+#   2. docker network create proxy   (if not already created by base stack)
+#   3. Set ZIGBEE_SERIAL_DEVICE to your Zigbee dongle path
+#      (e.g. /dev/ttyUSB0 or /dev/ttyACM0)
+#   4. For Home Assistant host network mode: ensure port 8123 is free
+#   5. docker compose up -d
+#
+# Note: Home Assistant uses network_mode: host for mDNS/UPnP device discovery.
+#       See README.md for bridge mode alternative with limitations.
+# =============================================================================
+
 services:
+
+  # ---------------------------------------------------------------------------
+  # Home Assistant — Smart Home Hub
+  # URL: http://<host_ip>:8123
+  # Docs: https://www.home-assistant.io/
+  # ---------------------------------------------------------------------------
   homeassistant:
-    image: homeassistant/home-assistant:2024.11.3
+    image: ghcr.io/home-assistant/home-assistant:2024.9.3
+    # CN alternative: swr.cn-north-4.myhuaweicloud.com/ddn-k8s/ghcr.io/home-assistant/home-assistant:2024.9.3
     container_name: homeassistant
     restart: unless-stopped
-    networks:
-      - proxy
+    # Home Assistant requires host network for mDNS/UPnP device discovery
+    # This enables automatic discovery of smart home devices on the LAN
+    # Note: When using host network mode, Traefik labels are NOT needed
+    #       HA is accessible directly at http://<host_ip>:8123
+    network_mode: host
     volumes:
       - ha-config:/config
     environment:
       - TZ=${TZ:-Asia/Shanghai}
     privileged: true
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.ha.rule=Host(`ha.${DOMAIN}`)"
-      - traefik.http.routers.ha.entrypoints=websecure
-      - traefik.http.routers.ha.tls=true
-      - traefik.http.services.ha.loadbalancer.server.port=8123
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8123/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8123/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+
+  # ---------------------------------------------------------------------------
+  # Home Assistant — Bridge Mode Alternative (uncomment to use instead of host)
+  # Limitations:
+  #   - mDNS/UPnP device discovery will NOT work
+  #   - Chromecast, Sonos, and other multicast-dependent devices won't auto-discover
+  #   - Must manually configure integrations that rely on network broadcast
+  #   - Some ESPHome devices may not be discovered automatically
+  # To use: Comment out the homeassistant block above and uncomment below
+  # ---------------------------------------------------------------------------
+  # homeassistant:
+  #   image: ghcr.io/home-assistant/home-assistant:2024.9.3
+  #   container_name: homeassistant
+  #   restart: unless-stopped
+  #   networks:
+  #     - proxy
+  #   volumes:
+  #     - ha-config:/config
+  #   environment:
+  #     - TZ=${TZ:-Asia/Shanghai}
+  #   privileged: true
+  #   labels:
+  #     - traefik.enable=true
+  #     - "traefik.http.routers.ha.rule=Host(`ha.${DOMAIN}`)"
+  #     - traefik.http.routers.ha.entrypoints=websecure
+  #     - traefik.http.routers.ha.tls=true
+  #     - traefik.http.services.ha.loadbalancer.server.port=8123
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "curl -sf http://localhost:8123/ || exit 1"]
+  #     interval: 30s
+  #     timeout: 10s
+  #     retries: 5
+  #     start_period: 120s
+
+  # ---------------------------------------------------------------------------
+  # Mosquitto — MQTT Broker
+  # Port: 1883 (MQTT), 9001 (WebSocket)
+  # Docs: https://mosquitto.org/
+  # ---------------------------------------------------------------------------
+  mosquitto:
+    image: eclipse-mosquitto:2.0.19
+    container_name: mosquitto
+    restart: unless-stopped
+    networks:
+      - proxy
+    volumes:
+      - mosquitto-data:/mosquitto/data
+      - mosquitto-log:/mosquitto/log
+      - ./config/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - ./config/mosquitto/passwd:/mosquitto/config/passwd:ro
+      - ./config/mosquitto/acl:/mosquitto/config/acl:ro
+    ports:
+      - "${MQTT_PORT:-1883}:1883"
+      - "${MQTT_WS_PORT:-9001}:9001"
+    healthcheck:
+      test: ["CMD-SHELL", "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 15s
 
+  # ---------------------------------------------------------------------------
+  # Node-RED — Visual Flow Editor
+  # URL: https://nodered.<DOMAIN>
+  # Docs: https://nodered.org/
+  # ---------------------------------------------------------------------------
   node-red:
-    image: nodered/node-red:3.1.14
+    image: nodered/node-red:4.0.3
     container_name: node-red
     restart: unless-stopped
     networks:
@@ -40,41 +125,32 @@ services:
       - traefik.http.routers.nodered.tls=true
       - traefik.http.services.nodered.loadbalancer.server.port=1880
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:1880/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:1880/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
 
-  mosquitto:
-    image: eclipse-mosquitto:2.0.20
-    container_name: mosquitto
-    restart: unless-stopped
-    networks:
-      - proxy
-    volumes:
-      - mosquitto-data:/mosquitto/data
-      - mosquitto-logs:/mosquitto/log
-      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
-    ports:
-      - "1883:1883"
-    healthcheck:
-      test: [CMD-SHELL, "mosquitto_sub -t '$$SYS/#' -C 1 -i healthcheck -W 3 || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
-
+  # ---------------------------------------------------------------------------
+  # Zigbee2MQTT — Zigbee Device Gateway
+  # URL: https://zigbee.<DOMAIN>
+  # Docs: https://www.zigbee2mqtt.io/
+  # Requires: Zigbee USB adapter (CC2531, Sonoff Zigbee 3.0, ConBee II, etc.)
+  # ---------------------------------------------------------------------------
   zigbee2mqtt:
-    image: koenkk/zigbee2mqtt:1.41.0
+    image: koenkk/zigbee2mqtt:1.40.2
     container_name: zigbee2mqtt
     restart: unless-stopped
     networks:
       - proxy
     volumes:
       - zigbee2mqtt-data:/app/data
+      - /run/udev:/run/udev:ro
     environment:
       - TZ=${TZ:-Asia/Shanghai}
+    devices:
+      # Zigbee USB adapter — update this path to match your hardware
+      - ${ZIGBEE_SERIAL_DEVICE:-/dev/ttyUSB0}:/dev/ttyUSB0
     depends_on:
       mosquitto:
         condition: service_healthy
@@ -85,7 +161,31 @@ services:
       - traefik.http.routers.zigbee2mqtt.tls=true
       - traefik.http.services.zigbee2mqtt.loadbalancer.server.port=8080
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8080/ || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  # ---------------------------------------------------------------------------
+  # ESPHome — ESP Device Firmware Manager
+  # URL: http://<host_ip>:6052
+  # Docs: https://esphome.io/
+  # Note: Uses host network for OTA updates and mDNS device discovery
+  # ---------------------------------------------------------------------------
+  esphome:
+    image: ghcr.io/esphome/esphome:2024.9.3
+    # CN alternative: swr.cn-north-4.myhuaweicloud.com/ddn-k8s/ghcr.io/esphome/esphome:2024.9.3
+    container_name: esphome
+    restart: unless-stopped
+    # ESPHome needs host network for OTA updates and mDNS device discovery
+    network_mode: host
+    volumes:
+      - esphome-data:/config
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:6052/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -97,7 +197,8 @@ networks:
 
 volumes:
   ha-config:
-  node-red-data:
   mosquitto-data:
-  mosquitto-logs:
+  mosquitto-log:
+  node-red-data:
   zigbee2mqtt-data:
+  esphome-data:

--- a/stacks/home-automation/mosquitto.conf
+++ b/stacks/home-automation/mosquitto.conf
@@ -1,6 +1,0 @@
-listener 1883
-allow_anonymous true
-persistence true
-persistence_location /mosquitto/data/
-log_dest file /mosquitto/log/mosquitto.log
-log_dest stdout


### PR DESCRIPTION
## Summary

Implements the complete Home Automation stack as described in #7.

### Services Included

| Service | Image | Version |
|---------|-------|--------|
| Home Assistant | `ghcr.io/home-assistant/home-assistant` | 2024.9.3 |
| Node-RED | `nodered/node-red` | 4.0.3 |
| Mosquitto | `eclipse-mosquitto` | 2.0.19 |
| Zigbee2MQTT | `koenkk/zigbee2mqtt` | 1.40.2 |
| ESPHome | `ghcr.io/esphome/esphome` | 2024.9.3 |

### Key Implementation Details

1. **Home Assistant — `network_mode: host`**
   - Required for mDNS/UPnP device discovery (Chromecast, Sonos, etc.)
   - Bridge mode alternative included as commented config with limitation docs

2. **Mosquitto — Security Configuration**
   - Authentication enabled (`allow_anonymous false`)
   - Per-service ACL: homeassistant, zigbee2mqtt, nodered, esphome
   - WebSocket listener on port 9001
   - Password file with placeholder (instructions for generation in README)

3. **Zigbee2MQTT — USB Passthrough**
   - Configurable serial device path via `ZIGBEE_SERIAL_DEVICE` env var
   - Depends on Mosquitto health check
   - udev mounted for device detection

4. **ESPHome — Host Network**
   - Uses `network_mode: host` for OTA updates and mDNS discovery
   - CN mirror alternatives provided for ghcr.io images

5. **CN Network Support**
   - Alternative mirror URLs commented in docker-compose.yml for ghcr.io images
   - Huawei Cloud SWR mirrors provided

### Files Changed

- `stacks/home-automation/docker-compose.yml` — Full 5-service stack
- `stacks/home-automation/.env.example` — Environment template
- `stacks/home-automation/README.md` — Architecture diagram, install guide, FAQ
- `stacks/home-automation/config/mosquitto/mosquitto.conf` — Broker config with auth
- `stacks/home-automation/config/mosquitto/acl` — Per-service access control
- `stacks/home-automation/config/mosquitto/passwd` — Password file template

### Checklist

- [x] All images pinned to specific versions (no `latest`)
- [x] Health checks for all services
- [x] Traefik labels for bridge-mode services
- [x] `.env` management for all configurable values
- [x] README with architecture, setup guide, and FAQ
- [x] CN mirror alternatives for ghcr.io images
- [x] Mosquitto auth + ACL security

Closes #7

---
*Generated with: claude-opus-4-6*