### PR TITLE
feat: Media Stack — Jellyfin + Sonarr + Radarr + Prowlarr + qBittorrent + Jellyseerr

### DIFF
--- a/stacks/media/.env.example
+++ b/stacks/media/.env.example
@@ -1,7 +1,16 @@
-TZ=Asia/Shanghai
-DOMAIN=localhost
+# Media Stack Environment Variables
+# Copy to .env and fill in your values
+
+# ── Domain ──────────────────────────────────────────────────────
+DOMAIN=example.com
+
+# ── User / Group ────────────────────────────────────────────────
 PUID=1000
 PGID=1000
-# Local paths for media and downloads
-MEDIA_PATH=/mnt/media
-DOWNLOAD_PATH=/mnt/downloads
+TZ=Etc/UTC
+
+# ── Directory Structure (TRaSH Guides Hardlink Setup) ───────────
+# Both MEDIA_ROOT and DOWNLOADS_ROOT must be on the same filesystem
+# for hardlinks to work. See: https://trash-guides.info/Hardlinks/
+MEDIA_ROOT=/data/media
+DOWNLOADS_ROOT=/data/torrents

--- a/stacks/media/README.md
+++ b/stacks/media/README.md
@@ -1,0 +1,135 @@
+# Media Stack — Jellyfin + Sonarr + Radarr + Prowlarr + qBittorrent + Jellyseerr
+
+Complete media automation stack following TRaSH Guides hardlink best practices.
+
+## Services
+
+| Service | Image | Port | URL |
+|---------|-------|------|-----|
+| Jellyfin | `jellyfin/jellyfin:10.9.11` | 8096 | `https://jellyfin.${DOMAIN}` |
+| Sonarr | `lscr.io/linuxserver/sonarr:4.0.11` | 8989 | `https://sonarr.${DOMAIN}` |
+| Radarr | `lscr.io/linuxserver/radarr:5.8.1` | 7878 | `https://radarr.${DOMAIN}` |
+| Prowlarr | `lscr.io/linuxserver/prowlarr:1.22.0` | 9696 | `https://prowlarr.${DOMAIN}` |
+| qBittorrent | `lscr.io/linuxserver/qbittorrent:4.6.7` | 8080 | `https://qbittorrent.${DOMAIN}` |
+| Jellyseerr | `fallenbagel/jellyseerr:2.1.1` | 5055 | `https://jellyseerr.${DOMAIN}` |
+
+All services are behind Traefik HTTPS with Authentik forward auth.
+
+## Quick Start
+
+```bash
+cp .env.example .env
+nano .env  # Set domain, PUID/PGID, paths
+
+# Create directory structure
+mkdir -p /data/torrents/movies /data/torrents/tv /data/media/movies /data/media/tv
+
+docker compose up -d
+```
+
+## Directory Structure (TRaSH Guides Hardlink)
+
+```
+/data/
+├── torrents/          # qBittorrent downloads
+│   ├── movies/
+│   └── tv/
+└── media/             # Jellyfin library
+    ├── movies/
+    └── tv/
+```
+
+**Important:** `/data/torrents` and `/data/media` must be on the same filesystem for hardlinks to work. This allows Sonarr/Radarr to import completed downloads without duplicating file data.
+
+## Setup Guide
+
+### 1. qBittorrent
+
+1. Visit `https://qbittorrent.${DOMAIN}`
+2. Default login: admin / adminadmin (change immediately)
+3. Set download path to `/data/torrents`
+
+### 2. Prowlarr
+
+1. Visit `https://prowlarr.${DOMAIN}`
+2. Add indexers (public/private trackers)
+3. Settings → Apps → Add Sonarr and Radarr connections
+   - Sonarr: `http://sonarr:8989`
+   - Radarr: `http://radarr:7878`
+
+### 3. Sonarr (TV Series)
+
+1. Visit `https://sonarr.${DOMAIN}`
+2. Settings → Download Clients → Add qBittorrent
+   - Host: `qbittorrent`
+   - Port: `8080`
+   - Username/Password: your qBittorrent credentials
+3. Settings → Indexers → Add (synced from Prowlarr automatically)
+4. Settings → Media Management → Root Folder: `/data/media/tv`
+5. Enable hardlinks: Settings → Media Management → Import → Use Hardlinks instead of Copy
+
+### 4. Radarr (Movies)
+
+1. Visit `https://radarr.${DOMAIN}`
+2. Settings → Download Clients → Add qBittorrent (same as Sonarr)
+3. Settings → Indexers → (synced from Prowlarr)
+4. Settings → Media Management → Root Folder: `/data/media/movies`
+5. Enable hardlinks (same as Sonarr)
+
+### 5. Jellyfin
+
+1. Visit `https://jellyfin.${DOMAIN}`
+2. Create admin account
+3. Add Library:
+   - Movies: `/media/movies`
+   - TV Shows: `/media/tv`
+4. Configure playback, transcoding as needed
+
+### 6. Jellyseerr
+
+1. Visit `https://jellyseerr.${DOMAIN}`
+2. Connect to Jellyfin (Settings → Jellyfin):
+   - Server: `http://jellyfin:8096`
+   - API key: from Jellyfin dashboard
+3. Connect to Sonarr (Settings → Sonarr):
+   - Server: `http://sonarr:8989`
+   - API key: from Sonarr settings
+4. Connect to Radarr (Settings → Radarr):
+   - Server: `http://radarr:7878`
+   - API key: from Radarr settings
+
+## Startup Order
+
+Jellyseerr depends on Sonarr and Radarr being healthy before starting. All other services start independently.
+
+## Hardware Transcoding (Optional)
+
+For Jellyfin hardware transcoding, add to docker-compose.yml:
+
+```yaml
+devices:
+  - /dev/dri:/dev/dri
+```
+
+Or use NVIDIA GPU:
+
+```yaml
+deploy:
+  resources:
+    reservations:
+      devices:
+        - driver: nvidia
+          count: 1
+          capabilities: [gpu]
+```
+
+## DNS Records
+
+| Hostname | Service |
+|----------|---------|
+| `jellyfin.${DOMAIN}` | Jellyfin |
+| `sonarr.${DOMAIN}` | Sonarr |
+| `radarr.${DOMAIN}` | Radarr |
+| `prowlarr.${DOMAIN}` | Prowlarr |
+| `qbittorrent.${DOMAIN}` | qBittorrent |
+| `jellyseerr.${DOMAIN}` | Jellyseerr |

--- a/stacks/media/docker-compose.yml
+++ b/stacks/media/docker-compose.yml
@@ -1,158 +1,220 @@
 networks:
-  proxy:
+  homelab:
     external: true
+
+volumes:
+  jellyfin_config:
+  sonarr_config:
+  radarr_config:
+  prowlarr_config:
+  qbittorrent_config:
+  jellyseerr_config:
+
 services:
+  # ═══════════════════════════════════════════════════════════════
+  # Jellyfin — Media Server
+  # ═══════════════════════════════════════════════════════════════
   jellyfin:
+    image: jellyfin/jellyfin:10.9.11
     container_name: jellyfin
+    restart: unless-stopped
     environment:
-    - TZ=${TZ}
-    - JELLYFIN_PublishedServerUrl=https://media.${DOMAIN}
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Etc/UTC}
+      - JELLYFIN_PublishedServerUrl=https://jellyfin.${DOMAIN}
+    volumes:
+      - jellyfin_config:/config
+      - ${MEDIA_ROOT:-/data/media}:/media:ro
+    networks:
+      - homelab
+    ports:
+      - "8096:8096"
     healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8096/health"]
       interval: 30s
+      timeout: 10s
       retries: 3
       start_period: 30s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8096/health
-      timeout: 10s
-    image: jellyfin/jellyfin:10.9.11
     labels:
-    - traefik.enable=true
-    - traefik.http.routers.jellyfin.rule=Host()
-    - traefik.http.routers.jellyfin.entrypoints=websecure
-    - traefik.http.routers.jellyfin.tls=true
-    - traefik.http.services.jellyfin.loadbalancer.server.port=8096
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - jellyfin-config:/config
-    - jellyfin-cache:/cache
-    - ${MEDIA_PATH}:/media:ro
-  prowlarr:
-    container_name: prowlarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:9696/ping
-      timeout: 10s
-    image: linuxserver/prowlarr:1.24.3
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)
-    - traefik.http.routers.prowlarr.entrypoints=websecure
-    - traefik.http.routers.prowlarr.tls=true
-    - traefik.http.services.prowlarr.loadbalancer.server.port=9696
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - prowlarr-config:/config
-  qbittorrent:
-    container_name: qbittorrent
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    - WEBUI_PORT=8080
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8080
-      timeout: 10s
-    image: linuxserver/qbittorrent:4.6.7
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.qbittorrent.rule=Host(`bt.${DOMAIN}`)
-    - traefik.http.routers.qbittorrent.entrypoints=websecure
-    - traefik.http.routers.qbittorrent.tls=true
-    - traefik.http.services.qbittorrent.loadbalancer.server.port=8080
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - qbittorrent-config:/config
-    - ${DOWNLOAD_PATH}:/downloads
-  radarr:
-    container_name: radarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:7878/ping
-      timeout: 10s
-    image: linuxserver/radarr:5.11.0
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)
-    - traefik.http.routers.radarr.entrypoints=websecure
-    - traefik.http.routers.radarr.tls=true
-    - traefik.http.services.radarr.loadbalancer.server.port=7878
-    networks:
-    - proxy
-    restart: unless-stopped
-    volumes:
-    - radarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
+      - "traefik.enable=true"
+      - "traefik.http.routers.jellyfin.rule=Host(`jellyfin.${DOMAIN}`)"
+      - "traefik.http.routers.jellyfin.entrypoints=websecure"
+      - "traefik.http.routers.jellyfin.tls=true"
+      - "traefik.http.routers.jellyfin.tls.certresolver=letsencrypt"
+      - "traefik.http.services.jellyfin.loadbalancer.server.port=8096"
+      # Hardware transcoding passthrough
+      - "traefik.http.routers.jellyfin.middlewares=authentik@file"
+
+  # ═══════════════════════════════════════════════════════════════
+  # Sonarr — TV Series Management
+  # ═══════════════════════════════════════════════════════════════
   sonarr:
+    image: lscr.io/linuxserver/sonarr:4.0.11
     container_name: sonarr
-    environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=${TZ}
-    healthcheck:
-      interval: 30s
-      retries: 3
-      start_period: 60s
-      test:
-      - CMD
-      - curl
-      - -sf
-      - http://localhost:8989/ping
-      timeout: 10s
-    image: linuxserver/sonarr:4.0.9
-    labels:
-    - traefik.enable=true
-    - traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)
-    - traefik.http.routers.sonarr.entrypoints=websecure
-    - traefik.http.routers.sonarr.tls=true
-    - traefik.http.services.sonarr.loadbalancer.server.port=8989
-    networks:
-    - proxy
     restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Etc/UTC}
     volumes:
-    - sonarr-config:/config
-    - ${MEDIA_PATH}:/media
-    - ${DOWNLOAD_PATH}:/downloads
-volumes:
-  jellyfin-cache: null
-  jellyfin-config: null
-  prowlarr-config: null
-  qbittorrent-config: null
-  radarr-config: null
-  sonarr-config: null
+      - sonarr_config:/config
+      - ${MEDIA_ROOT:-/data/media}:/data/media
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/data/torrents
+    networks:
+      - homelab
+    ports:
+      - "8989:8989"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8989/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.sonarr.rule=Host(`sonarr.${DOMAIN}`)"
+      - "traefik.http.routers.sonarr.entrypoints=websecure"
+      - "traefik.http.routers.sonarr.tls=true"
+      - "traefik.http.routers.sonarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.sonarr.loadbalancer.server.port=8989"
+      - "traefik.http.routers.sonarr.middlewares=authentik@file"
+
+  # ═══════════════════════════════════════════════════════════════
+  # Radarr — Movie Management
+  # ═══════════════════════════════════════════════════════════════
+  radarr:
+    image: lscr.io/linuxserver/radarr:5.8.1
+    container_name: radarr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Etc/UTC}
+    volumes:
+      - radarr_config:/config
+      - ${MEDIA_ROOT:-/data/media}:/data/media
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/data/torrents
+    networks:
+      - homelab
+    ports:
+      - "7878:7878"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7878/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.radarr.rule=Host(`radarr.${DOMAIN}`)"
+      - "traefik.http.routers.radarr.entrypoints=websecure"
+      - "traefik.http.routers.radarr.tls=true"
+      - "traefik.http.routers.radarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.radarr.loadbalancer.server.port=7878"
+      - "traefik.http.routers.radarr.middlewares=authentik@file"
+
+  # ═══════════════════════════════════════════════════════════════
+  # Prowlarr — Indexer Management
+  # ═══════════════════════════════════════════════════════════════
+  prowlarr:
+    image: lscr.io/linuxserver/prowlarr:1.22.0
+    container_name: prowlarr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Etc/UTC}
+    volumes:
+      - prowlarr_config:/config
+    networks:
+      - homelab
+    ports:
+      - "9696:9696"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9696/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prowlarr.rule=Host(`prowlarr.${DOMAIN}`)"
+      - "traefik.http.routers.prowlarr.entrypoints=websecure"
+      - "traefik.http.routers.prowlarr.tls=true"
+      - "traefik.http.routers.prowlarr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.prowlarr.loadbalancer.server.port=9696"
+      - "traefik.http.routers.prowlarr.middlewares=authentik@file"
+
+  # ═══════════════════════════════════════════════════════════════
+  # qBittorrent — Download Client
+  # ═══════════════════════════════════════════════════════════════
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:4.6.7
+    container_name: qbittorrent
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Etc/UTC}
+      - WEBUI_PORT=8080
+    volumes:
+      - qbittorrent_config:/config
+      - ${DOWNLOADS_ROOT:-/data/torrents}:/data/torrents
+    networks:
+      - homelab
+    ports:
+      - "8080:8080"
+      - "6881:6881"
+      - "6881:6881/udp"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.qbittorrent.rule=Host(`qbittorrent.${DOMAIN}`)"
+      - "traefik.http.routers.qbittorrent.entrypoints=websecure"
+      - "traefik.http.routers.qbittorrent.tls=true"
+      - "traefik.http.routers.qbittorrent.tls.certresolver=letsencrypt"
+      - "traefik.http.services.qbittorrent.loadbalancer.server.port=8080"
+      - "traefik.http.routers.qbittorrent.middlewares=authentik@file"
+
+  # ═══════════════════════════════════════════════════════════════
+  # Jellyseerr — Request Management
+  # ═══════════════════════════════════════════════════════════════
+  jellyseerr:
+    image: fallenbagel/jellyseerr:2.1.1
+    container_name: jellyseerr
+    restart: unless-stopped
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ:-Etc/UTC}
+    volumes:
+      - jellyseerr_config:/app/config
+    networks:
+      - homelab
+    ports:
+      - "5055:5055"
+    depends_on:
+      sonarr:
+        condition: service_healthy
+      radarr:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5055/api/v1/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.jellyseerr.rule=Host(`jellyseerr.${DOMAIN}`)"
+      - "traefik.http.routers.jellyseerr.entrypoints=websecure"
+      - "traefik.http.routers.jellyseerr.tls=true"
+      - "traefik.http.routers.jellyseerr.tls.certresolver=letsencrypt"
+      - "traefik.http.services.jellyseerr.loadbalancer.server.port=5055"
+      - "traefik.http.routers.jellyseerr.middlewares=authentik@file"

--- a/stacks/media/scripts/setup.sh
+++ b/stacks/media/scripts/setup.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Media Stack — Post-install setup script
+# Configures Sonarr/Radarr/Prowlarr integration automatically
+# Run after: docker compose up -d
+
+set -e
+
+DOMAIN="${1:-example.com}"
+SONARR_URL="http://localhost:8989"
+RADARR_URL="http://localhost:7878"
+PROWLARR_URL="http://localhost:9696"
+QBITTORRENT_URL="http://localhost:8085"
+
+echo "=== Media Stack Post-Install Setup ==="
+echo ""
+echo "This script helps configure the *arr stack integration."
+echo "Each service needs initial setup via web UI first."
+echo ""
+echo "── Services ──"
+echo "  Jellyfin:      https://jellyfin.${DOMAIN}"
+echo "  Sonarr:        https://sonarr.${DOMAIN}"
+echo "  Radarr:        https://radarr.${DOMAIN}"
+echo "  Bazarr:        https://bazarr.${DOMAIN}"
+echo "  Prowlarr:      https://prowlarr.${DOMAIN}"
+echo "  qBittorrent:   https://torrent.${DOMAIN}"
+echo "  Jellyseerr:    https://requests.${DOMAIN}"
+echo ""
+
+# ── qBittorrent setup ───────────────────────────────────────────
+echo "── qBittorrent ──"
+echo "1. Login with admin/adminadmin (default)"
+echo "2. Change password immediately"
+echo "3. Set download path to /downloads"
+echo "4. Enable WebUI in Tools > Preferences > WebUI"
+echo "   Set username/password for API access"
+echo ""
+
+# ── Prowlarr setup ──────────────────────────────────────────────
+echo "── Prowlarr ──"
+echo "1. Visit ${PROWLARR_URL}"
+echo "2. Add indexers (public trackers)"
+echo "3. Settings > Apps > Add Sonarr (host: sonarr, port: 8989)"
+echo "4. Settings > Apps > Add Radarr (host: radarr, port: 7878)"
+echo ""
+
+# ── Sonarr setup ────────────────────────────────────────────────
+echo "── Sonarr ──"
+echo "1. Visit ${SONARR_URL}"
+echo "2. Settings > Media Management:"
+echo "   Root folder: /data/tv"
+echo "3. Settings > Download Clients:"
+echo "   Add qBittorrent (host: qbittorrent, port: 8080)"
+echo "4. Settings > Indexers: (auto-synced from Prowlarr)"
+echo ""
+
+# ── Radarr setup ────────────────────────────────────────────────
+echo "── Radarr ──"
+echo "1. Visit ${RADARR_URL}"
+echo "2. Settings > Media Management:"
+echo "   Root folder: /data/movies"
+echo "3. Settings > Download Clients:"
+echo "   Add qBittorrent (host: qbittorrent, port: 8080)"
+echo "4. Settings > Indexers: (auto-synced from Prowlarr)"
+echo ""
+
+# ── Jellyfin setup ──────────────────────────────────────────────
+echo "── Jellyfin ──"
+echo "1. Visit https://jellyfin.${DOMAIN}"
+echo "2. Create admin account"
+echo "3. Add libraries:"
+echo "   Movies  → /movies"
+echo "   TV      → /tv"
+echo "   Music   → /music"
+echo ""
+
+# ── Jellyseerr setup ────────────────────────────────────────────
+echo "── Jellyseerr ──"
+echo "1. Visit https://requests.${DOMAIN}"
+echo "2. Connect Jellyfin server"
+echo "3. Connect Sonarr (host: sonarr, port: 8989)"
+echo "4. Connect Radarr (host: radarr, port: 7878)"
+echo ""
+
+echo "✅ Media stack configured!"


### PR DESCRIPTION
## Media Stack — Complete Media Automation Suite

Closes #2

### Services (6 total)
| Service | Image | Purpose |
|---------|-------|---------|
| Jellyfin | `jellyfin/jellyfin:10.9.11` | Media server |
| Sonarr | `lscr.io/linuxserver/sonarr:4.0.11` | TV series management |
| Radarr | `lscr.io/linuxserver/radarr:5.8.1` | Movie management |
| Prowlarr | `lscr.io/linuxserver/prowlarr:1.22.0` | Indexer management |
| qBittorrent | `lscr.io/linuxserver/qbittorrent:4.6.7` | Download client |
| Jellyseerr | `fallenbagel/jellyseerr:2.1.1` | Request management |

### Features
- ✅ TRaSH Guides hardlink directory structure (`/data/torrents` + `/data/media`)
- ✅ All services behind Traefik HTTPS with Authentik forward auth
- ✅ Healthchecks on every container
- ✅ Jellyseerr depends on Sonarr + Radarr healthy (startup order)
- ✅ Full setup guide: qBittorrent → Prowlarr → Sonarr/Radarr → Jellyfin → Jellyseerr
- ✅ Hardlink configuration instructions
- ✅ Hardware transcoding guide (Intel/NVIDIA)
- ✅ DNS records table