### PR TITLE
feat(database): add PostgreSQL + Redis + MariaDB shared database layer

### DIFF
--- a/database/.env.example
+++ b/database/.env.example
@@ -1,0 +1,31 @@
+# ============================================================
+#  Homelab Stack — Database Layer 环境变量模板
+#  复制为 .env 并填写密码后使用
+# ============================================================
+
+# ---- PostgreSQL ----
+PG_USER=homelab
+PG_PASSWORD=your_strong_password_here
+PG_DATABASE=homelab
+PG_PORT=5432
+PG_MEM_LIMIT=512m
+PG_MEM_RESERVE=256m
+
+# ---- Redis ----
+REDIS_PASSWORD=your_strong_redis_password_here
+REDIS_PORT=6379
+REDIS_MAX_MEMORY=256mb
+REDIS_MEM_LIMIT=512m
+REDIS_MEM_RESERVE=128m
+
+# ---- MariaDB ----
+MARIADB_ROOT_PASSWORD=your_strong_root_password_here
+MARIADB_DATABASE=homelab
+MARIADB_USER=homelab
+MARIADB_PASSWORD=your_strong_mariadb_password_here
+MARIADB_PORT=3306
+MARIADB_MEM_LIMIT=512m
+MARIADB_MEM_RESERVE=256m
+
+# ---- Adminer (管理工具, 可选) ----
+ADMINER_PORT=8080

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,153 @@
+# ============================================================
+#  Homelab Stack — Database Layer
+#  PostgreSQL + Redis + MariaDB 共享实例部署说明
+#  赏金任务: https://github.com/illbnm/homelab-stack
+# ============================================================
+
+## 概述
+
+为 Homelab Stack 提供一个可一键部署的数据库层，包含三个数据库服务：
+
+| 服务 | 用途 | 默认端口 |
+|------|------|---------|
+| **PostgreSQL 16** | 关系型数据库主存储 | 5432 |
+| **Redis 7** | 缓存 / 消息队列 / 会话存储 | 6379 |
+| **MariaDB 11** | MySQL兼容层 | 3306 |
+
+## 快速开始
+
+### 前置条件
+
+- Docker 24+
+- Docker Compose v2.20+
+
+### 1. 克隆仓库
+
+```bash
+git clone https://github.com/illbnm/homelab-stack.git
+cd homelab-stack/database
+```
+
+### 2. 配置环境变量
+
+```bash
+cp .env.example .env
+# 编辑 .env，填入安全密码
+vim .env
+```
+
+所有密码**必须修改**，不能使用默认值。
+
+### 3. 启动服务
+
+```bash
+docker compose up -d
+```
+
+### 4. 验证部署
+
+```bash
+chmod +x healthcheck.sh
+./healthcheck.sh
+```
+
+正常输出：
+```
+==========================================
+  Homelab DB Layer — Health Check
+  2026-06-29 18:30:00
+==========================================
+PostgreSQL ... ✅ OK
+Redis ........ ✅ OK
+MariaDB ...... ✅ OK
+==========================================
+✅ 所有数据库服务运行正常
+```
+
+### 5. 连接测试
+
+**PostgreSQL:**
+```bash
+docker exec -it homelab-postgres psql -U homelab -d homelab -c "SELECT version();"
+```
+
+**Redis:**
+```bash
+docker exec -it homelab-redis redis-cli -a "$REDIS_PASSWORD" ping
+```
+
+**MariaDB:**
+```bash
+docker exec -it homelab-mariadb mysql -u homelab -p"$MARIADB_PASSWORD" -e "SHOW DATABASES;"
+```
+
+## 自定义配置
+
+所有配置通过环境变量管理，完整变量列表见 `.env.example`：
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `PG_PORT` | PostgreSQL 端口 | 5432 |
+| `PG_MEM_LIMIT` | PostgreSQL 内存上限 | 512m |
+| `REDIS_PORT` | Redis 端口 | 6379 |
+| `REDIS_MAX_MEMORY` | Redis 最大内存 | 256mb |
+| `MARIADB_PORT` | MariaDB 端口 | 3306 |
+| `MARIADB_MEM_LIMIT` | MariaDB 内存上限 | 512m |
+
+## 初始化脚本
+
+- `init/postgres/` — PostgreSQL 启动时执行的 SQL 脚本
+- `init/mariadb/` — MariaDB 启动时执行的 SQL 脚本
+- `conf/redis/` — Redis 自定义配置
+- `conf/mariadb/` — MariaDB 自定义配置
+
+## 持久化
+
+所有数据存储在 Docker volumes 中：
+- `homelab-pgdata` — PostgreSQL 数据
+- `homelab-redisdata` — Redis 数据 (AOF持久化)
+- `homelab-mariadbdata` — MariaDB 数据
+
+## 管理工具
+
+启动管理工具 Adminer（仅供开发环境）：
+```bash
+docker compose --profile admin up -d adminer
+```
+访问 http://localhost:8080
+
+## 数据备份
+
+```bash
+# 导出 PostgreSQL
+docker exec homelab-postgres pg_dump -U homelab homelab > backup_pg_$(date +%Y%m%d).sql
+
+# 导出 MariaDB
+docker exec homelab-mariadb mysqldump -u homelab -p"$MARIADB_PASSWORD" homelab > backup_mariadb_$(date +%Y%m%d).sql
+
+# 备份 Redis RDB
+docker cp homelab-redis:/data/dump.rdb ./redis_backup_$(date +%Y%m%d).rdb
+```
+
+## 安全注意事项
+
+1. **必须修改所有默认密码**
+2. 生产环境请不要暴露端口到公网
+3. 建议使用 Docker 内部网络而非 host 模式
+4. 定期更新镜像版本
+
+## 目录结构
+
+```
+database/
+├── docker-compose.yml    # 核心编排文件
+├── .env.example          # 环境变量模板
+├── healthcheck.sh        # 健康检查脚本
+├── README.md             # 本文件
+├── init/
+│   ├── postgres/         # PostgreSQL 初始化脚本
+│   └── mariadb/          # MariaDB 初始化脚本
+└── conf/
+    ├── redis/            # Redis 自定义配置
+    └── mariadb/          # MariaDB 自定义配置
+```

--- a/database/conf/mariadb/my.cnf
+++ b/database/conf/mariadb/my.cnf
@@ -1,0 +1,24 @@
+# Homelab Stack — MariaDB 自定义配置
+# 挂载到 /etc/mysql/conf.d/
+
+[mysqld]
+# 字符集
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+# InnoDB 优化
+innodb_buffer_pool_size = 256M
+innodb_log_file_size = 64M
+innodb_flush_method = O_DIRECT
+
+# 连接
+max_connections = 100
+wait_timeout = 600
+
+# 日志
+slow_query_log = 1
+slow_query_log_file = /var/log/mysql/slow.log
+long_query_time = 2
+
+[client]
+default-character-set = utf8mb4

--- a/database/conf/redis/redis.conf
+++ b/database/conf/redis/redis.conf
@@ -1,0 +1,23 @@
+# Homelab Stack — Redis 自定义配置
+# 挂载到 /usr/local/etc/redis/redis.conf
+
+# 持久化
+save 900 1
+save 300 10
+save 60 10000
+
+# 内存管理
+maxmemory 256mb
+maxmemory-policy allkeys-lru
+
+# 安全
+rename-command FLUSHALL ""
+rename-command FLUSHDB ""
+rename-command DEBUG ""
+
+# 连接
+timeout 300
+tcp-keepalive 60
+
+# 日志
+loglevel notice

--- a/database/docker-compose.yml
+++ b/database/docker-compose.yml
@@ -1,0 +1,143 @@
+version: '3.8'
+
+# ============================================================
+#  Homelab Stack — Database Layer
+#  PostgreSQL + Redis + MariaDB 共享实例
+#  赏金任务: https://github.com/illbnm/homelab-stack
+#  赏金: $130 USD
+# ============================================================
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+services:
+  # ----------------------------------------------------------
+  # PostgreSQL — 关系型数据库主存储
+  # ----------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    container_name: homelab-postgres
+    restart: unless-stopped
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./init/postgres:/docker-entrypoint-initdb.d:ro
+    environment:
+      POSTGRES_USER: ${PG_USER:-homelab}
+      POSTGRES_PASSWORD: ${PG_PASSWORD:?请设置 PG_PASSWORD 环境变量}
+      POSTGRES_DB: ${PG_DATABASE:-homelab}
+    ports:
+      - "${PG_PORT:-5432}:5432"
+    networks:
+      - db-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PG_USER:-homelab} -d ${PG_DATABASE:-homelab}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: ${PG_MEM_LIMIT:-512m}
+        reservations:
+          memory: ${PG_MEM_RESERVE:-256m}
+
+  # ----------------------------------------------------------
+  # Redis — 缓存/消息队列/会话存储
+  # ----------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    container_name: homelab-redis
+    restart: unless-stopped
+    command: >
+      redis-server
+      --requirepass ${REDIS_PASSWORD:?请设置 REDIS_PASSWORD 环境变量}
+      --appendonly yes
+      --maxmemory ${REDIS_MAX_MEMORY:-256mb}
+      --maxmemory-policy allkeys-lru
+    volumes:
+      - redisdata:/data
+      - ./conf/redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    networks:
+      - db-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: ${REDIS_MEM_LIMIT:-512m}
+        reservations:
+          memory: ${REDIS_MEM_RESERVE:-128m}
+
+  # ----------------------------------------------------------
+  # MariaDB — MySQL兼容层
+  # ----------------------------------------------------------
+  mariadb:
+    image: mariadb:11
+    container_name: homelab-mariadb
+    restart: unless-stopped
+    volumes:
+      - mariadbdata:/var/lib/mysql
+      - ./init/mariadb:/docker-entrypoint-initdb.d:ro
+      - ./conf/mariadb:/etc/mysql/conf.d:ro
+    environment:
+      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD:?请设置 MARIADB_ROOT_PASSWORD 环境变量}
+      MARIADB_DATABASE: ${MARIADB_DATABASE:-homelab}
+      MARIADB_USER: ${MARIADB_USER:-homelab}
+      MARIADB_PASSWORD: ${MARIADB_PASSWORD:?请设置 MARIADB_PASSWORD 环境变量}
+    ports:
+      - "${MARIADB_PORT:-3306}:3306"
+    networks:
+      - db-network
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          memory: ${MARIADB_MEM_LIMIT:-512m}
+        reservations:
+          memory: ${MARIADB_MEM_RESERVE:-256m}
+
+  # ----------------------------------------------------------
+  # 数据库管理工具（可选，仅供开发/管理用）
+  # ----------------------------------------------------------
+  adminer:
+    image: adminer:latest
+    container_name: homelab-adminer
+    restart: unless-stopped
+    ports:
+      - "${ADMINER_PORT:-8080}:8080"
+    networks:
+      - db-network
+    profiles:
+      - admin
+    logging: *default-logging
+
+volumes:
+  pgdata:
+    name: homelab-pgdata
+  redisdata:
+    name: homelab-redisdata
+  mariadbdata:
+    name: homelab-mariadbdata
+
+networks:
+  db-network:
+    name: homelab-db-network
+    driver: bridge

--- a/database/healthcheck.sh
+++ b/database/healthcheck.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# ============================================================
+#  Homelab Stack — 数据库层健康检查脚本
+#  验证三个数据库服务是否正常运行
+# ============================================================
+
+set -e
+
+source .env 2>/dev/null || true
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo "=========================================="
+echo "  Homelab DB Layer — Health Check"
+echo "  $(date '+%Y-%m-%d %H:%M:%S')"
+echo "=========================================="
+
+# PostgreSQL 检查
+echo -n "PostgreSQL ... "
+if docker exec homelab-postgres pg_isready -U ${PG_USER:-homelab} >/dev/null 2>&1; then
+    echo -e "${GREEN}✅ OK${NC}"
+else
+    echo -e "${RED}❌ FAILED${NC}"
+    FAIL=1
+fi
+
+# Redis 检查
+echo -n "Redis ........ "
+if docker exec homelab-redis redis-cli --raw incr ping >/dev/null 2>&1; then
+    echo -e "${GREEN}✅ OK${NC}"
+else
+    echo -e "${RED}❌ FAILED${NC}"
+    FAIL=1
+fi
+
+# MariaDB 检查
+echo -n "MariaDB ...... "
+if docker exec homelab-mariadb mysqladmin ping -u root -p${MARIADB_ROOT_PASSWORD} >/dev/null 2>&1; then
+    echo -e "${GREEN}✅ OK${NC}"
+else
+    echo -e "${RED}❌ FAILED${NC}"
+    FAIL=1
+fi
+
+echo "=========================================="
+
+if [ -n "$FAIL" ]; then
+    echo -e "${RED}❌ 部分服务异常，请检查日志${NC}"
+    exit 1
+else
+    echo -e "${GREEN}✅ 所有数据库服务运行正常${NC}"
+    exit 0
+fi

--- a/database/init/mariadb/01-init.sql
+++ b/database/init/mariadb/01-init.sql
@@ -1,0 +1,4 @@
+-- Homelab Stack — MariaDB 初始化脚本
+-- 在数据库首次启动时自动执行
+
+CREATE DATABASE IF NOT EXISTS homelab CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/database/init/postgres/01-init.sql
+++ b/database/init/postgres/01-init.sql
@@ -1,0 +1,10 @@
+-- Homelab Stack — PostgreSQL 初始化脚本
+-- 在数据库首次启动时自动执行
+
+-- 创建扩展
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
+
+-- 创建应用表空间
+-- (按需启用)
+-- CREATE TABLESPACE homelab_ts LOCATION '/var/lib/postgresql/data/homelab_ts';


### PR DESCRIPTION
## 📦 Database Layer — PostgreSQL + Redis + MariaDB

One-click deployable database layer for Homelab Stack.

| File | Purpose |
|------|---------|
| `docker-compose.yml` | Core orchestration with resource limits & healthchecks |
| `.env.example` | Environment variable template |
| `healthcheck.sh` | One-command health check |
| `README.md` | Full deployment guide |
| `init/postgres/01-init.sql` | PostgreSQL init (uuid-ossp, pg_stat_statements) |
| `init/mariadb/01-init.sql` | MariaDB init (utf8mb4) |
| `conf/redis/redis.conf` | Redis custom config (persistence, security) |
| `conf/mariadb/my.cnf` | MariaDB custom config (InnoDB tuning) |

### Quick Start

```bash
cd database
cp .env.example .env
docker compose up -d
chmod +x healthcheck.sh && ./healthcheck.sh
```

Closes Database Layer Bounty ($130 USD)