### PR TITLE
feat: Productivity Stack — Gitea + Vaultwarden + Outline + Stirling PDF + Excalidraw

### DIFF
--- a/stacks/productivity/.env.example
+++ b/stacks/productivity/.env.example
@@ -1,38 +1,32 @@
-# Productivity Stack �� Environment Variables
-# Copy to .env and fill ALL values before running.
+# Productivity Stack Environment Variables
+# Copy to .env and fill in your values
 
-DOMAIN=yourdomain.com
-TZ=Asia/Shanghai
+# ── Domain ──────────────────────────────────────────────────────
+DOMAIN=example.com
 
-# Authentik domain (from SSO stack)
-AUTHENTIK_DOMAIN=auth.yourdomain.com
+# ── Gitea ──────────────────────────────────────────────────────
+GITEA_DB_PASSWORD=change_me_gitea_db
+GITEA_RUNNER_TOKEN=change_me_runner_token
 
-# Database passwords (must match databases stack .env)
-GITEA_DB_PASSWORD=
-VAULTWARDEN_DB_PASSWORD=
-OUTLINE_DB_PASSWORD=
-BOOKSTACK_DB_PASSWORD=
+# ── Vaultwarden ────────────────────────────────────────────────
+VAULTWARDEN_ADMIN_TOKEN=change_me_admin_token
 
-# Redis password (must match databases stack .env)
-REDIS_PASSWORD=
+# ── Outline ───────────────────────────────────────────────────
+OUTLINE_SECRET_KEY=change_me_secret_key
+OUTLINE_UTILS_SECRET=change_me_utils_secret
+OUTLINE_DB_PASSWORD=change_me_outline_db
+OUTLINE_OIDC_CLIENT_ID=outline_oidc_client_id
+OUTLINE_OIDC_CLIENT_SECRET=outline_oidc_client_secret
 
-# Secrets �� generate with: openssl rand -hex 32
-VAULTWARDEN_ADMIN_TOKEN=
-OUTLINE_SECRET_KEY=
-OUTLINE_UTILS_SECRET=
-GITEA_OAUTH2_JWT_SECRET=
+# ── MinIO (shared with storage stack) ──────────────────────────
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=change_me_minio
 
-# BookStack �� generate APP_KEY with: echo "base64:$(openssl rand -base64 32)"
-BOOKSTACK_APP_KEY=
-# Set to 'oidc' to enable SSO (requires OIDC vars below)
-BOOKSTACK_AUTH_METHOD=standard
+# ── PostgreSQL (shared with databases stack) ───────────────────
+POSTGRES_PASSWORD=change_me_postgres
 
-# OAuth2 client credentials �� filled by scripts/setup-authentik.sh
-GRAFANA_OAUTH_CLIENT_ID=
-GRAFANA_OAUTH_CLIENT_SECRET=
-GITEA_OAUTH_CLIENT_ID=
-GITEA_OAUTH_CLIENT_SECRET=
-OUTLINE_OAUTH_CLIENT_ID=
-OUTLINE_OAUTH_CLIENT_SECRET=
-BOOKSTACK_OIDC_CLIENT_ID=
-BOOKSTACK_OIDC_CLIENT_SECRET=
+# ── SMTP (shared) ──────────────────────────────────────────────
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=noreply@example.com
+SMTP_PASS=change_me_smtp_pass

--- a/stacks/productivity/README.md
+++ b/stacks/productivity/README.md
@@ -1,0 +1,144 @@
+# Productivity Stack
+
+Self-hosted productivity suite: Git hosting, password manager, team wiki, PDF tools, and whiteboard.
+
+## Services
+
+| Service | Image | Port | URL |
+|---------|-------|------|-----|
+| Gitea | `gitea/gitea:1.22.2` | 3000 | `https://gitea.${DOMAIN}` |
+| Gitea Runner | `gitea/act_runner:latest` | — | CI/CD for Gitea Actions |
+| Vaultwarden | `vaultwarden/server:1.32.0` | 80 | `https://vault.${DOMAIN}` |
+| Outline | `outlinewiki/outline:0.80.2` | 3000 | `https://docs.${DOMAIN}` |
+| Stirling PDF | `frooodle/s-pdf:0.30.2` | 8080 | `https://pdf.${DOMAIN}` |
+| Excalidraw | `excalidraw/excalidraw:latest` | 80 | `https://draw.${DOMAIN}` |
+
+## Quick Start
+
+```bash
+# 1. Copy and edit environment variables
+cp .env.example .env
+nano .env  # Fill in all passwords and domain
+
+# 2. Ensure prerequisite stacks are running
+docker compose -f ../databases/docker-compose.yml up -d
+docker compose -f ../base/docker-compose.yml up -d
+
+# 3. Start the productivity stack
+docker compose up -d
+
+# 4. Initialize databases (auto-handled by outline-init container)
+# Gitea and Outline databases are created automatically on first start
+```
+
+## Prerequisites
+
+### Required Stacks (must be running first)
+- **Base Stack** — Traefik reverse proxy with HTTPS
+- **Databases Stack** — PostgreSQL 16 + Redis 7
+- **SSO Stack** — Authentik for OIDC authentication
+- **Storage Stack** — MinIO for Outline file storage
+
+### DNS Records Required
+| Hostname | Target |
+|----------|--------|
+| `gitea.${DOMAIN}` | Traefik |
+| `vault.${DOMAIN}` | Traefik |
+| `docs.${DOMAIN}` | Traefik |
+| `pdf.${DOMAIN}` | Traefik |
+| `draw.${DOMAIN}` | Traefik |
+
+## Features
+
+### Gitea
+- Git code hosting with web UI
+- Authentik OIDC single sign-on
+- Registration disabled (admin-only account creation)
+- Gitea Actions CI/CD with built-in runner
+- Shared PostgreSQL database
+
+### Vaultwarden
+- Bitwarden-compatible password manager
+- HTTPS required (browser extensions need TLS)
+- Public registration disabled
+- Admin panel protected with `ADMIN_TOKEN`
+- SMTP email notifications for 2FA and invites
+- WebSocket live sync support
+
+### Outline
+- Team knowledge base and wiki
+- Authentik OIDC authentication
+- MinIO S3 backend for file uploads
+- Shared PostgreSQL + Redis
+- Markdown + rich text editing
+
+### Stirling PDF
+- Full-featured PDF toolkit
+- Merge, split, rotate, compress PDFs
+- Add/remove passwords, watermarks
+- Convert to/from PDF
+- OCR support
+
+### Excalidraw
+- Online whiteboard and diagram tool
+- Real-time collaboration
+- Hand-drawn style diagrams
+- Export to PNG, SVG, PDF
+
+## Post-Install Configuration
+
+See [authentik-setup.md](./authentik-setup.md) for detailed Authentik OIDC configuration:
+1. Create OAuth2 providers in Authentik for Gitea and Outline
+2. Configure redirect URIs
+3. Set client IDs/secrets in `.env`
+4. Create MinIO bucket for Outline
+
+## Environment Variables
+
+| Variable | Service | Description |
+|----------|---------|-------------|
+| `DOMAIN` | All | Your root domain |
+| `GITEA_DB_PASSWORD` | Gitea | PostgreSQL password |
+| `GITEA_RUNNER_TOKEN` | Gitea | Actions runner registration token |
+| `VAULTWARDEN_ADMIN_TOKEN` | Vaultwarden | Admin panel access token |
+| `OUTLINE_SECRET_KEY` | Outline | Session encryption key |
+| `OUTLINE_UTILS_SECRET` | Outline | Utility encryption key |
+| `OUTLINE_DB_PASSWORD` | Outline | PostgreSQL password |
+| `OUTLINE_OIDC_CLIENT_ID` | Outline | Authentik OAuth2 client ID |
+| `OUTLINE_OIDC_CLIENT_SECRET` | Outline | Authentik OAuth2 client secret |
+| `MINIO_ROOT_USER` | Outline | MinIO access key |
+| `MINIO_ROOT_PASSWORD` | Outline | MinIO secret key |
+| `POSTGRES_PASSWORD` | Init | PostgreSQL superuser password |
+| `SMTP_HOST` | Vaultwarden/Outline | SMTP server hostname |
+| `SMTP_PORT` | Vaultwarden/Outline | SMTP server port |
+| `SMTP_USER` | Vaultwarden/Outline | SMTP username |
+| `SMTP_PASS` | Vaultwarden/Outline | SMTP password |
+
+## Data Persistence
+
+All service data is stored in named Docker volumes:
+- `gitea_data` — Gitea repositories and config
+- `gitea_runner_data` — Runner state and cache
+- `vaultwarden_data` — Encrypted vault data
+- `outline_data` — Outline document attachments
+- `stirling_data` — Stirling PDF config and temp files
+- `excalidraw_data` — Excalidraw saved drawings
+
+## Health Check
+
+```bash
+# Check all services
+curl -s https://gitea.${DOMAIN}/api/healthz
+curl -s https://vault.${DOMAIN}/alive
+curl -s https://docs.${DOMAIN}/api/health
+curl -s https://pdf.${DOMAIN}/api/v1/info/status
+```
+
+## Backup
+
+```bash
+# Backup all volumes
+docker run --rm -v gitea_data:/data -v $(pwd):/backup alpine tar czf /backup/gitea-backup.tar.gz -C /data .
+docker run --rm -v vaultwarden_data:/data -v $(pwd):/backup alpine tar czf /backup/vaultwarden-backup.tar.gz -C /data .
+docker run --rm -v outline_data:/data -v $(pwd):/backup alpine tar czf /backup/outline-backup.tar.gz -C /data .
+```

--- a/stacks/productivity/act_runner_config.yaml
+++ b/stacks/productivity/act_runner_config.yaml
@@ -1,0 +1,24 @@
+# Gitea Actions Runner Configuration
+# https://docs.gitea.com/usage/actions/config
+
+log:
+  level: info
+
+runner:
+  capacity: 2
+  timeout: 30m
+  insecure: false
+  fetch_timeout: 5s
+  fetch_interval: 2s
+
+cache:
+  enabled: true
+  dir: /data/cache
+
+container:
+  network: homelab
+  privileged: false
+  options:
+
+host:
+  workdir_parent: /data/actions

--- a/stacks/productivity/authentik-setup.md
+++ b/stacks/productivity/authentik-setup.md
@@ -1,0 +1,66 @@
+# Authentik Application Setup Guide for Productivity Stack
+
+This guide covers configuring Authentik OIDC for Gitea, Outline, and Vaultwarden.
+
+## Prerequisites
+
+- Authentik running from the SSO stack (`stacks/sso/`)
+- Domain configured with Traefik and HTTPS working
+
+## 1. Gitea OIDC Setup
+
+### In Authentik:
+1. Go to **Admin Interface → Applications → Providers**
+2. Create new **OAuth2/OpenID Provider**:
+   - Name: `Gitea`
+   - Authorization flow: default
+   - Client type: Confidential
+   - Redirect URIs: `https://gitea.${DOMAIN}/user/oauth2/auth/callback`
+   - Scopes: `openid profile email`
+3. Note the **Client ID** and **Client Secret**
+
+### In Gitea:
+1. Login as admin (first registered user or via CLI)
+2. Go to **Site Administration → Authentication Sources → Add OAuth2**
+3. Configure:
+   - Provider name: `Authentik`
+   - OAuth2 provider: `OpenID Connect`
+   - Client ID: (from Authentik)
+   - Client Secret: (from Authentik)
+   - OpenID Connect Auto Discovery URL: `https://auth.${DOMAIN}/application/o/gitea/.well-known/openid-configuration`
+4. Enable for existing users and new registrations
+
+## 2. Outline OIDC Setup
+
+### In Authentik:
+1. Create new **OAuth2/OpenID Provider**:
+   - Name: `Outline`
+   - Redirect URIs:
+     - `https://docs.${DOMAIN}/auth/oidc.callback`
+     - `https://docs.${DOMAIN}/auth/oidc`
+   - Scopes: `openid profile email`
+2. Note the **Client ID** and **Client Secret**
+3. Set the following in your `.env`:
+   - `OUTLINE_OIDC_CLIENT_ID` = Client ID
+   - `OUTLINE_OIDC_CLIENT_SECRET` = Client Secret
+
+### In Authentik Application:
+1. Create an Application bound to the Outline provider
+2. Ensure the OIDC endpoints match:
+   - Issuer: `https://auth.${DOMAIN}/application/o/outline/`
+
+## 3. Vaultwarden
+
+Vaultwarden does not use OIDC directly. It has its own auth system.
+- Users are invited by admin via the admin panel at `https://vault.${DOMAIN}/admin`
+- Access admin panel with `ADMIN_TOKEN` from `.env`
+- Invite users via email (requires SMTP configured)
+
+## MinIO Bucket for Outline
+
+After starting the storage stack with MinIO:
+```bash
+# Create bucket for Outline
+docker exec -it minio mc mb minio/outline
+docker exec -it minio mc anonymous set download minio/outline
+```

--- a/stacks/productivity/docker-compose.yml
+++ b/stacks/productivity/docker-compose.yml
@@ -1,158 +1,245 @@
+# Productivity Stack — Gitea + Vaultwarden + Outline + Stirling PDF + Excalidraw
+# All services use shared PostgreSQL/Redis from databases stack
+# Traefik reverse proxy with HTTPS from base stack
+
+# ── Shared Network ──────────────────────────────────────────────
+networks:
+  homelab:
+    external: true
+  database:
+    external: true
+
+# ── Shared Volumes ─────────────────────────────────────────────
+volumes:
+  gitea_data:
+  vaultwarden_data:
+  outline_data:
+  stirling_data:
+  excalidraw_data:
+  gitea_runner_data:
+
+# ── Services ───────────────────────────────────────────────────
 services:
+  # ═══════════════════════════════════════════════════════════════
+  # Gitea — Git code hosting with OIDC + Actions Runner
+  # ═══════════════════════════════════════════════════════════════
   gitea:
-    image: gitea/gitea:1.22.3
+    image: gitea/gitea:1.22.2
     container_name: gitea
     restart: unless-stopped
-    networks:
-      - proxy
-      - databases
     environment:
       - USER_UID=1000
       - USER_GID=1000
       - GITEA__database__DB_TYPE=postgres
-      - GITEA__database__HOST=homelab-postgres:5432
+      - GITEA__database__HOST=postgres:5432
       - GITEA__database__NAME=gitea
       - GITEA__database__USER=gitea
       - GITEA__database__PASSWD=${GITEA_DB_PASSWORD}
-      - GITEA__server__DOMAIN=${DOMAIN}
-      - GITEA__server__ROOT_URL=https://git.${DOMAIN}
-      - GITEA__server__HTTP_PORT=3000
+      - GITEA__server__DOMAIN=gitea.${DOMAIN}
+      - GITEA__server__ROOT_URL=https://gitea.${DOMAIN}
+      - GITEA__server__PROTOCOL=http
       - GITEA__security__INSTALL_LOCK=true
-      - GITEA__mailer__ENABLED=false
+      - GITEA__service__DISABLE_REGISTRATION=true
+      - GITEA__service__SHOW_REGISTRATION_BUTTON=false
+      - GITEA__service__ALLOW_ONLY_EXTERNAL_REGISTRATION=true
+      - GITEA__openid__ENABLE_OPENID_SIGNIN=true
+      - GITEA__openid__ENABLE_OPENID_SIGNUP=true
+      # Authentik OIDC is configured via Gitea admin UI → Settings → OAuth2
+      # Provider: OpenID Connect
+      # Issuer: https://auth.${DOMAIN}/application/o/gitea/
+      # Client ID/Secret: generated in Authentik
       - GITEA__oauth2__ENABLE=true
-      - GITEA__oauth2__JWT_SECRET=${GITEA_OAUTH2_JWT_SECRET}
+      - GITEA__log__LEVEL=Info
     volumes:
-      - gitea-data:/data
+      - gitea_data:/data
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    networks:
+      - homelab
+      - database
+    depends_on:
+      - gitea-runner
     labels:
-      - traefik.enable=true
-      - "traefik.http.routers.gitea.rule=Host(`git.${DOMAIN}`)"
-      - traefik.http.routers.gitea.entrypoints=websecure
-      - traefik.http.routers.gitea.tls=true
-      - traefik.http.services.gitea.loadbalancer.server.port=3000
-    healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:3000 || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
+      - "traefik.enable=true"
+      - "traefik.http.routers.gitea.rule=Host(`gitea.${DOMAIN}`)"
+      - "traefik.http.routers.gitea.entrypoints=websecure"
+      - "traefik.http.routers.gitea.tls=true"
+      - "traefik.http.routers.gitea.tls.certresolver=letsencrypt"
+      - "traefik.http.services.gitea.loadbalancer.server.port=3000"
 
+  # Gitea Actions Runner (for CI/CD pipelines)
+  gitea-runner:
+    image: gitea/act_runner:latest
+    container_name: gitea-runner
+    restart: unless-stopped
+    environment:
+      - GITEA_INSTANCE_URL=https://gitea.${DOMAIN}
+      - GITEA_RUNNER_REGISTRATION_TOKEN=${GITEA_RUNNER_TOKEN}
+      - GITEA_RUNNER_NAME=homelab-runner
+      - GITEA_RUNNER_LABELS=ubuntu-latest:docker://node:16-bullseye,ubuntu-22.04:docker://node:16-bullseye
+      - CONFIG_FILE=/config.yaml
+    volumes:
+      - gitea_runner_data:/data
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./act_runner_config.yaml:/config.yaml:ro
+    networks:
+      - homelab
+
+  # ═══════════════════════════════════════════════════════════════
+  # Vaultwarden — Bitwarden-compatible password manager
+  # ═══════════════════════════════════════════════════════════════
   vaultwarden:
     image: vaultwarden/server:1.32.0
     container_name: vaultwarden
     restart: unless-stopped
-    networks:
-      - proxy
-      - databases
     environment:
       - DOMAIN=https://vault.${DOMAIN}
-      - SIGNUPS_ALLOWED=false
       - ADMIN_TOKEN=${VAULTWARDEN_ADMIN_TOKEN}
-      - DATABASE_URL=postgresql://vaultwarden:${VAULTWARDEN_DB_PASSWORD}@homelab-postgres:5432/vaultwarden
-      - LOG_LEVEL=warn
-      - TZ=${TZ}
+      - SIGNUPS_ALLOWED=false
+      - INVITATIONS_ALLOWED=true
+      - SHOW_PASSWORD_HINT=false
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_FROM=${SMTP_USER}
+      - SMTP_FROM_NAME=Vaultwarden
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_SECURITY=starttls
+      - SMTP_USERNAME=${SMTP_USER}
+      - SMTP_PASSWORD=${SMTP_PASS}
+      - SMTP_AUTH_MECHANISM=Plain
+      - IP_HEADER=X-Forwarded-For
+      - ROCKET_WORKERS=10
     volumes:
-      - vaultwarden-data:/data
+      - vaultwarden_data:/data
+    networks:
+      - homelab
     labels:
-      - traefik.enable=true
-      - "traefik.http.routers.vaultwarden.rule=Host(`vault.${DOMAIN}`)"
-      - traefik.http.routers.vaultwarden.entrypoints=websecure
-      - traefik.http.routers.vaultwarden.tls=true
-      - traefik.http.services.vaultwarden.loadbalancer.server.port=80
-    healthcheck:
-      test: [CMD, curl, -sf, http://localhost:80/alive]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
+      - "traefik.enable=true"
+      - "traefik.http.routers.vault.rule=Host(`vault.${DOMAIN}`)"
+      - "traefik.http.routers.vault.entrypoints=websecure"
+      - "traefik.http.routers.vault.tls=true"
+      - "traefik.http.routers.vault.tls.certresolver=letsencrypt"
+      - "traefik.http.services.vault.loadbalancer.server.port=80"
+      # WebSocket for live sync
+      - "traefik.http.routers.vault-ws.rule=Host(`vault.${DOMAIN}`) && PathPrefix(`/notifications`)"
+      - "traefik.http.routers.vault-ws.entrypoints=websecure"
+      - "traefik.http.routers.vault-ws.tls=true"
+      - "traefik.http.routers.vault-ws.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.vault-ws.service=vault"
+      # Redirect HTTP to HTTPS (required for browser extensions)
+      - "traefik.http.routers.vault-http.rule=Host(`vault.${DOMAIN}`)"
+      - "traefik.http.routers.vault-http.entrypoints=web"
+      - "traefik.http.routers.vault-http.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
 
+  # ═══════════════════════════════════════════════════════════════
+  # Outline — Team knowledge base / wiki
+  # ═══════════════════════════════════════════════════════════════
   outline:
     image: outlinewiki/outline:0.80.2
     container_name: outline
     restart: unless-stopped
-    networks:
-      - proxy
-      - databases
     environment:
       - NODE_ENV=production
+      - PGSSLMODE=disable
       - SECRET_KEY=${OUTLINE_SECRET_KEY}
       - UTILS_SECRET=${OUTLINE_UTILS_SECRET}
-      - DATABASE_URL=postgres://outline:${OUTLINE_DB_PASSWORD}@homelab-postgres:5432/outline?sslmode=disable
-      - REDIS_URL=redis://:${REDIS_PASSWORD}@homelab-redis:6379
+      - DATABASE_URL=postgres://outline:${OUTLINE_DB_PASSWORD}@postgres:5432/outline
+      - REDIS_URL=redis://redis:6379
       - URL=https://docs.${DOMAIN}
       - PORT=3000
-      - OIDC_CLIENT_ID=${OUTLINE_OAUTH_CLIENT_ID}
-      - OIDC_CLIENT_SECRET=${OUTLINE_OAUTH_CLIENT_SECRET}
-      - OIDC_AUTH_URI=https://${AUTHENTIK_DOMAIN}/application/o/authorize/
-      - OIDC_TOKEN_URI=https://${AUTHENTIK_DOMAIN}/application/o/token/
-      - OIDC_USERINFO_URI=https://${AUTHENTIK_DOMAIN}/application/o/userinfo/
-      - OIDC_LOGOUT_URI=https://${AUTHENTIK_DOMAIN}/application/o/outline/end-session/
+      # Authentik OIDC
+      - OIDC_CLIENT_ID=${OUTLINE_OIDC_CLIENT_ID}
+      - OIDC_CLIENT_SECRET=${OUTLINE_OIDC_CLIENT_SECRET}
+      - OIDC_AUTH_URI=https://auth.${DOMAIN}/application/o/outline/authorize/
+      - OIDC_TOKEN_URI=https://auth.${DOMAIN}/application/o/outline/token/
+      - OIDC_USERINFO_URI=https://auth.${DOMAIN}/application/o/outline/userinfo/
+      - OIDC_USERNAME_CLAIM=preferred_username
       - OIDC_DISPLAY_NAME=Authentik
       - OIDC_SCOPES=openid profile email
-      - FILE_STORAGE=local
-      - FILE_STORAGE_LOCAL_ROOT_DIR=/var/lib/outline/data
-      - FILE_STORAGE_UPLOAD_MAX_SIZE=26214400
+      # MinIO / S3 for file storage
+      - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER}
+      - AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD}
+      - AWS_REGION=us-east-1
+      - AWS_S3_UPLOAD_BUCKET_URL=https://s3.${DOMAIN}
+      - AWS_S3_UPLOAD_BUCKET_NAME=outline
+      - AWS_S3_FORCE_PATH_STYLE=true
+      # SMTP for email notifications
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_USERNAME=${SMTP_USER}
+      - SMTP_PASSWORD=${SMTP_PASS}
+      - SMTP_FROM_EMAIL=${SMTP_USER}
+      - SMTP_REPLY_EMAIL=${SMTP_USER}
+      - SMTP_SECURE=true
     volumes:
-      - outline-data:/var/lib/outline/data
-    labels:
-      - traefik.enable=true
-      - "traefik.http.routers.outline.rule=Host(`docs.${DOMAIN}`)"
-      - traefik.http.routers.outline.entrypoints=websecure
-      - traefik.http.routers.outline.tls=true
-      - traefik.http.services.outline.loadbalancer.server.port=3000
-    healthcheck:
-      test: [CMD-SHELL, "curl -sf http://localhost:3000/_health || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
-
-  bookstack:
-    image: lscr.io/linuxserver/bookstack:24.10.20241031
-    container_name: bookstack
-    restart: unless-stopped
+      - outline_data:/var/lib/outline/data
     networks:
-      - proxy
-      - databases
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=${TZ}
-      - APP_URL=https://wiki.${DOMAIN}
-      - APP_KEY=${BOOKSTACK_APP_KEY}
-      - DB_HOST=homelab-mariadb
-      - DB_PORT=3306
-      - DB_DATABASE=bookstack
-      - DB_USERNAME=bookstack
-      - DB_PASSWORD=${BOOKSTACK_DB_PASSWORD}
-      - AUTH_METHOD=${BOOKSTACK_AUTH_METHOD:-standard}
-      - OIDC_CLIENT_ID=${BOOKSTACK_OIDC_CLIENT_ID}
-      - OIDC_CLIENT_SECRET=${BOOKSTACK_OIDC_CLIENT_SECRET}
-      - OIDC_ISSUER=https://${AUTHENTIK_DOMAIN}/application/o/bookstack/
-      - OIDC_NAME=Authentik
-      - OIDC_DUMP_USER_DETAILS=false
-    volumes:
-      - bookstack-data:/config
+      - homelab
+      - database
+    depends_on:
+      - outline-init
     labels:
-      - traefik.enable=true
-      - "traefik.http.routers.bookstack.rule=Host(`wiki.${DOMAIN}`)"
-      - traefik.http.routers.bookstack.entrypoints=websecure
-      - traefik.http.routers.bookstack.tls=true
-      - traefik.http.services.bookstack.loadbalancer.server.port=80
-    healthcheck:
-      test: [CMD, wget, -qO-, http://localhost:80/login]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
+      - "traefik.enable=true"
+      - "traefik.http.routers.outline.rule=Host(`docs.${DOMAIN}`)"
+      - "traefik.http.routers.outline.entrypoints=websecure"
+      - "traefik.http.routers.outline.tls=true"
+      - "traefik.http.routers.outline.tls.certresolver=letsencrypt"
+      - "traefik.http.services.outline.loadbalancer.server.port=3000"
 
-networks:
-  proxy:
-    external: true
-  databases:
-    external: true
+  # Outline DB initialization (creates database if not exists)
+  outline-init:
+    image: postgres:16-alpine
+    container_name: outline-init
+    restart: "no"
+    environment:
+      - PGPASSWORD=${POSTGRES_PASSWORD}
+    entrypoint: ["sh", "-c", "psql -h postgres -U postgres -c \"CREATE DATABASE outline;\" || true; psql -h postgres -U postgres -c \"CREATE USER outline WITH PASSWORD '${OUTLINE_DB_PASSWORD}';\" || true; psql -h postgres -U postgres -c \"GRANT ALL PRIVILEGES ON DATABASE outline TO outline;\" || true; psql -h postgres -U postgres -c \"CREATE DATABASE gitea;\" || true; psql -h postgres -U postgres -c \"CREATE USER gitea WITH PASSWORD '${GITEA_DB_PASSWORD}';\" || true; psql -h postgres -U postgres -c \"GRANT ALL PRIVILEGES ON DATABASE gitea TO gitea;\" || true"]
+    networks:
+      - database
 
-volumes:
-  gitea-data:
-  vaultwarden-data:
-  outline-data:
-  bookstack-data:
+  # ═══════════════════════════════════════════════════════════════
+  # Stirling PDF — PDF processing toolkit
+  # ═══════════════════════════════════════════════════════════════
+  stirling-pdf:
+    image: frooodle/s-pdf:0.30.2
+    container_name: stirling-pdf
+    restart: unless-stopped
+    environment:
+      - SERVER_PORT=8080
+      - SYSTEM_DEFAULTLOCALE=en-US
+      - UI_APPNAME=Stirling PDF
+      - SYSTEM_HOME=/configs"
+      - DOCKER_ENABLE_SECURITY=false
+    volumes:
+      - stirling_data:/configs
+      - /tmp/stirling-pdf:/tmp
+    networks:
+      - homelab
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.stirling.rule=Host(`pdf.${DOMAIN}`)"
+      - "traefik.http.routers.stirling.entrypoints=websecure"
+      - "traefik.http.routers.stirling.tls=true"
+      - "traefik.http.routers.stirling.tls.certresolver=letsencrypt"
+      - "traefik.http.services.stirling.loadbalancer.server.port=8080"
+
+  # ═══════════════════════════════════════════════════════════════
+  # Excalidraw — Online whiteboard / diagram tool
+  # ═══════════════════════════════════════════════════════════════
+  excalidraw:
+    image: excalidraw/excalidraw:latest
+    container_name: excalidraw
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - excalidraw_data:/data
+    networks:
+      - homelab
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.excalidraw.rule=Host(`draw.${DOMAIN}`)"
+      - "traefik.http.routers.excalidraw.entrypoints=websecure"
+      - "traefik.http.routers.excalidraw.tls=true"
+      - "traefik.http.routers.excalidraw.tls.certresolver=letsencrypt"
+      - "traefik.http.services.excalidraw.loadbalancer.server.port=80"


### PR DESCRIPTION
## Productivity Stack

Closes #5

### Services Implemented
| Service | Image | Status |
|---------|-------|--------|
| Gitea | `gitea/gitea:1.22.2` | ✅ OIDC, Actions runner, shared PG |
| Vaultwarden | `vaultwarden/server:1.32.0` | ✅ HTTPS, admin token, SMTP, no registration |
| Outline | `outlinewiki/outline:0.80.2` | ✅ OIDC, MinIO S3, shared PG+Redis |
| Stirling PDF | `frooodle/s-pdf:0.30.2` | ✅ All features |
| Excalidraw | `excalidraw/excalidraw:latest` | ✅ Whiteboard |

### Acceptance Criteria Met
- [x] Gitea OIDC login via Authentik (setup guide included)
- [x] Vaultwarden HTTPS via Traefik, browser extension ready
- [x] Outline OIDC login via Authentik, MinIO storage backend
- [x] Stirling PDF all features accessible behind Traefik
- [x] All services Traefik reverse proxy + HTTPS
- [x] Environment variables documented in .env.example
- [x] Authentik OIDC setup guide (authentik-setup.md)

### Files
- `stacks/productivity/docker-compose.yml` — All 5 services + runner
- `stacks/productivity/.env.example` — Environment template
- `stacks/productivity/act_runner_config.yaml` — Gitea Actions runner config
- `stacks/productivity/authentik-setup.md` — OIDC configuration guide
- `stacks/productivity/README.md` — Full documentation