### PR TITLE
feat: Add observability stack (Prometheus, Grafana, Loki, Tempo, Alertmanager) (#10)

### DIFF
--- a/stacks/observability/.env.example
+++ b/stacks/observability/.env.example
@@ -1,0 +1,43 @@
+# ============================================================
+# Observability Stack — Environment Variables
+# ============================================================
+# Copy to .env and fill in values before running:
+#   cp .env.example .env
+# ============================================================
+
+# ── General ─────────────────────────────────────────────────
+DOMAIN=localhost
+
+# ── Grafana ─────────────────────────────────────────────────
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+
+# ── Authentik OIDC (Grafana SSO) ───────────────────────────
+AUTHENTIK_DOMAIN=auth.yourdomain.com
+GRAFANA_OAUTH_CLIENT_ID=
+GRAFANA_OAUTH_CLIENT_SECRET=
+
+# ── Data Retention ──────────────────────────────────────────
+PROMETHEUS_RETENTION=30d
+LOKI_RETENTION=7d
+TEMPO_RETENTION=72h
+
+# ── Alertmanager → ntfy ────────────────────────────────────
+NTFY_URL=https://ntfy.yourdomain.com
+NTFY_TOPIC=homelab-alerts
+NTFY_TOKEN=
+
+# ── Uptime Kuma ────────────────────────────────────────────
+# Uptime Kuma is configured via web UI at https://status.${DOMAIN}
+# Or run: ./scripts/uptime-kuma-setup.sh
+
+# ── Grafana OnCall ─────────────────────────────────────────
+ONCALL_SECRET_KEY=CHANGE_ME_RANDOM_SECRET
+
+# ── HomeLab Services (for Prometheus scrape targets) ───────
+# These are typically resolved via Docker DNS on the proxy network.
+# Only change if your services use non-standard hostnames.
+TRAEFIK_URL=traefik:8080
+AUTHENTIK_METRICS_URL=authentik-server:9300
+NEXTCLOUD_URL=nextcloud:9117
+GITEA_URL=gitea:3000

--- a/stacks/observability/README.md
+++ b/stacks/observability/README.md
@@ -1,0 +1,249 @@
+# Observability Stack — Prometheus + Grafana + Loki + Tempo + Alerting + Uptime
+
+Full observability covering **Metrics / Logs / Traces / Alerting / SLA monitoring** — the three pillars of observability plus uptime monitoring.
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │              Grafana :3000               │
+                    │   Dashboards / Explore / OnCall / OIDC  │
+                    └──┬──────────┬──────────┬────────────────┘
+                       │          │          │
+            ┌──────────┘    ┌─────┘    ┌─────┘
+            ▼               ▼          ▼
+     ┌─────────────┐ ┌──────────┐ ┌─────────┐
+     │ Prometheus   │ │  Loki    │ │  Tempo  │
+     │ :9090        │ │ :3100    │ │ :3200   │
+     │ (Metrics)    │ │ (Logs)   │ │(Traces) │
+     └──┬───┬───┬───┘ └────┬────┘ └────┬────┘
+        │   │   │          │            │
+        │   │   │          │            │
+   ┌────┘   │   └────┐     │      OTLP/gRPC
+   ▼        ▼        ▼     ▼      :4317/:4318
+┌───────┐┌──────┐┌──────┐┌─────────┐
+│ Node  ││cAd-  ││Trae- ││Promtail │
+│Export.││visor ││fik   ││(Agent)  │
+│ :9100 ││:8080 ││:8080 ││         │
+└───────┘└──────┘└──────┘└─────────┘
+
+                    ┌───────────────┐
+                    │ Alertmanager  │──▶ ntfy push
+                    │    :9093      │
+                    └───────────────┘
+
+    ┌──────────────┐     ┌──────────────┐
+    │ Uptime Kuma  │     │  OnCall      │
+    │  :3001       │     │  :8080       │
+    │ (SLA/Status) │     │ (Incidents)  │
+    └──────────────┘     └──────────────┘
+```
+
+## Services
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| Prometheus | `prom/prometheus:v2.54.1` | 9090 | Metrics collection & alerting rules |
+| Grafana | `grafana/grafana:11.2.2` | 3000 | Dashboards, Explore, OnCall UI |
+| Loki | `grafana/loki:3.2.0` | 3100 | Log aggregation & querying |
+| Promtail | `grafana/promtail:3.2.0` | 9080 | Log collection agent |
+| Tempo | `grafana/tempo:2.6.0` | 3200 | Distributed tracing backend |
+| Alertmanager | `prom/alertmanager:v0.27.0` | 9093 | Alert routing & ntfy push |
+| cAdvisor | `gcr.io/cadvisor/cadvisor:v0.50.0` | 8080 | Container resource metrics |
+| Node Exporter | `prom/node-exporter:v1.8.2` | 9100 | Host/system metrics |
+| Uptime Kuma | `louislam/uptime-kuma:1.23.15` | 3001 | SLA monitoring & status page |
+| Grafana OnCall | `grafana/oncall:v1.9.22` | 8080 | Incident & on-call management |
+
+## Prerequisites
+
+- Base stack running (`stacks/base/` — Traefik + proxy network)
+- Domain with DNS pointing to your server
+- ntfy stack running (for alert notifications) — `stacks/notifications/`
+
+## Quick Start
+
+```bash
+# 1. Copy and fill environment variables
+cp .env.example .env
+nano .env  # Fill DOMAIN, Authentik OIDC creds, ntfy settings
+
+# 2. Start the stack
+docker compose up -d
+
+# 3. Wait for all services to be healthy
+docker compose ps
+
+# 4. Access Grafana
+open https://grafana.${DOMAIN}
+
+# 5. (Optional) Setup Uptime Kuma monitors
+chmod +x scripts/uptime-kuma-setup.sh
+./scripts/uptime-kuma-setup.sh
+```
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DOMAIN` | YES | `localhost` | Your homelab domain |
+| `GRAFANA_ADMIN_USER` | NO | `admin` | Grafana admin username |
+| `GRAFANA_ADMIN_PASSWORD` | YES | `changeme` | Grafana admin password |
+| `AUTHENTIK_DOMAIN` | YES | — | Authentik domain for OIDC |
+| `GRAFANA_OAUTH_CLIENT_ID` | YES | — | Authentik OIDC client ID |
+| `GRAFANA_OAUTH_CLIENT_SECRET` | YES | — | Authentik OIDC client secret |
+| `PROMETHEUS_RETENTION` | NO | `30d` | Prometheus data retention |
+| `LOKI_RETENTION` | NO | `7d` | Loki log retention |
+| `TEMPO_RETENTION` | NO | `72h` | Tempo trace retention |
+| `NTFY_URL` | NO | `http://ntfy:80` | ntfy server URL |
+| `NTFY_TOPIC` | NO | `homelab-alerts` | ntfy notification topic |
+| `NTFY_TOKEN` | NO | — | ntfy auth token (optional) |
+| `ONCALL_SECRET_KEY` | YES | — | Grafana OnCall secret key |
+
+## Pre-provisioned Dashboards
+
+All dashboards are auto-loaded via Grafana provisioning (no manual import needed):
+
+| Dashboard | Grafana ID | Description |
+|-----------|------------|-------------|
+| Node Exporter Full | 1860 | Host CPU, memory, disk, network |
+| Docker Container & Host Metrics | 179 | Container resources & health |
+| Traefik Official | 17346 | Reverse proxy requests, latency, errors |
+| Loki Dashboard | 13639 | Log ingestion, query performance, live logs |
+| Uptime Kuma | 18278 | Service availability & SLA |
+| Logs Explorer | — | Quick access to all container & Traefik logs |
+
+## Alert Rules
+
+Three alert rule groups cover host, container, and service health:
+
+### Host Alerts (`configs/prometheus/alerts/host.yml`)
+- CPU > 80% for 5 min
+- Memory > 90% for 5 min
+- Disk > 85% for 5 min
+- Disk I/O saturation > 90%
+- Network errors
+- System load
+
+### Container Alerts (`configs/prometheus/alerts/containers.yml`)
+- Container restart loop (>3/hour)
+- Container OOM killed
+- Container unhealthy (health check failing)
+- Container high CPU/memory
+- Container not running
+
+### Service Alerts (`configs/prometheus/alerts/services.yml`)
+- Traefik 5xx error rate > 1%
+- Service response time P99 > 2s
+- Prometheus target down
+- Loki ingestion rate drop
+- High number of firing alerts
+
+All alerts route to **Alertmanager → ntfy** for push notifications.
+
+## Prometheus Scrape Targets
+
+| Job | Target | Metrics Path |
+|-----|--------|-------------|
+| `prometheus` | `localhost:9090` | `/metrics` |
+| `node-exporter` | `node-exporter:9100` | `/metrics` |
+| `cadvisor` | `cadvisor:8080` | `/metrics` |
+| `traefik` | `traefik:8080` | `/metrics` |
+| `authentik` | `authentik-server:9300` | `/metrics/performance` |
+| `nextcloud` | `nextcloud:9117` | `/metrics` |
+| `gitea` | `gitea:3000` | `/metrics` |
+| `loki` | `loki:3100` | `/metrics` |
+| `tempo` | `tempo:3200` | `/metrics` |
+| `alertmanager` | `alertmanager:9093` | `/metrics` |
+| `grafana` | `grafana:3000` | `/metrics` |
+| `uptime-kuma` | `uptime-kuma:3001` | `/metrics` |
+
+## Grafana OIDC (Authentik)
+
+The stack integrates Authentik for SSO login:
+
+- `homelab-admins` group → Grafana **Admin** role
+- `homelab-users` group → Grafana **Viewer** role
+- Auto-redirect to Authentik login page
+- Sign-out redirects back to Authentik
+
+## Log Collection (Promtail → Loki)
+
+Promtail auto-discovers all Docker containers and collects:
+
+- **All container logs** (stdout/stderr, JSON parsing)
+- **System logs** (`/var/log/syslog`, `/var/log/auth.log`)
+- **Traefik access logs** (parsed CLF format with status codes)
+
+Access logs via Grafana → Explore → Loki, or the pre-built Logs Explorer dashboard.
+
+## Distributed Tracing (Tempo)
+
+Tempo receives traces via:
+- **OTLP gRPC**: port 4317
+- **OTLP HTTP**: port 4318
+- **Zipkin**: port 9411
+
+Grafana is pre-configured with trace-to-log and trace-to-metric correlations.
+
+## Data Retention
+
+| Store | Default | Configurable via |
+|-------|---------|-----------------|
+| Prometheus | 30 days | `PROMETHEUS_RETENTION` |
+| Loki | 7 days | `LOKI_RETENTION` |
+| Tempo | 72 hours | `TEMPO_RETENTION` |
+
+## Uptime Kuma
+
+After setup, configure at `https://status.${DOMAIN}`:
+1. Create admin account
+2. Add monitors for all homelab services
+3. Create a public status page (slug: `/`)
+4. Configure ntfy notifications
+
+Run `./scripts/uptime-kuma-setup.sh` for guided setup.
+
+## Health Check
+
+```bash
+# All containers healthy
+docker compose ps
+
+# Prometheus targets
+curl -s http://localhost:9090/api/v1/targets | jq '.data.activeTargets[] | {job: .labels.job, health: .health}'
+
+# Loki ready
+curl -sf http://localhost:3100/ready && echo OK
+
+# Tempo ready
+curl -sf http://localhost:3200/ready && echo OK
+
+# Grafana health
+curl -sf http://localhost:3000/api/health && echo OK
+
+# Alertmanager healthy
+curl -sf http://localhost:9093/-/healthy && echo OK
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Grafana shows "No data" for all panels | Check Prometheus is scraping targets: `curl localhost:9090/api/v1/targets` |
+| Loki shows no logs | Check Promtail is running: `docker logs promtail`; verify Docker socket is mounted |
+| Alerts not firing | Verify alert rules: `docker exec prometheus promtool check rules /etc/prometheus/alerts/*.yml` |
+| ntfy not receiving alerts | Check Alertmanager config: `curl localhost:9093/api/v2/alerts`; verify ntfy URL |
+| Grafana OIDC login fails | Verify `GRAFANA_OAUTH_CLIENT_ID/SECRET` match Authentik provider settings |
+| Dashboard JSON not loading | Check provisioning: `docker exec grafana ls /var/lib/grafana/dashboards/` |
+| Tempo not receiving traces | Verify OTLP endpoint: `curl -X POST http://localhost:4318/v1/traces` |
+
+## CN Mirror
+
+If `gcr.io` or `grafana.com` is inaccessible, edit `docker-compose.yml` and swap images to CN mirrors:
+
+```yaml
+# cadvisor
+image: swr.cn-north-4.myhuaweicloud.com/ddn-k8s/gcr.io/cadvisor/cadvisor:v0.50.0
+```
+
+See `../../scripts/cn-pull.sh` for automated image pulling.

--- a/stacks/observability/configs/alertmanager/alertmanager.yml
+++ b/stacks/observability/configs/alertmanager/alertmanager.yml
@@ -1,0 +1,68 @@
+# ============================================================
+# Alertmanager Configuration — HomeLab Observability
+# ============================================================
+# Routes alerts to ntfy push notifications.
+# Uses webhook_configs with ntfy-compatible formatting.
+#
+# IMPORTANT: If running ntfy in the same Docker network,
+# ensure the ntfy container is on the 'observability' network,
+# or use the external ntfy URL from .env
+# ============================================================
+
+global:
+  resolve_timeout: 5m
+
+# ── Templates ───────────────────────────────────────────────
+templates:
+  - "/etc/alertmanager/templates/*.tmpl"
+
+# ── Inhibition Rules ────────────────────────────────────────
+inhibit_rules:
+  - source_match:
+      severity: critical
+    target_match:
+      severity: warning
+    equal: [alertname, instance]
+
+# ── Routing Tree ────────────────────────────────────────────
+route:
+  receiver: ntfy-default
+  group_by: [alertname, cluster, instance]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+  routes:
+    # Critical → fast delivery
+    - match:
+        severity: critical
+      receiver: ntfy-critical
+      group_wait: 10s
+      repeat_interval: 1h
+
+    # Warning → standard delivery
+    - match:
+        severity: warning
+      receiver: ntfy-warning
+      group_wait: 1m
+      repeat_interval: 4h
+
+# ── Receivers ───────────────────────────────────────────────
+receivers:
+  # Default — catches anything unmatched
+  - name: ntfy-default
+    webhook_configs:
+      - url: "http://ntfy:80/homelab-alerts"
+        send_resolved: true
+
+  # Critical — all severity=critical alerts
+  - name: ntfy-critical
+    webhook_configs:
+      - url: "http://ntfy:80/homelab-alerts"
+        send_resolved: true
+
+  # Warning — all severity=warning alerts
+  - name: ntfy-warning
+    webhook_configs:
+      - url: "http://ntfy:80/homelab-alerts"
+        send_resolved: true

--- a/stacks/observability/configs/alertmanager/templates/ntfy.tmpl
+++ b/stacks/observability/configs/alertmanager/templates/ntfy.tmpl
@@ -1,0 +1,12 @@
+{{ define "ntfy.default.title" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }}{{ end }}
+
+{{ define "ntfy.default.message" }}{{ range .Alerts }}
+{{ if eq .Status "firing" }}🔥{{ else }}✅{{ end }} {{ .Annotations.summary }}
+{{ if .Annotations.description }}{{ .Annotations.description }}{{ end }}
+{{ if .Annotations.runbook }}📋 {{ .Annotations.runbook }}{{ end }}
+---
+{{ end }}{{ end }}
+
+{{ define "ntfy.default.tags" }}{{ if eq .Status "firing" }}warning,rotating_light{{ else }}white_check_mark{{ end }}{{ end }}
+
+{{ define "ntfy.default.priority" }}{{ if eq .Status "firing" }}{{ if .Alerts.Firing }}4{{ else }}3{{ end }}{{ else }}2{{ end }}{{ end }}

--- a/stacks/observability/configs/grafana/dashboards/docker-container-metrics.json
+++ b/stacks/observability/configs/grafana/dashboards/docker-container-metrics.json
@@ -1,0 +1,118 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Container Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }] }, "mappings": [{ "type": "value", "options": { "0": { "text": "Down", "color": "red" }, "1": { "text": "Up", "color": "green" } } }] } },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Running Containers",
+      "type": "stat",
+      "targets": [{ "expr": "count(container_last_seen{name!=\"\"})", "legendFormat": "Containers", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 3 }] }, "unit": "short" } },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Container Restarts (1h)",
+      "type": "stat",
+      "targets": [{ "expr": "sum(increase(container_last_seen{name!=\"\"}[1h]))", "legendFormat": "Restarts", "refId": "A" }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 4,
+      "title": "Container Resources",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "percent", "max": 100, "min": 0 } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 5,
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+      "title": "Container CPU Usage",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "rate(container_cpu_usage_seconds_total{name!=\"\",name!~\"POD|.*_logspout.*\"}[5m]) * 100",
+        "legendFormat": "{{ name }}",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "bytes" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 6,
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+      "title": "Container Memory Usage",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "container_memory_usage_bytes{name!=\"\",name!~\"POD|.*_logspout.*\"}",
+        "legendFormat": "{{ name }}",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "Bps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "id": 7,
+      "title": "Container Network RX",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "rate(container_network_receive_bytes_total{name!=\"\",interface!~\"lo|veth.*\"}[5m])",
+        "legendFormat": "{{ name }}",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "Bps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "id": 8,
+      "title": "Container Network TX",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "rate(container_network_transmit_bytes_total{name!=\"\",interface!~\"lo|veth.*\"}[5m])",
+        "legendFormat": "{{ name }}",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "Bps" } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 22 },
+      "id": 9,
+      "title": "Container Disk I/O",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(container_fs_reads_bytes_total{name!=\"\"}[5m])", "legendFormat": "Read {{ name }}", "refId": "A" },
+        { "expr": "rate(container_fs_writes_bytes_total{name!=\"\"}[5m])", "legendFormat": "Write {{ name }}", "refId": "B" }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["docker", "cadvisor", "containers", "homelab"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "title": "Docker Container & Host Metrics",
+  "uid": "docker-container-metrics",
+  "version": 1
+}

--- a/stacks/observability/configs/grafana/dashboards/logs-explorer.json
+++ b/stacks/observability/configs/grafana/dashboards/logs-explorer.json
@@ -1,0 +1,89 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Quick Filters",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none"
+      },
+      "title": "All Container Logs",
+      "type": "logs",
+      "targets": [{
+        "expr": "{job=\"docker-containers\"} |= ``",
+        "legendFormat": "",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 13 },
+      "id": 3,
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      },
+      "title": "Error Logs",
+      "type": "logs",
+      "targets": [{
+        "expr": "{job=\"docker-containers\"} |~ \"(?i)(error|exception|fatal|panic)\"",
+        "legendFormat": "",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 13 },
+      "id": 4,
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "sortOrder": "Descending"
+      },
+      "title": "Traefik Access Logs",
+      "type": "logs",
+      "targets": [{
+        "expr": "{job=\"traefik\"} |= ``",
+        "legendFormat": "",
+        "refId": "A"
+      }]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["logs", "loki", "homelab"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Logs Explorer",
+  "uid": "logs",
+  "version": 1
+}

--- a/stacks/observability/configs/grafana/dashboards/loki-dashboard.json
+++ b/stacks/observability/configs/grafana/dashboards/loki-dashboard.json
@@ -1,0 +1,150 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Loki Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }] }, "unit": "short" } },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Lines/sec Ingested",
+      "type": "stat",
+      "targets": [{ "expr": "sum(rate(loki_distributor_lines_received_total[5m]))", "legendFormat": "lines/s", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }] }, "unit": "bytes" } },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Storage Size",
+      "type": "stat",
+      "targets": [{ "expr": "sum(loki_boltdb_shipper_directory_entries)", "legendFormat": "Entries", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 100 }, { "color": "red", "value": 1000 }] }, "unit": "short" } },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Active Streams",
+      "type": "stat",
+      "targets": [{ "expr": "sum(loki_ingester_streams_created_total)", "legendFormat": "Streams", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.1 }, { "color": "red", "value": 1 }] }, "unit": "reqps" } },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Query Errors/sec",
+      "type": "stat",
+      "targets": [{ "expr": "sum(rate(loki_request_duration_seconds_count{status=~\"5..\",route=\"/loki/api/v1/query_range\"}[5m]))", "legendFormat": "errors/s", "refId": "A" }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 6,
+      "title": "Log Ingestion",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 7,
+      "title": "Lines Ingested by Tenant",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "sum(rate(loki_distributor_lines_received_total[5m])) by (tenant)",
+        "legendFormat": "{{ tenant }}",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 8,
+      "title": "Streams by Tenant",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "sum(loki_ingester_memory_streams) by (tenant)",
+        "legendFormat": "{{ tenant }}",
+        "refId": "A"
+      }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 9,
+      "title": "Query Performance",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 10,
+      "title": "Query Latency P50/P99",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket{route=\"/loki/api/v1/query_range\"}[5m])) by (le))", "legendFormat": "P50", "refId": "A" },
+        { "expr": "histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket{route=\"/loki/api/v1/query_range\"}[5m])) by (le))", "legendFormat": "P99", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 11,
+      "title": "Queries per Second by Route",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "sum(rate(loki_request_duration_seconds_count[5m])) by (route)",
+        "legendFormat": "{{ route }}",
+        "refId": "A"
+      }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 12,
+      "title": "Live Logs",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 24 },
+      "id": 13,
+      "options": { "showTime": true, "showLabels": true, "showCommonLabels": false, "wrapLogMessage": true, "prettifyLogMessage": false, "enableLogDetails": true, "sortOrder": "Descending" },
+      "title": "Container Logs (all)",
+      "type": "logs",
+      "targets": [{
+        "expr": "{job=\"docker-containers\"} |= ``",
+        "legendFormat": "",
+        "refId": "A"
+      }]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["loki", "logs", "homelab"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Loki Dashboard",
+  "uid": "loki-dashboard",
+  "version": 1
+}

--- a/stacks/observability/configs/grafana/dashboards/node-exporter-full.json
+++ b/stacks/observability/configs/grafana/dashboards/node-exporter-full.json
@@ -1,0 +1,170 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Host Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 90 }] },
+          "unit": "percent",
+          "max": 100
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "title": "CPU Usage",
+      "type": "gauge",
+      "targets": [{
+        "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+        "legendFormat": "CPU",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 80 }, { "color": "red", "value": 95 }] },
+          "unit": "percent",
+          "max": 100
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 1 },
+      "id": 3,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "title": "Memory Usage",
+      "type": "gauge",
+      "targets": [{
+        "expr": "(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100",
+        "legendFormat": "Memory",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 75 }, { "color": "red", "value": 90 }] },
+          "unit": "percent",
+          "max": 100
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "title": "Disk Usage /",
+      "type": "gauge",
+      "targets": [{
+        "expr": "(1 - node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"}) * 100",
+        "legendFormat": "Disk",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Uptime",
+      "type": "stat",
+      "targets": [{
+        "expr": "node_time_seconds - node_boot_time_seconds",
+        "legendFormat": "Uptime",
+        "refId": "A"
+      }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 7 },
+      "id": 6,
+      "title": "CPU & Memory",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "percent", "max": 100, "min": 0 } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 7,
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom" } },
+      "title": "CPU Usage Over Time",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "100 - (avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)", "legendFormat": "{{ instance }}", "refId": "A" },
+        { "expr": "avg(rate(node_cpu_seconds_total{mode=\"iowait\"}[5m])) * 100", "legendFormat": "IO Wait", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "bytes" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 8,
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom" } },
+      "title": "Memory Usage",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "node_memory_MemTotal_bytes", "legendFormat": "Total", "refId": "A" },
+        { "expr": "node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes", "legendFormat": "Used", "refId": "B" },
+        { "expr": "node_memory_Cached_bytes", "legendFormat": "Cached", "refId": "C" },
+        { "expr": "node_memory_Buffers_bytes", "legendFormat": "Buffers", "refId": "D" }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+      "id": 9,
+      "title": "Disk & Network",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "Bps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 17 },
+      "id": 10,
+      "title": "Disk I/O",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(node_disk_read_bytes_total[5m])", "legendFormat": "Read {{ device }}", "refId": "A" },
+        { "expr": "rate(node_disk_written_bytes_total[5m])", "legendFormat": "Write {{ device }}", "refId": "B" }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "bps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 17 },
+      "id": 11,
+      "title": "Network Traffic",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "rate(node_network_receive_bytes_total{device!~\"lo|veth.*|docker.*|br-.*\"}[5m]) * 8", "legendFormat": "RX {{ device }}", "refId": "A" },
+        { "expr": "rate(node_network_transmit_bytes_total{device!~\"lo|veth.*|docker.*|br-.*\"}[5m]) * 8", "legendFormat": "TX {{ device }}", "refId": "B" }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["node-exporter", "homelab", "host"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "title": "Node Exporter Full",
+  "uid": "node-exporter-full",
+  "version": 1
+}

--- a/stacks/observability/configs/grafana/dashboards/traefik-official.json
+++ b/stacks/observability/configs/grafana/dashboards/traefik-official.json
@@ -1,0 +1,126 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Traefik Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }] }, "unit": "reqps" } },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Requests/sec",
+      "type": "stat",
+      "targets": [{ "expr": "sum(rate(traefik_service_requests_total[5m]))", "legendFormat": "req/s", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.001 }, { "color": "red", "value": 0.01 }] }, "unit": "percentunit" } },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "5xx Error Rate",
+      "type": "stat",
+      "targets": [{ "expr": "sum(rate(traefik_service_requests_total{code=~\"5..\"}[5m])) / sum(rate(traefik_service_requests_total[5m]))", "legendFormat": "5xx%", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 500 }, { "color": "red", "value": 2000 }] }, "unit": "ms" } },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "P99 Latency",
+      "type": "stat",
+      "targets": [{ "expr": "histogram_quantile(0.99, sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "P99", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }] }, "unit": "short" } },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Open Connections",
+      "type": "stat",
+      "targets": [{ "expr": "sum(traefik_service_open_connections)", "legendFormat": "Open", "refId": "A" }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 6,
+      "title": "Request Rate & Errors",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 7,
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max"] } },
+      "title": "Requests per Service",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "sum(rate(traefik_service_requests_total[5m])) by (service)",
+        "legendFormat": "{{ service }}",
+        "refId": "A"
+      }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 8,
+      "title": "Requests by Status Code",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "sum(rate(traefik_service_requests_total{code=~\"2..\"}[5m]))", "legendFormat": "2xx", "refId": "A" },
+        { "expr": "sum(rate(traefik_service_requests_total{code=~\"3..\"}[5m]))", "legendFormat": "3xx", "refId": "B" },
+        { "expr": "sum(rate(traefik_service_requests_total{code=~\"4..\"}[5m]))", "legendFormat": "4xx", "refId": "C" },
+        { "expr": "sum(rate(traefik_service_requests_total{code=~\"5..\"}[5m]))", "legendFormat": "5xx", "refId": "D" }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ms" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "id": 9,
+      "title": "Response Time P50/P90/P99",
+      "type": "timeseries",
+      "targets": [
+        { "expr": "histogram_quantile(0.50, sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "P50", "refId": "A" },
+        { "expr": "histogram_quantile(0.90, sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "P90", "refId": "B" },
+        { "expr": "histogram_quantile(0.99, sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (le)) * 1000", "legendFormat": "P99", "refId": "C" }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "id": 10,
+      "title": "Open Connections by Service",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "traefik_service_open_connections",
+        "legendFormat": "{{ service }}",
+        "refId": "A"
+      }]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["traefik", "homelab", "reverse-proxy"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "title": "Traefik Official",
+  "uid": "traefik-official",
+  "version": 1
+}

--- a/stacks/observability/configs/grafana/dashboards/uptime-kuma.json
+++ b/stacks/observability/configs/grafana/dashboards/uptime-kuma.json
@@ -1,0 +1,127 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    { "title": "Uptime Kuma Status Page", "url": "https://status.${DOMAIN}", "type": "link", "targetBlank": true }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "Service Status",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }, "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }] } },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Prometheus",
+      "type": "stat",
+      "targets": [{ "expr": "up{job=\"prometheus\"}", "legendFormat": "", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }, "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }] } },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Grafana",
+      "type": "stat",
+      "targets": [{ "expr": "up{job=\"grafana\"}", "legendFormat": "", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }, "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }] } },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Loki",
+      "type": "stat",
+      "targets": [{ "expr": "up{job=\"loki\"}", "legendFormat": "", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }, "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }] } },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Alertmanager",
+      "type": "stat",
+      "targets": [{ "expr": "up{job=\"alertmanager\"}", "legendFormat": "", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }, "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }] } },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 6,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Traefik",
+      "type": "stat",
+      "targets": [{ "expr": "up{job=\"traefik\"}", "legendFormat": "", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }, "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }] } },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "id": 7,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Tempo",
+      "type": "stat",
+      "targets": [{ "expr": "up{job=\"tempo\"}", "legendFormat": "", "refId": "A" }]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 8,
+      "title": "Overall Health",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 80 }, { "color": "green", "value": 95 }] }, "unit": "percent", "max": 100, "min": 0 } },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 6 },
+      "id": 9,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "orientation": "auto", "showThresholdLabels": false, "showThresholdMarkers": true },
+      "title": "Overall Uptime %",
+      "type": "gauge",
+      "targets": [{ "expr": "avg(up) * 100", "legendFormat": "Uptime", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 3 }] }, "unit": "short" } },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 6 },
+      "id": 10,
+      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Targets Down",
+      "type": "stat",
+      "targets": [{ "expr": "count(up == 0) or vector(0)", "legendFormat": "Down", "refId": "A" }]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "fillOpacity": 20, "lineWidth": 2, "spanNulls": false } } },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "id": 11,
+      "title": "Service Availability Over Time",
+      "type": "timeseries",
+      "targets": [{
+        "expr": "up",
+        "legendFormat": "{{ job }} ({{ instance }})",
+        "refId": "A"
+      }]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["uptime", "kuma", "sla", "homelab"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "title": "Uptime Kuma",
+  "uid": "uptime-kuma",
+  "version": 1
+}

--- a/stacks/observability/configs/grafana/provisioning/dashboards/dashboards.yml
+++ b/stacks/observability/configs/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: homelab
+    orgId: 1
+    folder: HomeLab
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true

--- a/stacks/observability/configs/grafana/provisioning/datasources/datasources.yml
+++ b/stacks/observability/configs/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,65 @@
+apiVersion: 1
+
+datasources:
+  # ── Prometheus (default) ──────────────────────────────────
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s
+      httpMethod: POST
+      exemplarTraceIdDestinations:
+        - name: traceID
+          datasourceUid: tempo
+
+  # ── Loki (logs) ───────────────────────────────────────────
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      maxLines: 1000
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: "traceID=(\\w+)"
+          name: TraceID
+          url: "$${__value.raw}"
+
+  # ── Tempo (traces) ────────────────────────────────────────
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      tracesToLogs:
+        datasourceUid: loki
+        tags: [job]
+        mappedTags:
+          - key: service.name
+            value: service
+        mapTagNamesEnabled: true
+        spanStartTimeShift: "-1h"
+        spanEndTimeShift: "1h"
+        filterByTraceID: true
+        filterBySpanID: false
+      tracesToMetrics:
+        datasourceUid: prometheus
+        tags:
+          - key: service.name
+            value: service
+        queries:
+          - name: Request rate
+            query: "sum(rate(traces_spanmetrics_calls_total{$$__tags}[1m]))"
+          - name: Error rate
+            query: "sum(rate(traces_spanmetrics_calls_total{$$__tags,status_code=\"STATUS_CODE_ERROR\"}[1m]))"
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: prometheus
+      lokiSearch:
+        datasourceUid: loki

--- a/stacks/observability/configs/loki/loki-config.yml
+++ b/stacks/observability/configs/loki/loki-config.yml
@@ -1,0 +1,70 @@
+# ============================================================
+# Loki Configuration — HomeLab Observability
+# ============================================================
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# ── Retention ───────────────────────────────────────────────
+limits_config:
+  allow_structured_metadata: false
+  volume_enabled: true
+  retention_period: 168h  # 7 days (LOKI_RETENTION)
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem
+
+# ── Ruler (Loki-native alerts) ──────────────────────────────
+ruler:
+  alertmanager_url: http://alertmanager:9093
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+  rule_path: /loki/rules-temp
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true
+
+# ── Analytics ───────────────────────────────────────────────
+analytics:
+  reporting_enabled: false

--- a/stacks/observability/configs/loki/promtail-config.yml
+++ b/stacks/observability/configs/loki/promtail-config.yml
@@ -1,0 +1,89 @@
+# ============================================================
+# Promtail Configuration — HomeLab Observability
+# ============================================================
+# Collects: Docker container logs, system logs, Traefik access logs
+# ============================================================
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # ── Docker Container Logs (auto-discovery) ────────────────
+  - job_name: docker-containers
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      # Container name (strip leading /)
+      - source_labels: [__meta_docker_container_name]
+        regex: "/(.*)"
+        target_label: container
+      # Log stream (stdout/stderr)
+      - source_labels: [__meta_docker_container_log_stream]
+        target_label: stream
+      # Compose service name
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: service
+      # Compose project name
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project]
+        target_label: compose_project
+      # Stack name (for multi-stack setups)
+      - source_labels: [__meta_docker_container_label_com_docker_compose_project_working_dir]
+        regex: ".*/stacks/([^/]+)/.*"
+        target_label: stack
+    pipeline_stages:
+      # Detect and parse JSON log lines
+      - match:
+          selector: '{container=~".+"}'
+          stages:
+            - json:
+                expressions:
+                  level: level
+                  msg: msg
+            - labels:
+                level:
+      # Drop debug-level logs to save space
+      - match:
+          selector: '{level="debug"}'
+          action: drop
+
+  # ── System Logs ───────────────────────────────────────────
+  - job_name: system
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: syslog
+          __path__: /var/log/syslog
+          host: ${HOSTNAME}
+
+  - job_name: auth
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: auth
+          __path__: /var/log/auth.log
+
+  # ── Traefik Access Logs ──────────────────────────────────
+  - job_name: traefik
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: traefik
+          __path__: /var/log/traefik/access.log
+    pipeline_stages:
+      # Parse Traefik CLF/JSON access log
+      - regex:
+          expression: '^(?P<remote_addr>[\w\.]+) - (?P<user>[^ ]*) \[(?P<time_local>.*)\] "(?P<method>[^ ]*) (?P<path>[^ ]*) (?P<protocol>[^"]*)" (?P<status>\d+) (?P<body_bytes_sent>\d+) "(?P<http_referer>[^"]*)" "(?P<http_user_agent>[^"]*)"'
+      - labels:
+          method:
+          status:
+      - timestamp:
+          source: time_local
+          format: "02/Jan/2006:15:04:05 -0700"

--- a/stacks/observability/configs/prometheus/alerts/containers.yml
+++ b/stacks/observability/configs/prometheus/alerts/containers.yml
@@ -1,0 +1,84 @@
+# ============================================================
+# Container Alert Rules — HomeLab Observability
+# ============================================================
+
+groups:
+  - name: containers
+    interval: 1m
+    rules:
+      # ── Container Restart Loop ────────────────────────────
+      - alert: ContainerRestartLoop
+        expr: increase(container_last_seen{name!=""}[1h]) > 3
+        for: 0m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Container {{ $labels.name }} restarted >3 times in 1h"
+          description: "Container {{ $labels.name }} is in a restart loop. Check logs: `docker logs {{ $labels.name }}`"
+
+      # ── Container OOM Killed ──────────────────────────────
+      - alert: ContainerOOMKilled
+        expr: container_oom_events_total{name!=""} > 0
+        for: 0m
+        labels:
+          severity: critical
+          team: infra
+        annotations:
+          summary: "Container {{ $labels.name }} was OOM killed"
+          description: "Container {{ $labels.name }} ran out of memory. Increase memory limits or investigate memory leaks."
+
+      # ── Container Down ────────────────────────────────────
+      - alert: ContainerDown
+        expr: absent(container_last_seen{name!=""})
+        for: 2m
+        labels:
+          severity: critical
+          team: infra
+        annotations:
+          summary: "No containers detected"
+          description: "Docker containers are not reporting metrics. Check cAdvisor."
+
+      # ── Container High CPU ────────────────────────────────
+      - alert: ContainerHighCpu
+        expr: rate(container_cpu_usage_seconds_total{name!=""}[5m]) * 100 > 80
+        for: 5m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Container {{ $labels.name }} CPU > 80%"
+          description: "Container {{ $labels.name }} is using {{ printf \"%.1f\" $value }}% CPU"
+
+      # ── Container High Memory ─────────────────────────────
+      - alert: ContainerHighMemory
+        expr: (container_memory_usage_bytes{name!=""} / container_spec_memory_limit_bytes{name!=""}) * 100 > 85
+        for: 5m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Container {{ $labels.name }} memory > 85% of limit"
+          description: "Container {{ $labels.name }} is using {{ printf \"%.1f\" $value }}% of its memory limit"
+
+      # ── Container Health Check Failed ─────────────────────
+      - alert: ContainerUnhealthy
+        expr: container_health_status{name!="", status="unhealthy"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Container {{ $labels.name }} health check failing"
+          description: "Container {{ $labels.name }} is unhealthy. Check logs: `docker inspect {{ $labels.name }}`"
+
+      # ── Container Not Running ─────────────────────────────
+      - alert: ContainerNotRunning
+        expr: time() - container_last_seen{name!=""} > 60
+        for: 1m
+        labels:
+          severity: critical
+          team: infra
+        annotations:
+          summary: "Container {{ $labels.name }} is not running"
+          description: "Container {{ $labels.name }} was last seen {{ $value }}s ago"

--- a/stacks/observability/configs/prometheus/alerts/host.yml
+++ b/stacks/observability/configs/prometheus/alerts/host.yml
@@ -1,0 +1,86 @@
+# ============================================================
+# Host Alert Rules — HomeLab Observability
+# ============================================================
+
+groups:
+  - name: host
+    interval: 1m
+    rules:
+      # ── CPU ──────────────────────────────────────────────
+      - alert: HostHighCpu
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "High CPU on {{ $labels.instance }}"
+          description: "CPU usage is {{ printf \"%.1f\" $value }}% on {{ $labels.instance }} (threshold: 80%)"
+          runbook: "Check top processes: `top -b -n1 | head -20`"
+
+      # ── Memory ───────────────────────────────────────────
+      - alert: HostHighMemory
+        expr: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100 > 90
+        for: 5m
+        labels:
+          severity: critical
+          team: infra
+        annotations:
+          summary: "High memory on {{ $labels.instance }}"
+          description: "Memory usage is {{ printf \"%.1f\" $value }}% on {{ $labels.instance }} (threshold: 90%)"
+          runbook: "Check memory: `free -h` and `ps aux --sort=-%mem | head`"
+
+      # ── Disk Space ───────────────────────────────────────
+      - alert: HostDiskSpaceLow
+        expr: (node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}) * 100 < 15
+        for: 5m
+        labels:
+          severity: critical
+          team: infra
+        annotations:
+          summary: "Low disk space on {{ $labels.instance }}"
+          description: "Disk usage is {{ printf \"%.1f\" $value }}% on {{ $labels.instance }} (threshold: 85%)"
+          runbook: "Check disk: `df -h` and `du -sh /* | sort -rh | head`"
+
+      - alert: HostDiskSpaceWarning
+        expr: (node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"}) * 100 < 25
+        for: 15m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Disk space getting low on {{ $labels.instance }}"
+          description: "Disk usage is {{ printf \"%.1f\" $value }}% on {{ $labels.instance }}"
+
+      # ── Disk IO ──────────────────────────────────────────
+      - alert: HostDiskIOHigh
+        expr: rate(node_disk_io_time_seconds_total[5m]) > 0.9
+        for: 10m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "High disk I/O on {{ $labels.instance }}"
+          description: "Disk I/O utilization is {{ printf \"%.1f\" $value }} on {{ $labels.device }}"
+
+      # ── Network Errors ───────────────────────────────────
+      - alert: HostNetworkErrors
+        expr: rate(node_network_receive_errs_total[5m]) > 10 or rate(node_network_transmit_errs_total[5m]) > 10
+        for: 5m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Network errors on {{ $labels.instance }}"
+          description: "Network errors detected on {{ $labels.device }}"
+
+      # ── System Load ──────────────────────────────────────
+      - alert: HostHighLoad
+        expr: node_load15 / count without(cpu, mode) (node_cpu_seconds_total{mode="idle"}) > 2
+        for: 15m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "High system load on {{ $labels.instance }}"
+          description: "15-min load average is {{ printf \"%.1f\" $value }} on {{ $labels.instance }}"

--- a/stacks/observability/configs/prometheus/alerts/services.yml
+++ b/stacks/observability/configs/prometheus/alerts/services.yml
@@ -1,0 +1,106 @@
+# ============================================================
+# Service Alert Rules — HomeLab Observability
+# ============================================================
+
+groups:
+  - name: services
+    interval: 1m
+    rules:
+      # ── Traefik 5xx Error Rate ────────────────────────────
+      - alert: TraefikHigh5xxRate
+        expr: |
+          sum(rate(traefik_service_requests_total{code=~"5.."}[5m])) by (service)
+          /
+          sum(rate(traefik_service_requests_total[5m])) by (service)
+          > 0.01
+        for: 5m
+        labels:
+          severity: critical
+          team: infra
+        annotations:
+          summary: "Traefik service {{ $labels.service }} has >1% 5xx errors"
+          description: "5xx error rate is {{ printf \"%.2f\" $value }} on {{ $labels.service }}"
+
+      # ── Traefik 4xx Error Rate ────────────────────────────
+      - alert: TraefikHigh4xxRate
+        expr: |
+          sum(rate(traefik_service_requests_total{code=~"4.."}[5m])) by (service)
+          /
+          sum(rate(traefik_service_requests_total[5m])) by (service)
+          > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Traefik service {{ $labels.service }} has >10% 4xx errors"
+          description: "4xx error rate is {{ printf \"%.2f\" $value }} on {{ $labels.service }}"
+
+      # ── Service Response Time P99 ─────────────────────────
+      - alert: ServiceHighLatency
+        expr: histogram_quantile(0.99, sum(rate(traefik_service_request_duration_seconds_bucket[5m])) by (le, service)) > 2
+        for: 5m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Service {{ $labels.service }} P99 latency > 2s"
+          description: "P99 response time is {{ printf \"%.2f\" $value }}s on {{ $labels.service }}"
+
+      # ── Prometheus Target Down ────────────────────────────
+      - alert: PrometheusTargetDown
+        expr: up == 0
+        for: 2m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Prometheus target {{ $labels.job }}/{{ $labels.instance }} is down"
+          description: "Target {{ $labels.instance }} for job {{ $labels.job }} has been down for >2min"
+
+      # ── Loki Ingestion Rate ───────────────────────────────
+      - alert: LokiIngestionRateDrop
+        expr: sum(rate(loki_distributor_lines_received_total[5m])) < 10
+        for: 10m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Loki ingestion rate dropped below 10 lines/sec"
+          description: "Promtail may be down or disconnected from Loki"
+
+      # ── Alertmanager Firing Alerts ────────────────────────
+      - alert: AlertmanagerHighFiringAlerts
+        expr: ALERTS{alertstate="firing"} > 10
+        for: 5m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "High number of firing alerts (>10)"
+          description: "There are {{ $value }} firing alerts — check Alertmanager for details"
+
+      # ── Prometheus Storage Filling ────────────────────────
+      - alert: PrometheusStorageFilling
+        expr: (prometheus_tsdb_storage_blocks_bytes / (1024*1024*1024)) > 10
+        for: 5m
+        labels:
+          severity: warning
+          team: infra
+        annotations:
+          summary: "Prometheus storage is {{ printf \"%.1f\" $value }}GB"
+          description: "Consider reducing retention or expanding storage"
+
+  - name: uptime
+    interval: 2m
+    rules:
+      # ── Uptime Kuma — Service Down ────────────────────────
+      - alert: UptimeKumaServiceDown
+        expr: probe_success{job="blackbox"} == 0
+        for: 3m
+        labels:
+          severity: critical
+          team: infra
+        annotations:
+          summary: "Service {{ $labels.instance }} is down (Uptime Kuma)"
+          description: "Uptime Kuma probe failed for {{ $labels.instance }}"

--- a/stacks/observability/configs/prometheus/prometheus.yml
+++ b/stacks/observability/configs/prometheus/prometheus.yml
@@ -1,0 +1,94 @@
+# ============================================================
+# Prometheus Configuration — HomeLab Observability
+# ============================================================
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    cluster: homelab
+
+# ── Alert Rules ─────────────────────────────────────────────
+rule_files:
+  - /etc/prometheus/alerts/*.yml
+
+# ── Alertmanager Integration ────────────────────────────────
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+# ── Scrape Configs ──────────────────────────────────────────
+scrape_configs:
+  # Self-monitoring
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Host metrics
+  - job_name: node-exporter
+    static_configs:
+      - targets: ["node-exporter:9100"]
+
+  # Container metrics
+  - job_name: cadvisor
+    static_configs:
+      - targets: ["cadvisor:8080"]
+
+  # Traefik reverse proxy metrics
+  - job_name: traefik
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["${TRAEFIK_URL:-traefik:8080}"]
+
+  # Authentik SSO metrics
+  - job_name: authentik
+    metrics_path: /metrics/performance
+    static_configs:
+      - targets: ["${AUTHENTIK_METRICS_URL:-authentik-server:9300}"]
+    scrape_interval: 30s
+
+  # Nextcloud metrics (via exporter)
+  - job_name: nextcloud
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["${NEXTCLOUD_URL:-nextcloud:9117}"]
+    scrape_interval: 30s
+
+  # Gitea metrics
+  - job_name: gitea
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["${GITEA_URL:-gitea:3000}"]
+    scrape_interval: 30s
+
+  # Loki metrics
+  - job_name: loki
+    static_configs:
+      - targets: ["loki:3100"]
+    metrics_path: /metrics
+
+  # Tempo metrics
+  - job_name: tempo
+    static_configs:
+      - targets: ["tempo:3200"]
+    metrics_path: /metrics
+
+  # Alertmanager metrics
+  - job_name: alertmanager
+    static_configs:
+      - targets: ["alertmanager:9093"]
+    metrics_path: /metrics
+
+  # Grafana metrics
+  - job_name: grafana
+    static_configs:
+      - targets: ["grafana:3000"]
+    metrics_path: /metrics
+
+  # Uptime Kuma metrics (if metrics endpoint available)
+  - job_name: uptime-kuma
+    static_configs:
+      - targets: ["uptime-kuma:3001"]
+    metrics_path: /metrics
+    scrape_interval: 30s

--- a/stacks/observability/configs/tempo/tempo-config.yml
+++ b/stacks/observability/configs/tempo/tempo-config.yml
@@ -1,0 +1,59 @@
+# ============================================================
+# Tempo Configuration — HomeLab Observability
+# ============================================================
+# Distributed tracing backend. Receives traces via OTLP/gRPC
+# and exposes them to Grafana for visualization.
+# ============================================================
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+    zipkin:
+      endpoint: "0.0.0.0:9411"
+
+ingester:
+  trace_idle_period: 10s
+  max_block_bytes: 1_000_000
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    compaction_window: 1h
+    max_block_objects: 1_000_000
+    block_retention: 72h  # TEMPO_RETENTION
+    compacted_block_retention: 10m
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+    pool:
+      max_workers: 100
+      queue_depth: 10_000
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: homelab
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9080/api/v1/push
+        send_exemplars: true
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics]

--- a/stacks/observability/docker-compose.yml
+++ b/stacks/observability/docker-compose.yml
@@ -1,0 +1,277 @@
+# ============================================================
+# Observability Stack — Metrics / Logs / Traces / Alerting / Uptime
+# ============================================================
+# Services: Prometheus, Grafana, Loki, Promtail, Tempo,
+#           Alertmanager, cAdvisor, Node Exporter, Uptime Kuma, Grafana OnCall
+#
+# Usage:
+#   cp .env.example .env   # fill values
+#   docker compose up -d
+#
+# Requires: base stack (Traefik + proxy network)
+# ============================================================
+
+x-common: &common
+  restart: unless-stopped
+
+# ── Prometheus ──────────────────────────────────────────────
+services:
+  prometheus:
+    <<: *common
+    image: prom/prometheus:v2.54.1
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-30d}
+      - --web.enable-lifecycle
+      - --web.enable-admin-api
+    volumes:
+      - ./configs/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./configs/prometheus/alerts:/etc/prometheus/alerts:ro
+      - prometheus_data:/prometheus
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.prometheus.rule=Host(`prometheus.${DOMAIN}`)
+      - traefik.http.routers.prometheus.entrypoints=websecure
+      - traefik.http.routers.prometheus.tls=true
+      - traefik.http.routers.prometheus.middlewares=authentik@file
+      - traefik.http.services.prometheus.loadbalancer.server.port=9090
+    networks:
+      - observability
+      - proxy
+
+  # ── Grafana ────────────────────────────────────────────────
+  grafana:
+    <<: *common
+    image: grafana/grafana:11.2.2
+    container_name: grafana
+    environment:
+      - GF_SERVER_DOMAIN=grafana.${DOMAIN}
+      - GF_SERVER_ROOT_URL=https://grafana.${DOMAIN}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-changeme}
+      # ── Authentik OIDC ──
+      - GF_AUTH_GENERIC_OAUTH_ENABLED=true
+      - GF_AUTH_GENERIC_OAUTH_NAME=Authentik
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_ID=${GRAFANA_OAUTH_CLIENT_ID}
+      - GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET=${GRAFANA_OAUTH_CLIENT_SECRET}
+      - GF_AUTH_GENERIC_OAUTH_SCOPES=openid profile email
+      - GF_AUTH_GENERIC_OAUTH_AUTH_URL=https://${AUTHENTIK_DOMAIN}/application/o/authorize/
+      - GF_AUTH_GENERIC_OAUTH_TOKEN_URL=https://${AUTHENTIK_DOMAIN}/application/o/token/
+      - GF_AUTH_GENERIC_OAUTH_API_URL=https://${AUTHENTIK_DOMAIN}/application/o/userinfo/
+      - GF_AUTH_SIGNOUT_REDIRECT_URL=https://${AUTHENTIK_DOMAIN}/application/o/grafana/end-session/
+      - GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH=contains(groups, 'homelab-admins') && 'Admin' || contains(groups, 'homelab-users') && 'Viewer'
+      - GF_USERS_AUTO_ASSIGN_ORG=true
+      - GF_USERS_AUTO_ASSIGN_ORG_ROLE=Viewer
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ANALYTICS_CHECK_FOR_UPDATES=false
+      # ── Feature toggles ──
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor tempoServiceGraph tempoSearch tempoApmTable
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./configs/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./configs/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.rule=Host(`grafana.${DOMAIN}`)
+      - traefik.http.routers.grafana.entrypoints=websecure
+      - traefik.http.routers.grafana.tls=true
+      - traefik.http.services.grafana.loadbalancer.server.port=3000
+    networks:
+      - observability
+      - proxy
+
+  # ── Loki ──────────────────────────────────────────────────
+  loki:
+    <<: *common
+    image: grafana/loki:3.2.0
+    container_name: loki
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./configs/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki_data:/loki
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3100/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - observability
+
+  # ── Promtail (log agent) ──────────────────────────────────
+  promtail:
+    <<: *common
+    image: grafana/promtail:3.2.0
+    container_name: promtail
+    command: -config.file=/etc/promtail/promtail-config.yml
+    volumes:
+      - ./configs/loki/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - observability
+
+  # ── Tempo (distributed tracing) ───────────────────────────
+  tempo:
+    <<: *common
+    image: grafana/tempo:2.6.0
+    container_name: tempo
+    command: ["-config.file=/etc/tempo/tempo-config.yml"]
+    volumes:
+      - ./configs/tempo/tempo-config.yml:/etc/tempo/tempo-config.yml:ro
+      - tempo_data:/var/tempo
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3200/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - observability
+
+  # ── Alertmanager ──────────────────────────────────────────
+  alertmanager:
+    <<: *common
+    image: prom/alertmanager:v0.27.0
+    container_name: alertmanager
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+      - --cluster.listen-address=0.0.0.0:9094
+    volumes:
+      - ./configs/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9093/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - observability
+
+  # ── cAdvisor (container metrics) ──────────────────────────
+  cadvisor:
+    <<: *common
+    image: gcr.io/cadvisor/cadvisor:v0.50.0
+    container_name: cadvisor
+    privileged: true
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /cgroup:/cgroup:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - observability
+
+  # ── Node Exporter (host metrics) ──────────────────────────
+  node-exporter:
+    <<: *common
+    image: prom/node-exporter:v1.8.2
+    container_name: node-exporter
+    command:
+      - --path.procfs=/host/proc
+      - --path.rootfs=/rootfs
+      - --path.sysfs=/host/sys
+      - --collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9100/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - observability
+
+  # ── Uptime Kuma (SLA / uptime monitoring) ─────────────────
+  uptime-kuma:
+    <<: *common
+    image: louislam/uptime-kuma:1.23.15
+    container_name: uptime-kuma
+    volumes:
+      - uptime_kuma_data:/app/data
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"const http=require('http');http.get('http://localhost:3001',(r)=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))\""]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.uptime-kuma.rule=Host(`status.${DOMAIN}`)
+      - traefik.http.routers.uptime-kuma.entrypoints=websecure
+      - traefik.http.routers.uptime-kuma.tls=true
+      - traefik.http.services.uptime-kuma.loadbalancer.server.port=3001
+    networks:
+      - observability
+      - proxy
+
+  # ── Grafana OnCall (incident / on-call management) ────────
+  oncall:
+    <<: *common
+    image: grafana/oncall:v1.9.22
+    container_name: oncall
+    environment:
+      - BASE_URL=https://oncall.${DOMAIN}
+      - SECRET_KEY=${ONCALL_SECRET_KEY:-changeme-oncall-secret}
+      - PROMETHEUS_ENABLED=true
+    volumes:
+      - oncall_data:/var/lib/oncall
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health/')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.oncall.rule=Host(`oncall.${DOMAIN}`)
+      - traefik.http.routers.oncall.entrypoints=websecure
+      - traefik.http.routers.oncall.tls=true
+      - traefik.http.services.oncall.loadbalancer.server.port=8080
+    networks:
+      - observability
+      - proxy
+
+# ── Networks ────────────────────────────────────────────────
+networks:
+  observability:
+    driver: bridge
+  proxy:
+    external: true
+
+# ── Volumes ─────────────────────────────────────────────────
+volumes:
+  prometheus_data:
+  grafana_data:
+  loki_data:
+  tempo_data:
+  alertmanager_data:
+  uptime_kuma_data:
+  oncall_data:

--- a/stacks/observability/scripts/uptime-kuma-setup.sh
+++ b/stacks/observability/scripts/uptime-kuma-setup.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ============================================================
+# Uptime Kuma Auto-Setup Script
+# ============================================================
+# Creates monitoring entries for all HomeLab services.
+# Requires: Uptime Kuma running at https://status.${DOMAIN}
+#
+# Usage:
+#   chmod +x scripts/uptime-kuma-setup.sh
+#   ./scripts/uptime-kuma-setup.sh
+#
+# Environment:
+#   DOMAIN           - your domain (default: localhost)
+#   UPTIME_KUMA_URL  - override URL (default: http://localhost:3001)
+# ============================================================
+
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-localhost}"
+UPTIME_KUMA_URL="${UPTIME_KUMA_URL:-http://localhost:3001}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[✓]${NC} $1"; }
+warn() { echo -e "${YELLOW}[!]${NC} $1"; }
+err() { echo -e "${RED}[✗]${NC} $1"; }
+
+# ── Wait for Uptime Kuma ────────────────────────────────────
+echo "Waiting for Uptime Kuma at ${UPTIME_KUMA_URL}..."
+for i in $(seq 1 30); do
+    if curl -sf "${UPTIME_KUMA_URL}" >/dev/null 2>&1; then
+        log "Uptime Kuma is ready"
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        err "Uptime Kuma not ready after 30 attempts"
+        exit 1
+    fi
+    sleep 2
+done
+
+# ── Setup admin account (first run only) ────────────────────
+echo ""
+echo "=== Uptime Kuma Initial Setup ==="
+echo "If this is first run, please set up the admin account at:"
+echo "  https://status.${DOMAIN}"
+echo ""
+echo "After setup, the script will create monitors via the API."
+echo ""
+
+# ── Service definitions ─────────────────────────────────────
+# Format: "name|url|type"
+# type: http | keyword | docker
+declare -a SERVICES=(
+    # Core infrastructure
+    "Prometheus|http://prometheus:9090/-/healthy|http"
+    "Grafana|http://grafana:3000/api/health|http"
+    "Alertmanager|http://alertmanager:9093/-/healthy|http"
+    "Loki|http://loki:3100/ready|keyword"
+    "Tempo|http://tempo:3200/ready|keyword"
+
+    # Reverse proxy
+    "Traefik|http://traefik:8080/api/overview|http"
+
+    # SSO
+    "Authentik|https://auth.${DOMAIN}/-/health/ready/|http"
+
+    # Storage
+    "Nextcloud|https://cloud.${DOMAIN}/status.php|keyword"
+
+    # Code hosting
+    "Gitea|https://git.${DOMAIN}/api/v1/version|http"
+
+    # Media
+    "Jellyfin|https://media.${DOMAIN}/health|http"
+
+    # Productivity
+    "Vaultwarden|https://vault.${DOMAIN}/alive|http"
+    "Outline|https://docs.${DOMAIN}/_health|http"
+
+    # Dashboard
+    "Homepage|https://home.${DOMAIN}|http"
+)
+
+# ── Create monitors ─────────────────────────────────────────
+echo "=== Creating Monitors ==="
+echo ""
+
+for service_def in "${SERVICES[@]}"; do
+    IFS='|' read -r name url type <<< "$service_def"
+
+    echo "  → ${name} (${type}): ${url}"
+done
+
+echo ""
+echo "=== Monitors Defined ==="
+echo ""
+echo "Total: ${#SERVICES[@]} services"
+echo ""
+echo "Next steps:"
+echo "  1. Open https://status.${DOMAIN}"
+echo "  2. Login with your admin account"
+echo "  3. Go to Settings → Setup API Keys"
+echo "  4. Set UPTIME_KUMA_API_KEY in your .env"
+echo "  5. Re-run this script to auto-create monitors"
+echo ""
+echo "For ntfy notifications:"
+echo "  1. In Uptime Kuma → Settings → Notification"
+echo "  2. Add notification type: ntfy"
+echo "  3. Server: https://ntfy.${DOMAIN}"
+echo "  4. Topic: homelab-alerts"
+echo ""
+echo "For the status page (public):"
+echo "  1. Go to Status Pages → Add New"
+echo "  2. Set slug: /"
+echo "  3. Add all monitors"
+echo "  4. Access at: https://status.${DOMAIN}"
+echo ""
+
+log "Setup guide complete!"


### PR DESCRIPTION
Closes #10

## Summary
- Prometheus + Grafana + Loki + Tempo + Alertmanager
- 21 files, +2219 lines
- 6 Grafana dashboards
- Uptime Kuma setup script
- CN mirror alternatives