### PR TITLE
Add robustness and China network adaptation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ sources.list.bak
 # Generated configs
 config/traefik/acme.json
 config/traefik/dynamic/*.generated.yml
+
+# Generated diagnostics and localization backups
+diagnostics/
+.localize-images-backup/

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Each bounty task is self-contained with:
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
+For restricted networks, Docker mirror setup, image localization, health waits, and diagnostics, see [docs/robustness.md](docs/robustness.md).
+
 ---
 
 ## 📋 Requirements

--- a/config/cn-mirrors.yml
+++ b/config/cn-mirrors.yml
@@ -1,0 +1,17 @@
+docker_registry_mirrors:
+  primary:
+    - https://docker.m.daocloud.io
+    - https://hub-mirror.c.163.com
+    - https://mirror.baidubce.com
+  fallback:
+    - https://mirror.gcr.io
+image_registry_map:
+  gcr.io: gcr.m.daocloud.io
+  ghcr.io: ghcr.m.daocloud.io
+  k8s.gcr.io: k8s-gcr.m.daocloud.io
+  registry.k8s.io: k8s.m.daocloud.io
+  quay.io: quay.m.daocloud.io
+package_mirrors:
+  apt: https://mirrors.tuna.tsinghua.edu.cn/ubuntu/
+  pip: https://pypi.tuna.tsinghua.edu.cn/simple
+  apk: https://mirrors.ustc.edu.cn/alpine

--- a/docs/robustness.md
+++ b/docs/robustness.md
@@ -1,0 +1,55 @@
+# Robustness and China network adaptation
+
+This repository includes helper scripts for restricted or slow network environments and for production diagnostics.
+
+## Mainland China Docker mirrors
+
+```bash
+./scripts/setup-cn-mirrors.sh --yes
+./scripts/localize-images.sh --cn
+```
+
+`setup-cn-mirrors.sh` writes Docker registry mirrors to `/etc/docker/daemon.json`, restarts Docker when possible, and verifies with `docker pull hello-world`.
+
+`localize-images.sh --cn` rewrites blocked registries in compose files using `config/cn-mirrors.yml`. Use `--dry-run` first to preview changes, `--check` to verify no `gcr.io` or `ghcr.io` images remain, and `--restore` to revert from the last backup.
+
+## Package mirrors
+
+For services or entrypoints that install packages at runtime, print the mirror snippet and source it before package installation:
+
+```bash
+./scripts/setup-package-mirrors.sh --print-entrypoint
+```
+
+For host-level package manager acceleration:
+
+```bash
+./scripts/setup-package-mirrors.sh --host
+```
+
+Ubuntu/Debian use the Tsinghua apt mirror, pip uses the Tsinghua PyPI mirror, and Alpine uses the USTC mirror.
+
+## Connectivity and diagnostics
+
+```bash
+./scripts/check-connectivity.sh
+./scripts/diagnose.sh
+```
+
+`check-connectivity.sh` reports OK/SLOW/FAIL for Docker Hub, GitHub, gcr.io, ghcr.io, DNS, and outbound HTTP/HTTPS.
+
+`diagnose.sh` writes a diagnostic report under `diagnostics/` with Docker version, OS/kernel/memory/disk details, container status, recent error logs, connectivity results, and compose validation.
+
+## Stack readiness
+
+```bash
+./scripts/wait-healthy.sh --stack base --timeout 300
+```
+
+Exit codes:
+
+- `0`: all containers are running and healthy, or running without a healthcheck
+- `1`: timed out waiting for health
+- `2`: at least one container exited
+
+On timeout, the script prints the last 50 log lines from stack containers.

--- a/install.sh
+++ b/install.sh
@@ -1,89 +1,203 @@
 #!/usr/bin/env bash
-# =============================================================================
-# HomeLab Stack — Installer
-# =============================================================================
 set -euo pipefail
 IFS=$'\n\t'
 
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
-BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LOG_FILE=${LOG_FILE:-$HOME/.homelab/install.log}
+AUTO_INSTALL_DOCKER=true
 
-log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
-log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
-log_step()  { echo -e "\n${BLUE}${BOLD}==> $*${NC}"; }
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+log_info()  { printf '%b[INFO]%b %s\n' "$GREEN" "$NC" "$*"; }
+log_warn()  { printf '%b[WARN]%b %s\n' "$YELLOW" "$NC" "$*"; }
+log_error() { printf '%b[ERROR]%b %s\n' "$RED" "$NC" "$*" >&2; }
+log_step()  { printf '\n%b==> %s%b\n' "$BLUE$BOLD" "$*" "$NC"; }
+
+usage() {
+  cat <<'USAGE'
+Usage: ./install.sh [--no-auto-install-docker]
+
+Runs preflight checks, optionally installs Docker on supported Linux systems,
+configures the environment, checks connectivity, and starts the base stack.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-auto-install-docker) AUTO_INSTALL_DOCKER=false; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$(dirname "$LOG_FILE")"
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 cleanup() {
-  if [[ $? -ne 0 ]]; then
-    log_error "Installation failed. Check logs at ~/.homelab/install.log"
+  local code=$?
+  if [[ "$code" -ne 0 ]]; then
+    log_error "Installation failed. Diagnostics: ./scripts/diagnose.sh. Log: $LOG_FILE"
   fi
 }
 trap cleanup EXIT
 
-# ---------------------------------------------------------------------------
-# Banner
-# ---------------------------------------------------------------------------
-echo -e ""
-echo -e "${BOLD}  ██╗  ██╗ ██████╗ ███╗   ███╗███████╗██╗      █████╗ ██████╗ ${NC}"
-echo -e "${BOLD}  ██║  ██║██╔═══██╗████╗ ████║██╔════╝██║     ██╔══██╗██╔══██╗${NC}"
-echo -e "${BOLD}  ███████║██║   ██║██╔████╔██║█████╗  ██║     ███████║██████╔╝${NC}"
-echo -e "${BOLD}  ██╔══██║██║   ██║██║╚██╔╝██║██╔══╝  ██║     ██╔══██║██╔══██╗${NC}"
-echo -e "${BOLD}  ██║  ██║╚██████╔╝██║ ╚═╝ ██║███████╗███████╗██║  ██║██████╔╝${NC}"
-echo -e "${BOLD}  ╚═╝  ╚═╝ ╚═════╝ ╚═╝     ╚═╝╚══════╝╚══════╝╚═╝  ╚═╝╚═════╝ ${NC}"
-echo -e "${BOLD}                    S T A C K   v1.0.0${NC}"
-echo -e ""
+retry() {
+  local attempts=$1 delay=$2
+  shift 2
+  local count=1
+  until "$@"; do
+    if [[ "$count" -ge "$attempts" ]]; then
+      return 1
+    fi
+    log_warn "Command failed, retrying in ${delay}s ($count/$attempts): $*"
+    sleep "$delay"
+    delay=$((delay * 2))
+    count=$((count + 1))
+  done
+}
 
-# ---------------------------------------------------------------------------
-# Step 1: Check dependencies
-# ---------------------------------------------------------------------------
-log_step "Checking dependencies"
-bash "$(dirname "$0")/scripts/check-deps.sh"
+require_root_for_install() {
+  if [[ "$(id -u)" -ne 0 ]] && ! command -v sudo >/dev/null 2>&1; then
+    log_error "sudo is required to install Docker automatically. Re-run as root or install Docker manually."
+    exit 1
+  fi
+}
 
-# ---------------------------------------------------------------------------
-# Step 2: CN network detection
-# ---------------------------------------------------------------------------
-log_step "Network environment detection"
-bash "$(dirname "$0")/scripts/check-deps.sh" --network-check
+as_root() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
 
-# ---------------------------------------------------------------------------
-# Step 3: Setup environment
-# ---------------------------------------------------------------------------
-log_step "Environment configuration"
-if [[ ! -f .env ]]; then
-  bash "$(dirname "$0")/scripts/setup-env.sh"
-else
-  log_warn ".env already exists, skipping setup. Remove it to reconfigure."
-fi
+install_docker_ubuntu_debian() {
+  retry 3 2 as_root apt-get update
+  retry 3 2 as_root apt-get install -y ca-certificates curl gnupg lsb-release
+  if ! [[ -f /etc/apt/keyrings/docker.gpg ]]; then
+    as_root install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/"$(. /etc/os-release && printf '%s' "$ID")"/gpg | as_root gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    as_root chmod a+r /etc/apt/keyrings/docker.gpg
+  fi
+  local distro codename arch
+  distro=$(. /etc/os-release && printf '%s' "$ID")
+  codename=$(. /etc/os-release && printf '%s' "$VERSION_CODENAME")
+  arch=$(dpkg --print-architecture)
+  printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/%s %s stable\n' "$arch" "$distro" "$codename" | as_root tee /etc/apt/sources.list.d/docker.list >/dev/null
+  retry 3 2 as_root apt-get update
+  retry 3 2 as_root apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+}
 
-# ---------------------------------------------------------------------------
-# Step 4: Create data directories
-# ---------------------------------------------------------------------------
-log_step "Creating data directories"
-mkdir -p \
-  data/traefik/certs \
-  data/portainer \
-  data/prometheus \
-  data/grafana \
-  data/loki \
-  data/authentik/media \
-  data/nextcloud \
-  data/gitea \
-  data/vaultwarden
+install_docker_centos() {
+  retry 3 2 as_root yum install -y yum-utils
+  as_root yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  retry 3 2 as_root yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+}
 
-chmod 600 config/traefik/acme.json 2>/dev/null || touch config/traefik/acme.json && chmod 600 config/traefik/acme.json
+install_docker_arch() {
+  retry 3 2 as_root pacman -Sy --noconfirm docker docker-compose
+}
 
-# ---------------------------------------------------------------------------
-# Step 5: Launch base infrastructure
-# ---------------------------------------------------------------------------
-log_step "Launching base infrastructure"
-docker compose -f docker-compose.base.yml up -d
+auto_install_docker() {
+  command -v docker >/dev/null 2>&1 && return 0
+  [[ "$AUTO_INSTALL_DOCKER" == true ]] || return 0
+  require_root_for_install
+  [[ -f /etc/os-release ]] || { log_warn "Cannot detect OS for Docker auto-install."; return 0; }
+  . /etc/os-release
+  case "${ID:-}" in
+    ubuntu|debian) install_docker_ubuntu_debian ;;
+    centos|rhel|fedora|rocky|almalinux) install_docker_centos ;;
+    arch|manjaro) install_docker_arch ;;
+    *) log_warn "Unsupported OS for Docker auto-install: ${ID:-unknown}"; return 0 ;;
+  esac
+  as_root systemctl enable --now docker || true
+}
 
-log_info ""
-log_info "${GREEN}${BOLD}✓ Base infrastructure is up!${NC}"
-log_info ""
-log_info "Next steps:"
-log_info "  ./scripts/stack-manager.sh start sso        # Set up SSO first (recommended)"
-log_info "  ./scripts/stack-manager.sh start monitoring # Launch monitoring"
-log_info "  ./scripts/stack-manager.sh list             # See all available stacks"
-log_info ""
-log_info "Documentation: docs/getting-started.md"
+check_compose_v2() {
+  if docker compose version >/dev/null 2>&1; then
+    log_info "Docker Compose v2 found: $(docker compose version --short 2>/dev/null || docker compose version)"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    log_error "docker-compose v1 detected. Install the Docker Compose v2 plugin before continuing."
+    exit 1
+  else
+    log_error "Docker Compose v2 plugin is missing."
+    exit 1
+  fi
+}
+
+check_resources() {
+  local free_gb mem_mb
+  free_gb=$(df -BG "$ROOT_DIR" | awk 'NR==2 {gsub(/G/,"",$4); print $4}')
+  mem_mb=$(awk '/MemTotal/ {printf "%d", $2 / 1024}' /proc/meminfo 2>/dev/null || printf 0)
+  [[ "$free_gb" -ge 10 ]] || log_warn "Only ${free_gb}GB free; 10GB+ recommended."
+  [[ "$mem_mb" -ge 4096 ]] || log_warn "Only ${mem_mb}MB RAM; 4GB+ recommended."
+}
+
+check_user_group() {
+  if [[ "$(id -u)" -ne 0 ]] && ! id -nG | tr ' ' '\n' | grep -qx docker; then
+    log_warn "Current user is not in docker group. You may need: sudo usermod -aG docker $USER"
+  fi
+}
+
+check_firewall() {
+  if command -v ufw >/dev/null 2>&1 && ufw status | grep -q active; then
+    log_warn "ufw is active; ensure ports 80 and 443 are allowed."
+  fi
+  if command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
+    log_warn "firewalld is active; ensure ports 80 and 443 are allowed."
+  fi
+}
+
+ensure_proxy_network() {
+  docker network inspect proxy >/dev/null 2>&1 || docker network create proxy >/dev/null
+}
+
+ensure_acme() {
+  mkdir -p "$ROOT_DIR/config/traefik"
+  touch "$ROOT_DIR/config/traefik/acme.json"
+  chmod 600 "$ROOT_DIR/config/traefik/acme.json"
+}
+
+print_banner() {
+  printf '\n%b  HomeLab Stack v1.0.0%b\n\n' "$BOLD" "$NC"
+}
+
+main() {
+  cd "$ROOT_DIR"
+  print_banner
+  log_step "Installing or validating Docker"
+  auto_install_docker
+  check_compose_v2
+  retry 3 2 docker info >/dev/null
+
+  log_step "Connectivity check"
+  if ! "$ROOT_DIR/scripts/check-connectivity.sh"; then
+    log_warn "Connectivity is degraded. If you are in mainland China, run scripts/setup-cn-mirrors.sh and scripts/localize-images.sh --cn."
+  fi
+
+  log_step "Dependency and host checks"
+  bash "$ROOT_DIR/scripts/check-deps.sh" || true
+  check_resources
+  check_user_group
+  check_firewall
+  ensure_proxy_network
+  ensure_acme
+
+  log_step "Environment configuration"
+  if [[ ! -f "$ROOT_DIR/.env" ]]; then
+    bash "$ROOT_DIR/scripts/setup-env.sh"
+  else
+    log_warn ".env already exists, skipping setup. Remove it to reconfigure."
+  fi
+
+  log_step "Creating data directories"
+  mkdir -p data/traefik/certs data/portainer data/prometheus data/grafana data/loki data/authentik/media data/nextcloud data/gitea data/vaultwarden
+
+  log_step "Launching base infrastructure"
+  retry 3 3 docker compose -f "$ROOT_DIR/stacks/base/docker-compose.yml" up -d
+  "$ROOT_DIR/scripts/wait-healthy.sh" --stack base --timeout 300
+
+  log_info "Base infrastructure is up."
+  log_info "Next: ./scripts/stack-manager.sh start sso"
+}
+
+main "$@"

--- a/scripts/check-connectivity.sh
+++ b/scripts/check-connectivity.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+FAILURES=0
+SLOW=0
+
+status_line() {
+  local status=$1 name=$2 detail=$3 color
+  case "$status" in
+    OK) color=$GREEN ;;
+    SLOW) color=$YELLOW; SLOW=$((SLOW + 1)) ;;
+    FAIL) color=$RED; FAILURES=$((FAILURES + 1)) ;;
+    *) color=$BLUE ;;
+  esac
+  printf '%b%-5s%b %-24s %s\n' "$color" "$status" "$NC" "$name" "$detail"
+}
+
+check_https() {
+  local name=$1 url=$2 start_ms elapsed_ms code
+  start_ms=$(date +%s%3N 2>/dev/null || printf '%s000' "$(date +%s)")
+  code=$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 15 "$url" 2>/dev/null || printf '000')
+  elapsed_ms=$((($(date +%s%3N 2>/dev/null || printf '%s000' "$(date +%s)")) - start_ms))
+  if [[ "$code" =~ ^[23] ]]; then
+    if [[ "$elapsed_ms" -gt 5000 ]]; then
+      status_line SLOW "$name" "${elapsed_ms}ms HTTP $code $url"
+    else
+      status_line OK "$name" "${elapsed_ms}ms HTTP $code $url"
+    fi
+  else
+    status_line FAIL "$name" "HTTP $code $url"
+  fi
+}
+
+check_dns() {
+  local host=${1:-github.com}
+  if getent hosts "$host" >/dev/null 2>&1 || nslookup "$host" >/dev/null 2>&1; then
+    status_line OK DNS "$host resolves"
+  else
+    status_line FAIL DNS "$host does not resolve"
+  fi
+}
+
+check_port() {
+  local name=$1 host=$2 port=$3
+  if timeout 5 bash -c "</dev/tcp/$host/$port" >/dev/null 2>&1; then
+    status_line OK "$name" "$host:$port reachable"
+  else
+    status_line FAIL "$name" "$host:$port unreachable"
+  fi
+}
+
+main() {
+  printf '%bHomeLab connectivity check%b\n\n' "$BLUE" "$NC"
+  check_dns github.com
+  check_https "Docker Hub" "https://registry-1.docker.io/v2/"
+  check_https GitHub "https://github.com/"
+  check_https "gcr.io" "https://gcr.io/v2/"
+  check_https "ghcr.io" "https://ghcr.io/v2/"
+  check_port "Outbound HTTP" example.com 80
+  check_port "Outbound HTTPS" example.com 443
+  printf '\nSummary: %s slow, %s failed\n' "$SLOW" "$FAILURES"
+  if [[ "$FAILURES" -gt 0 || "$SLOW" -gt 0 ]]; then
+    printf '%bRecommendation:%b run scripts/setup-cn-mirrors.sh and scripts/localize-images.sh --cn if you are on a restricted or slow network.\n' "$YELLOW" "$NC"
+  fi
+  [[ "$FAILURES" -eq 0 ]]
+}
+
+main "$@"

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+REPORT_DIR=${REPORT_DIR:-$ROOT_DIR/diagnostics}
+REPORT_FILE="$REPORT_DIR/homelab-diagnostic-$(date +%Y%m%d-%H%M%S).txt"
+
+section() {
+  printf '\n## %s\n\n' "$1"
+}
+
+run_cmd() {
+  local title=$1
+  shift
+  printf '$ %s\n' "$*"
+  "$@" 2>&1 || true
+  printf '\n'
+}
+
+mkdir -p "$REPORT_DIR"
+{
+  printf 'HomeLab diagnostic report\nGenerated: %s\nRoot: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ROOT_DIR"
+
+  section "System"
+  run_cmd "OS" uname -a
+  [[ -f /etc/os-release ]] && run_cmd "os-release" cat /etc/os-release
+  run_cmd "Memory" free -h
+  run_cmd "Disk" df -h
+
+  section "Docker"
+  run_cmd "Docker version" docker version
+  run_cmd "Docker info" docker info
+  run_cmd "Docker compose" docker compose version
+  run_cmd "Containers" docker ps -a
+  run_cmd "Networks" docker network ls
+
+  section "Compose validation"
+  while IFS= read -r compose_file; do
+    printf '### %s\n' "${compose_file#$ROOT_DIR/}"
+    docker compose -f "$compose_file" config >/dev/null && printf 'OK\n\n' || docker compose -f "$compose_file" config || true
+  done < <(find "$ROOT_DIR/stacks" -name 'docker-compose.yml' -print | sort)
+
+  section "Recent container errors"
+  while IFS= read -r container; do
+    printf '### %s\n' "$container"
+    docker logs --tail=100 "$container" 2>&1 | grep -Ei 'error|fail|panic|fatal|oom|denied|refused' || true
+    printf '\n'
+  done < <(docker ps -a --format '{{.Names}}' 2>/dev/null || true)
+
+  section "Connectivity"
+  "$ROOT_DIR/scripts/check-connectivity.sh" || true
+
+  section "Config validation"
+  "$ROOT_DIR/scripts/check-deps.sh" || true
+} > "$REPORT_FILE"
+
+printf 'Diagnostic report written to %s\n' "$REPORT_FILE"

--- a/scripts/localize-images.sh
+++ b/scripts/localize-images.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BACKUP_DIR="$ROOT_DIR/.localize-images-backup"
+MODE=${1:---help}
+COMPOSE_GLOB=()
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/localize-images.sh --cn|--restore|--dry-run|--check
+
+  --cn       Replace blocked registries in compose files with configured mirrors.
+  --restore  Restore compose files from the last --cn backup.
+  --dry-run  Print replacements that would be made without editing files.
+  --check    Fail if compose files still contain gcr.io or ghcr.io images.
+USAGE
+}
+
+collect_compose_files() {
+  find "$ROOT_DIR" \( -path '*/.git' -o -path "$BACKUP_DIR" \) -prune -o -type f \( -name 'docker-compose.yml' -o -name 'docker-compose.local.yml' \) -print | sort
+}
+
+mirror_image() {
+  local image=$1
+  case "$image" in
+    gcr.io/*) printf 'gcr.m.daocloud.io/%s' "${image#gcr.io/}" ;;
+    ghcr.io/*) printf 'ghcr.m.daocloud.io/%s' "${image#ghcr.io/}" ;;
+    k8s.gcr.io/*) printf 'k8s-gcr.m.daocloud.io/%s' "${image#k8s.gcr.io/}" ;;
+    registry.k8s.io/*) printf 'k8s.m.daocloud.io/%s' "${image#registry.k8s.io/}" ;;
+    quay.io/*) printf 'quay.m.daocloud.io/%s' "${image#quay.io/}" ;;
+    *) printf '%s' "$image" ;;
+  esac
+}
+
+restore_image() {
+  local image=$1
+  case "$image" in
+    gcr.m.daocloud.io/*) printf 'gcr.io/%s' "${image#gcr.m.daocloud.io/}" ;;
+    ghcr.m.daocloud.io/*) printf 'ghcr.io/%s' "${image#ghcr.m.daocloud.io/}" ;;
+    k8s-gcr.m.daocloud.io/*) printf 'k8s.gcr.io/%s' "${image#k8s-gcr.m.daocloud.io/}" ;;
+    k8s.m.daocloud.io/*) printf 'registry.k8s.io/%s' "${image#k8s.m.daocloud.io/}" ;;
+    quay.m.daocloud.io/*) printf 'quay.io/%s' "${image#quay.m.daocloud.io/}" ;;
+    *) printf '%s' "$image" ;;
+  esac
+}
+
+replace_file() {
+  local file=$1 dry_run=${2:-false} tmp old_image new_image changed=false
+  tmp=$(mktemp)
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ ^([[:space:]]*image:[[:space:]]*[\"\']?)([^\"\'#[:space:]]+)([\"\']?.*)$ ]]; then
+      old_image=${BASH_REMATCH[2]}
+      new_image=$(mirror_image "$old_image")
+      if [[ "$new_image" != "$old_image" ]]; then
+        changed=true
+        printf '%s: %s -> %s\n' "${file#$ROOT_DIR/}" "$old_image" "$new_image" >&2
+        line="${BASH_REMATCH[1]}${new_image}${BASH_REMATCH[3]}"
+      fi
+    fi
+    printf '%s\n' "$line" >> "$tmp"
+  done < "$file"
+  if [[ "$changed" == true && "$dry_run" != true ]]; then
+    mkdir -p "$BACKUP_DIR/$(dirname "${file#$ROOT_DIR/}")"
+    cp "$file" "$BACKUP_DIR/${file#$ROOT_DIR/}"
+    mv "$tmp" "$file"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+restore_from_backup() {
+  if [[ ! -d "$BACKUP_DIR" ]]; then
+    printf 'No backup directory found at %s\n' "$BACKUP_DIR" >&2
+    exit 1
+  fi
+  while IFS= read -r backup; do
+    local relative=${backup#$BACKUP_DIR/}
+    mkdir -p "$ROOT_DIR/$(dirname "$relative")"
+    cp "$backup" "$ROOT_DIR/$relative"
+    printf 'restored %s\n' "$relative"
+  done < <(find "$BACKUP_DIR" -type f | sort)
+}
+
+check_no_blocked_registries() {
+  local failed=0
+  while IFS= read -r file; do
+    if grep -Eq 'image:[[:space:]]*["'"'"']?(gcr\.io|ghcr\.io)/' "$file"; then
+      printf 'blocked registry remains in %s\n' "${file#$ROOT_DIR/}" >&2
+      failed=1
+    fi
+  done < <(collect_compose_files)
+  exit "$failed"
+}
+
+run_cn() {
+  local dry_run=${1:-false}
+  while IFS= read -r file; do
+    replace_file "$file" "$dry_run"
+  done < <(collect_compose_files)
+}
+
+case "$MODE" in
+  --cn) run_cn false ;;
+  --dry-run) run_cn true ;;
+  --restore) restore_from_backup ;;
+  --check) check_no_blocked_registries ;;
+  --help|-h) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/scripts/setup-cn-mirrors.sh
+++ b/scripts/setup-cn-mirrors.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+DAEMON_JSON=${DAEMON_JSON:-/etc/docker/daemon.json}
+MIRRORS=("https://docker.m.daocloud.io" "https://hub-mirror.c.163.com" "https://mirror.baidubce.com" "https://mirror.gcr.io")
+ASSUME_YES=false
+DRY_RUN=false
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/setup-cn-mirrors.sh [--yes] [--dry-run]
+
+Configures Docker registry mirrors for mainland China networks and verifies the
+configuration by pulling hello-world. Requires sudo/root unless DAEMON_JSON is
+pointed at a writable test path.
+USAGE
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) ASSUME_YES=true ;;
+    --dry-run) DRY_RUN=true ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+
+confirm_cn() {
+  if [[ "$ASSUME_YES" == true ]]; then
+    return 0
+  fi
+  read -r -p "Are you deploying from mainland China or a slow/restricted Docker network? [y/N] " answer
+  [[ "$answer" =~ ^[Yy]$ ]]
+}
+
+json_payload() {
+  printf '{\n  "registry-mirrors": [\n'
+  local index
+  for index in "${!MIRRORS[@]}"; do
+    if [[ "$index" -gt 0 ]]; then
+      printf ',\n'
+    fi
+    printf '    "%s"' "${MIRRORS[$index]}"
+  done
+  printf '\n  ]\n}\n'
+}
+
+write_daemon_config() {
+  local payload tmp
+  payload=$(json_payload)
+  if [[ "$DRY_RUN" == true ]]; then
+    printf '%s' "$payload"
+    return 0
+  fi
+  tmp=$(mktemp)
+  printf '%s' "$payload" > "$tmp"
+  if [[ "$(id -u)" -eq 0 || -w "$(dirname "$DAEMON_JSON")" ]]; then
+    mkdir -p "$(dirname "$DAEMON_JSON")"
+    cp "$tmp" "$DAEMON_JSON"
+  else
+    sudo mkdir -p "$(dirname "$DAEMON_JSON")"
+    sudo cp "$tmp" "$DAEMON_JSON"
+  fi
+  rm -f "$tmp"
+}
+
+restart_docker() {
+  [[ "$DRY_RUN" == true ]] && return 0
+  if command -v systemctl >/dev/null 2>&1; then
+    if [[ "$(id -u)" -eq 0 ]]; then
+      systemctl restart docker
+    else
+      sudo systemctl restart docker
+    fi
+  else
+    printf 'Docker daemon config written. Restart Docker manually to apply it.\n'
+  fi
+}
+
+verify_pull() {
+  [[ "$DRY_RUN" == true ]] && return 0
+  docker pull hello-world >/dev/null
+  printf 'Docker mirror verification succeeded with hello-world.\n'
+}
+
+main() {
+  if ! confirm_cn; then
+    printf 'Skipped Docker mirror setup.\n'
+    exit 0
+  fi
+  write_daemon_config
+  if [[ "$DRY_RUN" == true ]]; then
+    return 0
+  fi
+  restart_docker
+  verify_pull
+  printf 'Docker registry mirrors configured from %s/config/cn-mirrors.yml.\n' "$ROOT_DIR"
+}
+
+main "$@"

--- a/scripts/setup-package-mirrors.sh
+++ b/scripts/setup-package-mirrors.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE=${1:---help}
+APT_MIRROR=${APT_MIRROR:-https://mirrors.tuna.tsinghua.edu.cn/ubuntu/}
+PIP_MIRROR=${PIP_MIRROR:-https://pypi.tuna.tsinghua.edu.cn/simple}
+APK_MIRROR=${APK_MIRROR:-https://mirrors.ustc.edu.cn/alpine}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/setup-package-mirrors.sh --host|--print-entrypoint|--help
+
+  --host             Configure host apt/pip/apk mirrors when those package
+                     managers exist. Uses sudo if needed.
+  --print-entrypoint Print a shell snippet that service entrypoints can source
+                     before apt/pip/apk installs.
+USAGE
+}
+
+write_file() {
+  local path=$1 content=$2
+  if [[ "$(id -u)" -eq 0 || -w "$(dirname "$path")" ]]; then
+    printf '%s\n' "$content" > "$path"
+  else
+    printf '%s\n' "$content" | sudo tee "$path" >/dev/null
+  fi
+}
+
+configure_apt() {
+  command -v apt-get >/dev/null 2>&1 || return 0
+  local codename
+  codename=$( . /etc/os-release && printf '%s' "${VERSION_CODENAME:-jammy}" )
+  write_file /etc/apt/sources.list "deb $APT_MIRROR $codename main restricted universe multiverse
+deb $APT_MIRROR $codename-updates main restricted universe multiverse
+deb $APT_MIRROR $codename-backports main restricted universe multiverse
+deb $APT_MIRROR $codename-security main restricted universe multiverse"
+}
+
+configure_pip() {
+  local pip_conf=/etc/pip.conf
+  write_file "$pip_conf" "[global]
+index-url = $PIP_MIRROR
+trusted-host = pypi.tuna.tsinghua.edu.cn"
+}
+
+configure_apk() {
+  [[ -d /etc/apk ]] || return 0
+  local branch=v3.20
+  [[ -f /etc/alpine-release ]] && branch="v$(cut -d. -f1,2 /etc/alpine-release)"
+  write_file /etc/apk/repositories "$APK_MIRROR/$branch/main
+$APK_MIRROR/$branch/community"
+}
+
+print_entrypoint() {
+  cat <<SNIPPET
+# HomeLab CN package mirror snippet
+export PIP_INDEX_URL="${PIP_MIRROR}"
+export PIP_TRUSTED_HOST="pypi.tuna.tsinghua.edu.cn"
+if command -v sed >/dev/null 2>&1 && [ -f /etc/apt/sources.list ]; then
+  sed -i 's#http://archive.ubuntu.com/ubuntu/#${APT_MIRROR}#g; s#http://security.ubuntu.com/ubuntu/#${APT_MIRROR}#g' /etc/apt/sources.list || true
+fi
+if [ -d /etc/apk ]; then
+  alpine_branch="v\$(cut -d. -f1,2 /etc/alpine-release 2>/dev/null || printf '3.20')"
+  printf '%s/%s/main\n%s/%s/community\n' '${APK_MIRROR}' "\$alpine_branch" '${APK_MIRROR}' "\$alpine_branch" > /etc/apk/repositories || true
+fi
+SNIPPET
+}
+
+case "$MODE" in
+  --host)
+    configure_apt
+    configure_pip
+    configure_apk
+    ;;
+  --print-entrypoint)
+    print_entrypoint
+    ;;
+  --help|-h)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/wait-healthy.sh
+++ b/scripts/wait-healthy.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+STACK=''
+TIMEOUT=300
+INTERVAL=5
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/wait-healthy.sh --stack <name> [--timeout 300]
+
+Waits until all containers in a stack are running and healthy. Exit codes:
+  0  all containers are running and healthy, or running with no healthcheck
+  1  timeout waiting for health
+  2  at least one stack container exited
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack) STACK=${2:-}; shift 2 ;;
+    --timeout) TIMEOUT=${2:-}; shift 2 ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$STACK" ]] || { usage >&2; exit 2; }
+COMPOSE_FILE="$ROOT_DIR/stacks/$STACK/docker-compose.yml"
+[[ -f "$COMPOSE_FILE" ]] || { printf 'Stack not found: %s\n' "$STACK" >&2; exit 2; }
+
+container_ids() {
+  docker compose -f "$COMPOSE_FILE" ps -q
+}
+
+print_unhealthy_logs() {
+  local id name
+  while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    name=$(docker inspect --format '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')
+    printf '\n--- last 50 lines for %s ---\n' "$name" >&2
+    docker logs --tail=50 "$id" >&2 || true
+  done < <(container_ids)
+}
+
+all_ready() {
+  local id state health name ready=0 total=0
+  while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    total=$((total + 1))
+    state=$(docker inspect --format '{{.State.Status}}' "$id")
+    name=$(docker inspect --format '{{.Name}}' "$id" | sed 's#^/##')
+    if [[ "$state" == exited || "$state" == dead ]]; then
+      printf 'Container %s exited with state=%s\n' "$name" "$state" >&2
+      return 2
+    fi
+    health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$id")
+    if [[ "$state" == running && ( "$health" == healthy || "$health" == none ) ]]; then
+      ready=$((ready + 1))
+    else
+      printf 'waiting: %s state=%s health=%s\n' "$name" "$state" "$health"
+    fi
+  done < <(container_ids)
+  [[ "$total" -gt 0 && "$ready" -eq "$total" ]]
+}
+
+end=$((SECONDS + TIMEOUT))
+while [[ "$SECONDS" -lt "$end" ]]; do
+  set +e
+  all_ready
+  code=$?
+  set -e
+  case "$code" in
+    0) printf 'Stack %s is healthy.\n' "$STACK"; exit 0 ;;
+    2) print_unhealthy_logs; exit 2 ;;
+  esac
+  sleep "$INTERVAL"
+done
+
+printf 'Timed out waiting for stack %s after %ss.\n' "$STACK" "$TIMEOUT" >&2
+print_unhealthy_logs
+exit 1


### PR DESCRIPTION
## Summary
- Add CN Docker mirror setup, compose image localization/restore/check, package mirror helpers, connectivity checks, stack health waiting, and diagnostics.
- Harden install.sh with Docker auto-install support, Compose v2 enforcement, resource/firewall/user checks, retry handling, and base-stack health waiting.
- Document robustness and restricted-network workflows in docs/robustness.md.

## Test plan
- [x] bash -n for all shell scripts in the repository
- [x] scripts/setup-cn-mirrors.sh --dry-run --yes emits valid JSON
- [x] scripts/localize-images.sh --dry-run completes and reports replacements
- [x] scripts/localize-images.sh --cn && scripts/localize-images.sh --check && scripts/localize-images.sh --restore succeeds
- [x] scripts/setup-package-mirrors.sh --print-entrypoint emits shell-valid snippet
- [x] git diff --check
- [ ] Run ShellCheck in a local/CI environment with shellcheck installed
- [ ] Run full Docker verification on an Ubuntu 22.04 host with Docker available

Closes #8