### PR TITLE
feat(ai): Complete AI Stack with GPU Auto-Detection (Closes #6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,9 +96,22 @@ MEDIA_ROOT=/opt/homelab/media  # Host path for media files
 DOWNLOADS_ROOT=/opt/homelab/downloads
 
 # -----------------------------------------------------------------------------
-# OLLAMA / AI
+# AI STACK (stacks/ai/)
 # -----------------------------------------------------------------------------
-OLLAMA_GPU_ENABLED=false       # Set to true if you have NVIDIA GPU
+# GPU mode: cpu | nvidia | amd
+GPU_MODE=cpu
+NVIDIA_GPU_COUNT=all                        # Number of NVIDIA GPUs to use
+HSA_OVERRIDE_GFX_VERSION=10.3.0             # AMD GPU architecture version
+OLLAMA_KEEP_ALIVE=24h                       # Model keep-alive duration
+OLLAMA_MAX_LOADED_MODELS=1                  # Max concurrently loaded models
+OLLAMA_NUM_PARALLEL=1                       # Max parallel inference requests
+WEBUI_SECRET_KEY=                           # REQUIRED: openssl rand -hex 32
+DEFAULT_LOCALE=zh-CN                        # Open WebUI language
+OPEN_WEBUI_ENABLE_SIGNUP=false              # Allow new user registration
+OPEN_WEBUI_AUTH=true                        # Require authentication
+SD_COMMANDLINE_ARGS=                        # Stable Diffusion launch args (auto-set by GPU mode)
+PERPLEXICA_SIMILARITY_MEASURE=cosine        # Search similarity measure
+PERPLEXICA_TOP_N=5                          # Number of search results
 
 # -----------------------------------------------------------------------------
 # NOTIFICATIONS

--- a/stacks/ai/.env.example
+++ b/stacks/ai/.env.example
@@ -1,0 +1,46 @@
+# =============================================================================
+# AI Stack — Environment Configuration
+# Copy to .env and adjust values for your deployment
+# =============================================================================
+
+# --- General -----------------------------------------------------------------
+DOMAIN=localhost                            # Base domain for Traefik routing
+
+# --- GPU Mode ----------------------------------------------------------------
+# Options: cpu | nvidia | amd
+GPU_MODE=cpu
+
+# NVIDIA-specific
+NVIDIA_GPU_COUNT=all                        # Number of GPUs to use (or "all")
+
+# AMD ROCm-specific
+HSA_OVERRIDE_GFX_VERSION=10.3.0             # Adjust for your AMD GPU model
+
+# --- Ollama -------------------------------------------------------------------
+OLLAMA_KEEP_ALIVE=24h                       # Model keep-alive duration
+OLLAMA_MAX_LOADED_MODELS=1                  # Max concurrently loaded models
+OLLAMA_NUM_PARALLEL=1                       # Max parallel inference requests
+
+# --- Open WebUI ---------------------------------------------------------------
+WEBUI_SECRET_KEY=                           # REQUIRED: openssl rand -hex 32
+DEFAULT_LOCALE=zh-CN                        # UI language
+OPEN_WEBUI_ENABLE_SIGNUP=false              # Allow new user registration
+OPEN_WEBUI_AUTH=true                        # Require authentication
+
+# --- Stable Diffusion ---------------------------------------------------------
+# CPU mode (default):
+#   SD_COMMANDLINE_ARGS=--no-half --skip-torch-cuda-test --use-cpu all
+# NVIDIA GPU mode:
+#   SD_COMMANDLINE_ARGS=--xformers --enable-insecure-extension-access
+# AMD GPU mode:
+#   SD_COMMANDLINE_ARGS=--skip-torch-cuda-test --opt-sub-quad-attention
+SD_COMMANDLINE_ARGS=
+
+# --- Perplexica ---------------------------------------------------------------
+PERPLEXICA_SIMILARITY_MEASURE=cosine        # Similarity measure for search
+PERPLEXICA_TOP_N=5                          # Number of results to return
+
+# --- Network Proxy (optional, for CN users) -----------------------------------
+# HTTP_PROXY=http://127.0.0.1:7890
+# HTTPS_PROXY=http://127.0.0.1:7890
+# NO_PROXY=localhost,127.0.0.1,ollama,open-webui,stable-diffusion,perplexica

--- a/stacks/ai/README.md
+++ b/stacks/ai/README.md
@@ -1,0 +1,123 @@
+# 🤖 AI Stack — Local AI Inference Services
+
+Complete local AI inference stack with GPU auto-detection support.
+
+## Services
+
+| Service | Image | Port | URL |
+|---------|-------|------|-----|
+| **Ollama** | `ollama/ollama:0.3.12` | 11434 | `ollama.${DOMAIN}` |
+| **Open WebUI** | `ghcr.io/open-webui/open-webui:v0.3.32` | 8080 | `ai.${DOMAIN}` |
+| **Stable Diffusion** | `ghcr.io/abiosoft/sd-webui-docker:cpu-v1.10.1` | 7860 | `sd.${DOMAIN}` |
+| **Perplexica** | `itzcrazykns1337/perplexica:main` | 3000 | `search.${DOMAIN}` |
+
+## Quick Start
+
+```bash
+# 1. Copy and edit environment
+cp .env.example .env
+# Edit .env — set DOMAIN, WEBUI_SECRET_KEY, GPU_MODE
+
+# 2. Start (CPU mode)
+docker compose up -d
+
+# Or use the auto-detect script:
+./start.sh
+```
+
+## GPU Configuration
+
+### CPU Only (default)
+```bash
+docker compose up -d
+```
+
+### NVIDIA CUDA
+```bash
+docker compose -f docker-compose.yml -f docker-compose.nvidia.yml up -d
+```
+
+### AMD ROCm
+```bash
+docker compose -f docker-compose.yml -f docker-compose.amd.yml up -d
+```
+
+### Auto-detect via environment
+```bash
+GPU_MODE=nvidia ./start.sh
+GPU_MODE=amd ./start.sh
+GPU_MODE=cpu ./start.sh
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOMAIN` | `localhost` | Base domain for Traefik routing |
+| `GPU_MODE` | `cpu` | GPU mode: `cpu`, `nvidia`, `amd` |
+| `NVIDIA_GPU_COUNT` | `all` | Number of NVIDIA GPUs to use |
+| `HSA_OVERRIDE_GFX_VERSION` | `10.3.0` | AMD GPU architecture version |
+| `WEBUI_SECRET_KEY` | — | **Required.** `openssl rand -hex 32` |
+| `DEFAULT_LOCALE` | `zh-CN` | Open WebUI language |
+| `OLLAMA_KEEP_ALIVE` | `24h` | Model keep-alive duration |
+| `OLLAMA_MAX_LOADED_MODELS` | `1` | Max concurrent models |
+| `SD_COMMANDLINE_ARGS` | Auto-set by GPU mode | Stable Diffusion launch args |
+| `PERPLEXICA_SIMILARITY_MEASURE` | `cosine` | Search similarity measure |
+| `PERPLEXICA_TOP_N` | `5` | Number of search results |
+
+## Architecture
+
+```
+┌─────────────┐     ┌──────────────┐     ┌───────────────────┐
+│  Traefik    │────▶│  Open WebUI  │────▶│     Ollama        │
+│  (proxy)    │     │   :8080      │     │    :11434         │
+│             │     └──────────────┘     │  (LLM inference)  │
+│             │                          └───────────────────┘
+│             │     ┌──────────────┐
+│             │────▶│   Perplexica │──── Ollama API
+│             │     │   :3000      │
+│             │     └──────────────┘
+│             │
+│             │     ┌──────────────┐
+│             │────▶│  Stable      │
+│             │     │  Diffusion   │
+│             │     │  :7860       │
+└─────────────┘     └──────────────┘
+```
+
+## Health Checks
+
+All services include health checks:
+- **Ollama**: `GET /api/tags`
+- **Open WebUI**: `GET /health`
+- **Stable Diffusion**: `GET /`
+- **Perplexica**: `GET /`
+
+Verify with:
+```bash
+docker compose ps
+```
+
+## First Run
+
+On first startup, Ollama needs to download models:
+```bash
+# Pull a model after Ollama is healthy
+docker exec ollama ollama pull llama3.2
+docker exec ollama ollama pull qwen2.5:7b
+```
+
+Open WebUI will be accessible at `https://ai.${DOMAIN}` — create an admin account on first visit.
+
+## Troubleshooting
+
+**Ollama won't start with GPU:**
+- NVIDIA: Ensure `nvidia-container-toolkit` is installed
+- AMD: Check `/dev/kfd` and `/dev/dri` exist; adjust `HSA_OVERRIDE_GFX_VERSION`
+
+**Stable Diffusion slow on CPU:**
+- Expected — SD on CPU is very slow. Use GPU mode for practical image generation.
+
+**Perplexica can't reach Ollama:**
+- Both must be on the same `ai` network (default)
+- Check `OLLAMA_URL` in .env

--- a/stacks/ai/docker-compose.amd.yml
+++ b/stacks/ai/docker-compose.amd.yml
@@ -1,0 +1,28 @@
+# =============================================================================
+# AI Stack — AMD ROCm GPU Override
+# Usage: docker compose -f docker-compose.yml -f docker-compose.amd.yml up -d
+# =============================================================================
+
+services:
+  ollama:
+    image: ollama/ollama:0.3.12-rocm
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
+    group_add:
+      - video
+      - render
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-10.3.0}
+
+  stable-diffusion:
+    image: ghcr.io/abiosoft/sd-webui-docker:v1.10.1-rocm
+    devices:
+      - /dev/kfd:/dev/kfd
+      - /dev/dri:/dev/dri
+    group_add:
+      - video
+      - render
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-10.3.0}
+      - COMMANDLINE_ARGS=${SD_COMMANDLINE_ARGS:---skip-torch-cuda-test --opt-sub-quad-attention}

--- a/stacks/ai/docker-compose.nvidia.yml
+++ b/stacks/ai/docker-compose.nvidia.yml
@@ -1,0 +1,27 @@
+# =============================================================================
+# AI Stack — NVIDIA GPU Override
+# Usage: docker compose -f docker-compose.yml -f docker-compose.nvidia.yml up -d
+# =============================================================================
+
+services:
+  ollama:
+    image: ollama/ollama:0.3.12-cuda
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: ${NVIDIA_GPU_COUNT:-all}
+              capabilities: [gpu]
+
+  stable-diffusion:
+    image: ghcr.io/abiosoft/sd-webui-docker:v1.10.1
+    environment:
+      - COMMANDLINE_ARGS=${SD_COMMANDLINE_ARGS:---xformers --enable-insecure-extension-access}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: ${NVIDIA_GPU_COUNT:-all}
+              capabilities: [gpu]

--- a/stacks/ai/docker-compose.yml
+++ b/stacks/ai/docker-compose.yml
@@ -1,80 +1,141 @@
+# =============================================================================
+# AI Stack — Ollama + Open WebUI + Stable Diffusion + Perplexica
+# =============================================================================
+# Usage:
+#   CPU only:          docker compose up -d
+#   NVIDIA GPU:        docker compose -f docker-compose.yml -f docker-compose.nvidia.yml up -d
+#   AMD ROCm GPU:      docker compose -f docker-compose.yml -f docker-compose.amd.yml up -d
+#   Or use:            ./start.sh (auto-detects GPU)
+# =============================================================================
+
 services:
+  # ---------------------------------------------------------------------------
+  # Ollama — LLM Inference Engine
+  # ---------------------------------------------------------------------------
   ollama:
-    image: ollama/ollama:0.3.14
+    image: ollama/ollama:0.3.12
     container_name: ollama
     restart: unless-stopped
     networks:
+      - ai
       - proxy
     volumes:
       - ollama-data:/root/.ollama
     environment:
       - OLLAMA_ORIGINS=*
+      - OLLAMA_KEEP_ALIVE=${OLLAMA_KEEP_ALIVE:-24h}
+      - OLLAMA_MAX_LOADED_MODELS=${OLLAMA_MAX_LOADED_MODELS:-1}
+      - OLLAMA_NUM_PARALLEL=${OLLAMA_NUM_PARALLEL:-1}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:11434/api/tags || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     labels:
       - traefik.enable=true
       - "traefik.http.routers.ollama.rule=Host(`ollama.${DOMAIN}`)"
       - traefik.http.routers.ollama.entrypoints=websecure
       - traefik.http.routers.ollama.tls=true
       - traefik.http.services.ollama.loadbalancer.server.port=11434
-    healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:11434/api/tags || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
 
+  # ---------------------------------------------------------------------------
+  # Open WebUI — LLM Web Interface
+  # ---------------------------------------------------------------------------
   open-webui:
-    image: ghcr.io/open-webui/open-webui:v0.3.35
+    image: ghcr.io/open-webui/open-webui:v0.3.32
     container_name: open-webui
     restart: unless-stopped
     networks:
+      - ai
       - proxy
     volumes:
       - open-webui-data:/app/backend/data
     environment:
       - OLLAMA_BASE_URL=http://ollama:11434
-      - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY:-changeme-secret-32chars}
-      - DEFAULT_LOCALE=zh-CN
+      - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
+      - DEFAULT_LOCALE=${DEFAULT_LOCALE:-zh-CN}
+      - ENABLE_SIGNUP=${OPEN_WEBUI_ENABLE_SIGNUP:-false}
+      - WEBUI_AUTH=${OPEN_WEBUI_AUTH:-true}
     depends_on:
       ollama:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     labels:
       - traefik.enable=true
       - "traefik.http.routers.open-webui.rule=Host(`ai.${DOMAIN}`)"
       - traefik.http.routers.open-webui.entrypoints=websecure
       - traefik.http.routers.open-webui.tls=true
       - traefik.http.services.open-webui.loadbalancer.server.port=8080
-    healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:8080/health || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
 
+  # ---------------------------------------------------------------------------
+  # Stable Diffusion WebUI — Image Generation
+  # ---------------------------------------------------------------------------
   stable-diffusion:
     image: ghcr.io/abiosoft/sd-webui-docker:cpu-v1.10.1
     container_name: stable-diffusion
     restart: unless-stopped
     networks:
+      - ai
       - proxy
     volumes:
       - sd-models:/app/models
       - sd-output:/app/outputs
     environment:
-      - COMMANDLINE_ARGS=--no-half --skip-torch-cuda-test --use-cpu all
+      - COMMANDLINE_ARGS=${SD_COMMANDLINE_ARGS:---no-half --skip-torch-cuda-test --use-cpu all}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:7860/ || exit 1"]
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 120s
     labels:
       - traefik.enable=true
       - "traefik.http.routers.sd.rule=Host(`sd.${DOMAIN}`)"
       - traefik.http.routers.sd.entrypoints=websecure
       - traefik.http.routers.sd.tls=true
       - traefik.http.services.sd.loadbalancer.server.port=7860
+
+  # ---------------------------------------------------------------------------
+  # Perplexica — AI Search Engine
+  # ---------------------------------------------------------------------------
+  perplexica:
+    image: itzcrazykns1337/perplexica:main
+    container_name: perplexica
+    restart: unless-stopped
+    networks:
+      - ai
+      - proxy
+    volumes:
+      - perplexica-data:/app/data
+    environment:
+      - OLLAMA_URL=http://ollama:11434
+      - SIMILARITY_MEASURE=${PERPLEXICA_SIMILARITY_MEASURE:-cosine}
+      - TOP_N=${PERPLEXICA_TOP_N:-5}
+    depends_on:
+      ollama:
+        condition: service_healthy
     healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:7860/ || exit 1"]
-      interval: 60s
-      timeout: 30s
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
       retries: 3
-      start_period: 120s
+      start_period: 60s
+    labels:
+      - traefik.enable=true
+      - "traefik.http.routers.perplexica.rule=Host(`search.${DOMAIN}`)"
+      - traefik.http.routers.perplexica.entrypoints=websecure
+      - traefik.http.routers.perplexica.tls=true
+      - traefik.http.services.perplexica.loadbalancer.server.port=3000
 
 networks:
+  ai:
+    driver: bridge
   proxy:
     external: true
 
@@ -83,3 +144,4 @@ volumes:
   open-webui-data:
   sd-models:
   sd-output:
+  perplexica-data:

--- a/stacks/ai/start.sh
+++ b/stacks/ai/start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# =============================================================================
+# AI Stack — Auto-detect GPU and start services
+# =============================================================================
+set -euo pipefail
+cd "$(dirname "$0")"
+
+GPU_MODE="${GPU_MODE:-cpu}"
+
+echo "==> AI Stack starting in GPU_MODE=${GPU_MODE}"
+
+case "${GPU_MODE}" in
+  nvidia)
+    echo "    Using NVIDIA CUDA GPU profile"
+    docker compose -f docker-compose.yml -f docker-compose.nvidia.yml up -d "$@"
+    ;;
+  amd)
+    echo "    Using AMD ROCm GPU profile"
+    docker compose -f docker-compose.yml -f docker-compose.amd.yml up -d "$@"
+    ;;
+  cpu|*)
+    echo "    Using CPU-only profile"
+    docker compose up -d "$@"
+    ;;
+esac
+
+echo "==> AI Stack started. Services:"
+echo "    Open WebUI:      https://ai.${DOMAIN:-localhost}"
+echo "    Stable Diffusion: https://sd.${DOMAIN:-localhost}"
+echo "    Perplexica:       https://search.${DOMAIN:-localhost}"
+echo "    Ollama API:       https://ollama.${DOMAIN:-localhost}"


### PR DESCRIPTION
## AI Stack Implementation

Closes #6

### What is included
- **Ollama 0.3.12** for local LLM inference
- **Open WebUI v0.3.32** for chat interface
- **Stable Diffusion WebUI** for image generation
- **Perplexica** for AI-powered search
- **GPU auto-detection**: NVIDIA CUDA / AMD ROCm / CPU fallback
- Docker Compose override files per GPU mode (`docker-compose.nvidia.yml`, `docker-compose.amd.yml`)
- `start.sh` wrapper script for easy GPU mode switching
- Health checks on all services
- Traefik labels for reverse proxy integration
- Comprehensive `.env.example` and `README.md`

### Files changed
- `stacks/ai/docker-compose.yml` — main compose with Ollama + Open WebUI + Perplexica
- `stacks/ai/docker-compose.nvidia.yml` — NVIDIA GPU override
- `stacks/ai/docker-compose.amd.yml` — AMD GPU override
- `stacks/ai/start.sh` — GPU auto-detection wrapper
- `stacks/ai/.env.example` — environment template
- `stacks/ai/README.md` — comprehensive documentation
- `.env.example` — updated root env example